### PR TITLE
Add java time datatypes

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,37 @@
+version = "2.0.1"
+
+align = most
+assumeStandardLibraryStripMargin = true
+danglingParentheses = true
+docstrings = JavaDoc
+includeCurlyBraceInSelectChains = false
+lineEndings = unix
+maxColumn = 120
+
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+
+newlines {
+  alwaysBeforeTopLevelStatements = true
+  alwaysBeforeMultilineDef = true
+}
+
+spaces {
+  afterKeywordBeforeParen = true
+  inImportCurlyBraces = true
+}
+
+rewrite.rules = [
+  AsciiSortImports,
+  AvoidInfix,
+  PreferCurlyFors,
+  RedundantBraces,
+  RedundantParens,
+  SortModifiers
+]
+
+optIn {
+  annotationNewlines = true
+}

--- a/core/src/main/scala/zio/schema/StandardType.scala
+++ b/core/src/main/scala/zio/schema/StandardType.scala
@@ -1,6 +1,8 @@
 package zio.schema
 
 import java.time._
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalUnit
 
 sealed trait StandardType[A]
 
@@ -15,21 +17,22 @@ object StandardType {
   implicit object DoubleType extends StandardType[Double]
   implicit object ByteType   extends StandardType[Byte]
   implicit object CharType   extends StandardType[Char]
+
   //java.time specific types
-  implicit object DayOfWeekType      extends StandardType[DayOfWeek]
-  implicit object DurationType       extends StandardType[Duration]
-  implicit object InstantType        extends StandardType[Instant]
-  implicit object LocalDateType      extends StandardType[LocalDate]
-  implicit object LocalDateTimeType  extends StandardType[LocalDateTime]
-  implicit object LocalTimeType      extends StandardType[LocalTime]
-  implicit object MonthType          extends StandardType[Month]
-  implicit object MonthDayType       extends StandardType[MonthDay]
-  implicit object OffsetDateTimeType extends StandardType[OffsetDateTime]
-  implicit object OffsetTimeType     extends StandardType[OffsetTime]
-  implicit object PeriodType         extends StandardType[Period]
-  implicit object YearType           extends StandardType[Year]
-  implicit object YearMonthType      extends StandardType[YearMonth]
-  implicit object ZonedDateTimeType  extends StandardType[ZonedDateTime]
-  implicit object ZoneIdType         extends StandardType[ZoneId]
-  implicit object ZoneOffsetType     extends StandardType[ZoneOffset]
+  implicit object DayOfWeekType                                 extends StandardType[DayOfWeek]
+  implicit object Month                                         extends StandardType[java.time.Month]
+  implicit object MonthDay                                      extends StandardType[java.time.MonthDay]
+  implicit object Period                                        extends StandardType[java.time.Period]
+  implicit object Year                                          extends StandardType[java.time.Year]
+  implicit object YearMonth                                     extends StandardType[java.time.YearMonth]
+  implicit object ZoneId                                        extends StandardType[java.time.ZoneId]
+  implicit object ZoneOffset                                    extends StandardType[java.time.ZoneOffset]
+  final case class Duration(temporalUnit: TemporalUnit)         extends StandardType[java.time.Duration]
+  final case class Instant(formatter: DateTimeFormatter)        extends StandardType[java.time.Instant]
+  final case class LocalDate(formatter: DateTimeFormatter)      extends StandardType[LocalDate]
+  final case class LocalTime(formatter: DateTimeFormatter)      extends StandardType[LocalTime]
+  final case class LocalDateTime(formatter: DateTimeFormatter)  extends StandardType[LocalDateTime]
+  final case class OffsetTime(formatter: DateTimeFormatter)     extends StandardType[java.time.OffsetTime]
+  final case class OffsetDateTime(formatter: DateTimeFormatter) extends StandardType[java.time.OffsetDateTime]
+  final case class ZonedDateTime(formatter: DateTimeFormatter)  extends StandardType[java.time.ZonedDateTime]
 }


### PR DESCRIPTION
Issue from `zio-web` project (https://github.com/zio/zio-web/issues/74)
For types that can be constructed without additional info (at least by convention), I left them as `implicit object`. Other types require formatting info so they must be `case class`