### PR TITLE
Implement Generic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/target": true
+  }
+}

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -9,7 +9,7 @@ import scalafix.sbt.ScalafixPlugin.autoImport._
 
 object BuildHelper {
 
-  val zioVersion      = "1.0.3"
+  val zioVersion      = "1.0.7"
   val zioNioVersion   = "1.0.0-RC9"
   val zioJsonVersion  = "0.1.2"
   val silencerVersion = "1.7.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.2
+sbt.version=1.5.1

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.5-6-4768184c")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.5-6-4768184c")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")

--- a/zio-schema/shared/src/main/scala/zio/schema/Generic.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Generic.scala
@@ -1,0 +1,86 @@
+package zio.schema
+// import zio.schema.Schema.Primitive
+
+trait Generic { self =>
+
+// sealed case class Record(structure: Map[String, Schema[_]]) extends Schema[Map[String, _]]
+
+  def toTypedValue[A](schema: Schema[A]): Either[String, A] =
+    (self, schema) match {
+      case (Generic.Primitive(value, p), Schema.Primitive(p2)) if p == p2 =>
+        Right(value.asInstanceOf[A])
+      case (Generic.Record(generics), Schema.Record(schemas)) if (generics.keySet != schemas.keySet) =>
+        Left(s"$generics and $schema have incompatible shape")
+      case (Generic.Record(generics), Schema.Record(schemas)) =>
+        val keys = generics.keySet
+        keys.foldLeft[Either[String, Map[String, Any]]](Right(Map.empty)) {
+          case (Right(map), key) =>
+            val generic = generics(key)
+            val schema  = schemas(key)
+            generic.toTypedValue(schema) match {
+              case Left(error)  => Left(error)
+              case Right(value) => Right(map + (key -> value))
+            }
+          case (Left(string), _) => Left(string)
+        }
+      case _ =>
+        Left(s"Failed to cast $self to schema $schema")
+    }
+}
+
+object Generic {
+
+  def fromSchemaAndValue[A](schema: Schema[A], value: A): Generic =
+    schema match {
+      case Schema.Primitive(p) => Generic.Primitive(value, p)
+      case Schema.Record(schemas) =>
+        val map: Map[String, _] = value
+        Generic.Record(schemas.map {
+          case (key, schema: Schema[a]) =>
+            key -> fromSchemaAndValue(schema, map(key).asInstanceOf[a])
+        })
+      case _ => ???
+    }
+
+  // final case class Integer(value: Int)                   extends Generic
+  final case class Record(values: Map[String, Generic])  extends Generic
+  final case class Enumeration(value: (String, Generic)) extends Generic
+
+  // sealed case class Record(structure: Map[String, Schema[_]]) extends Schema[Map[String, _]]
+
+  // final case class Sequence[Col[_], A](schemaA: Schema[A], fromChunk: Chunk[A] => Col[A], toChunk: Col[A] => Chunk[A])
+  //     extends Schema[Col[A]]
+
+  // sealed case class Enumeration(structure: Map[String, Schema[_]]) extends Schema[Map[String, _]]
+
+  // sealed case class Transform[A, B](codec: Schema[A], f: A => Either[String, B], g: B => Either[String, A])
+  //     extends Schema[B]
+
+  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends Generic
+
+  // sealed case class Optional[A](codec: Schema[A]) extends Schema[Option[A]]
+
+  // final case class Fail[A](message: String) extends Schema[A]
+
+  // sealed case class Tuple[A, B](left: Schema[A], right: Schema[B]) extends Schema[(A, B)]
+
+  // final case class EitherSchema[A, B](left: Schema[A], right: Schema[B]) extends Schema[Either[A, B]]
+
+  // final case class Case[A <: Z, Z](id: String, codec: Schema[A], unsafeDeconstruct: Z => A) {
+
+  //   def deconstruct(z: Z): Option[A] =
+  //     try {
+  //       Some(unsafeDeconstruct(z))
+  //     } catch { case _: IllegalArgumentException => None }
+  // }
+
+  // final case class Enum1[A <: Z, Z](case1: Case[A, Z])                                extends Schema[Z]
+  // final case class Enum2[A1 <: Z, A2 <: Z, Z](case1: Case[A1, Z], case2: Case[A2, Z]) extends Schema[Z]
+  // final case class Enum3[A1 <: Z, A2 <: Z, A3 <: Z, Z](case1: Case[A1, Z], case2: Case[A2, Z], case3: Case[A3, Z])
+  //     extends Schema[Z]
+  // final case class EnumN[Z](cases: Seq[Case[_, Z]]) extends Schema[Z]
+
+  // sealed trait CaseClass[Z] extends Schema[Z] {
+  //   def toRecord: Record
+  // }
+}

--- a/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
@@ -31,7 +31,7 @@ object Schema {
   final case class Sequence[Col[_], A](schemaA: Schema[A], fromChunk: Chunk[A] => Col[A], toChunk: Col[A] => Chunk[A])
       extends Schema[Col[A]]
 
-  sealed case class Enumeration(structure: Map[String, Schema[_]]) extends Schema[Map[String, _]]
+  sealed case class Enumeration(structure: Map[String, Schema[_]]) extends Schema[(String, _)]
 
   sealed case class Transform[A, B](codec: Schema[A], f: A => Either[String, B], g: B => Either[String, A])
       extends Schema[B]
@@ -778,7 +778,7 @@ object Schema {
   def tuple[A, B](left: Schema[A], right: Schema[B]): Schema[(A, B)] =
     Tuple(left, right)
 
-  def enumeration(structure: Map[String, Schema[_]]): Schema[Map[String, _]] =
+  def enumeration(structure: Map[String, Schema[_]]): Schema[(String, _)] =
     Enumeration(structure)
 
   def first[A](codec: Schema[(A, Unit)]): Schema[A] =

--- a/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
@@ -8,6 +8,12 @@ sealed trait Schema[A] {
   self =>
   def ? : Schema[Option[A]] = Schema.Optional(self)
 
+  def toGeneric(value: A): Generic =
+    Generic.fromSchemaAndValue(self, value)
+
+  def fromGeneric(generic: Generic): Either[String, A] =
+    generic.toTypedValue(self)
+
   def transform[B](f: A => B, g: B => A): Schema[B] =
     Schema.Transform[A, B](self, a => Right(f(a)), b => Right(g(b)))
 

--- a/zio-schema/shared/src/test/scala/zio/schema/GenericSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/GenericSpec.scala
@@ -1,0 +1,51 @@
+package zio.schema
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+
+object GenericSpec extends DefaultRunnableSpec {
+
+  def spec =
+    suite("GenericSpec")(
+      testM("round-trips Ints") {
+        val schema: Schema[Int] = Schema.primitive[Int]
+        genericLaw(Gen.anyInt, schema)
+      },
+      testM("round-trips Doubles") {
+        val schema: Schema[Double] = Schema.primitive[Double]
+        genericLaw(Gen.anyDouble, schema)
+      },
+      testM("round-trips String") {
+        val schema: Schema[String] = Schema.primitive[String]
+        genericLaw(Gen.anyString, schema)
+      },
+      testM("round-trips Boolean") {
+        val schema: Schema[Boolean] = Schema.primitive[Boolean]
+        genericLaw(Gen.boolean, schema)
+      },
+      testM("round-trips Floats") {
+        val schema: Schema[Float] = Schema.primitive[Float]
+        genericLaw(Gen.anyFloat, schema)
+      },
+      testM("round-trips Records") {
+        val schema: Schema[Map[String, _]] =
+          Schema.record(
+            Map("name" -> Schema.primitive(StandardType.StringType), "age" -> Schema.primitive(StandardType.IntType))
+          )
+
+        val recordGen = for {
+          name <- Gen.anyString
+          age  <- Gen.anyInt
+        } yield Map[String, Any]("name" -> name, "age" -> age)
+
+        genericLaw(recordGen, schema)
+      }
+    )
+
+  def genericLaw[R <: TestConfig, A](gen: Gen[R, A], schema: Schema[A]): URIO[R, TestResult] =
+    check(gen) { a =>
+      assert(schema.fromGeneric(schema.toGeneric(a)))(isRight(equalTo(a)))
+    }
+
+}

--- a/zio-schema/shared/src/test/scala/zio/schema/GenericSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/GenericSpec.scala
@@ -18,10 +18,36 @@ object GenericSpec extends DefaultRunnableSpec {
         check(SchemaGen.anyRecordOfRecordsAndValue) {
           case (schema, a) => assert(schema.fromGeneric(schema.toGeneric(a)))(isRight(equalTo(a)))
         }
+      },
+      testM("round-trips Enumerations") {
+        check(SchemaGen.anyEnumerationAndValue) {
+          case (schema, a) =>
+            assert(schema.fromGeneric(schema.toGeneric(a)))(isRight(equalTo(a)))
+        }
+      },
+      testM("round-trips Eithers") {
+        check(SchemaGen.anyEitherAndValue) {
+          case (schema, a) => assert(schema.fromGeneric(schema.toGeneric(a)))(isRight(equalTo(a)))
+        }
+      },
+      testM("round-trips Tuples") {
+        check(SchemaGen.anyTupleAndValue) {
+          case (schema, a) => assert(schema.fromGeneric(schema.toGeneric(a)))(isRight(equalTo(a)))
+        }
+      },
+      testM("round-trips Optionals") {
+        check(SchemaGen.anyOptionalAndValue) {
+          case (schema, a) => assert(schema.fromGeneric(schema.toGeneric(a)))(isRight(equalTo(a)))
+        }
+      },
+      testM("round-trips Transform") {
+        check(SchemaGen.anyTransformAndValue) {
+          case (schema, a) => assert(schema.fromGeneric(schema.toGeneric(a)))(isRight(equalTo(a)))
+        }
       }
     )
 
-  private val primitiveTests = schemasAndGens.map {
+  val primitiveTests = schemasAndGens.map {
     case SchemaTest(name, schema, gen) =>
       testM(s"round-trips $name") {
         genericLaw(gen, schema)

--- a/zio-schema/shared/src/test/scala/zio/schema/SchemaGen.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/SchemaGen.scala
@@ -107,7 +107,7 @@ object SchemaGen {
   val anyEnumeration: Gen[Random with Sized, Schema.Enumeration] =
     Gen.mapOf(Gen.anyString, anySchema).map(Schema.Enumeration)
 
-  type EnumerationAndGen = (Schema.Enumeration, Gen[Random with Sized, Map[String, _]])
+  type EnumerationAndGen = (Schema.Enumeration, Gen[Random with Sized, (String, _)])
 
   val anyEnumerationAndGen: Gen[Random with Sized, EnumerationAndGen] =
     for {
@@ -119,11 +119,11 @@ object SchemaGen {
       val keyValueGenerators = keyToSchemaAndGen.map {
         case (key, (_, gen)) => Gen.const(key).zip(gen)
       }.toSeq
-      val gen = Gen.oneOf(keyValueGenerators: _*).map(Map(_))
+      val gen = Gen.oneOf(keyValueGenerators: _*)
       Schema.Enumeration(structure) -> gen
     }
 
-  type EnumerationAndValue = (Schema.Enumeration, Map[String, _])
+  type EnumerationAndValue = (Schema.Enumeration, (String, _))
 
   val anyEnumerationAndValue: Gen[Random with Sized, EnumerationAndValue] =
     for {
@@ -231,7 +231,7 @@ object SchemaGen {
       value         <- gen
     } yield schema -> value
 
-  type EnumerationTransform[A] = Schema.Transform[Map[String, _], A]
+  type EnumerationTransform[A] = Schema.Transform[(String, _), A]
 
   val anyEnumerationTransform: Gen[Random with Sized, EnumerationTransform[_]] = {
     anyEnumeration.map(schema => transformEnumeration(schema))
@@ -248,7 +248,7 @@ object SchemaGen {
 
   // TODO: Dynamically generate a sealed trait and case/value classes.
   def transformEnumeration[A](schema: Schema.Enumeration): EnumerationTransform[_] =
-    Schema.Transform[Map[String, _], A](schema, _ => Left("Not implemented."), _ => Left("Not implemented."))
+    Schema.Transform[(String, _), A](schema, _ => Left("Not implemented."), _ => Left("Not implemented."))
 
   type EnumerationTransformAndValue[A] = (EnumerationTransform[A], A)
 
@@ -268,7 +268,7 @@ object SchemaGen {
 
   val anyTransformAndValue: Gen[Random with Sized, TransformAndValue[_]] =
     Gen.oneOf[Random with Sized, TransformAndValue[_]](
-      anySequenceTransformAndValue,
+      // anySequenceTransformAndValue,
       anyRecordTransformAndValue,
       anyEnumerationTransformAndValue
     )

--- a/zio-schema/shared/src/test/scala/zio/schema/StandardTypeGen.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/StandardTypeGen.scala
@@ -8,33 +8,35 @@ import zio.test.{ Gen, Sized }
 
 object StandardTypeGen {
 
-  val anyStandardType: Gen[Random, StandardType[_]] = Gen.oneOf(
-    Gen.const(StandardType.StringType),
-    Gen.const(StandardType.BoolType),
-    Gen.const(StandardType.ShortType),
-    Gen.const(StandardType.IntType),
-    Gen.const(StandardType.LongType),
-    Gen.const(StandardType.FloatType),
-    Gen.const(StandardType.DoubleType),
-    Gen.const(StandardType.BinaryType),
-    Gen.const(StandardType.BigDecimalType),
-    Gen.const(StandardType.BigIntegerType),
-    Gen.const(StandardType.CharType),
-    Gen.const(StandardType.DayOfWeekType),
-    Gen.const(StandardType.Duration(ChronoUnit.SECONDS)),
-    Gen.const(StandardType.Instant(DateTimeFormatter.ISO_DATE_TIME)),
-    Gen.const(StandardType.LocalDate(DateTimeFormatter.ISO_DATE)),
-    Gen.const(StandardType.LocalDateTime(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
-    Gen.const(StandardType.LocalTime(DateTimeFormatter.ISO_LOCAL_TIME)),
-    Gen.const(StandardType.Month),
-    Gen.const(StandardType.MonthDay),
-    Gen.const(StandardType.OffsetDateTime(DateTimeFormatter.ISO_OFFSET_DATE_TIME)),
-    Gen.const(StandardType.OffsetTime(DateTimeFormatter.ISO_OFFSET_TIME)),
-    Gen.const(StandardType.Period),
-    Gen.const(StandardType.Year),
-    Gen.const(StandardType.YearMonth),
-    Gen.const(StandardType.ZonedDateTime(DateTimeFormatter.ISO_ZONED_DATE_TIME)),
-    Gen.const(StandardType.ZoneId)
+  val anyStandardType: Gen[Random, StandardType[_]] = Gen.fromIterable(
+    List(
+      (StandardType.StringType),
+      (StandardType.BoolType),
+      (StandardType.ShortType),
+      (StandardType.IntType),
+      (StandardType.LongType),
+      (StandardType.FloatType),
+      (StandardType.DoubleType),
+      (StandardType.BinaryType),
+      (StandardType.BigDecimalType),
+      (StandardType.BigIntegerType),
+      (StandardType.CharType),
+      (StandardType.DayOfWeekType),
+      (StandardType.Duration(ChronoUnit.SECONDS)),
+      (StandardType.Instant(DateTimeFormatter.ISO_DATE_TIME)),
+      (StandardType.LocalDate(DateTimeFormatter.ISO_DATE)),
+      (StandardType.LocalDateTime(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
+      (StandardType.LocalTime(DateTimeFormatter.ISO_LOCAL_TIME)),
+      (StandardType.Month),
+      (StandardType.MonthDay),
+      (StandardType.OffsetDateTime(DateTimeFormatter.ISO_OFFSET_DATE_TIME)),
+      (StandardType.OffsetTime(DateTimeFormatter.ISO_OFFSET_TIME)),
+      (StandardType.Period),
+      (StandardType.Year),
+      (StandardType.YearMonth),
+      (StandardType.ZonedDateTime(DateTimeFormatter.ISO_ZONED_DATE_TIME)),
+      (StandardType.ZoneId)
+    )
     //FIXME For some reason adding this causes other unrelated tests to break.
 //    Gen.const(StandardType.ZoneOffset)
   )

--- a/zio-schema/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -101,7 +101,7 @@ object JsonCodecSpec extends DefaultRunnableSpec {
       testM("of primitives") {
         assertEncodes(
           enumSchema,
-          Map[String, Any]("string" -> "foo"),
+          ("string" -> "foo"),
           JsonCodec.Encoder.charSequenceToByteChunk("""{"string":"foo"}""")
         )
       },
@@ -331,7 +331,7 @@ object JsonCodecSpec extends DefaultRunnableSpec {
       testM("of primitives") {
         assertEncodesThenDecodes(
           enumSchema,
-          Map("string" -> "foo")
+          "string" -> "foo"
         )
       },
       testM("ADT") {
@@ -476,17 +476,18 @@ object JsonCodecSpec extends DefaultRunnableSpec {
         "boolean" -> Schema[Boolean]
       )
     ),
-    (value: Map[String, _]) => {
-      value
-        .get("string")
-        .map(v => Right(StringValue(v.asInstanceOf[String])))
-        .orElse(value.get("int").map(v => Right(IntValue(v.asInstanceOf[Int]))))
-        .orElse(value.get("boolean").map(v => Right(BooleanValue(v.asInstanceOf[Boolean]))))
-        .getOrElse(Left("No value found"))
+    (value: (String, Any)) => {
+      val (string, v) = value
+      string match {
+        case "int"     => Right(IntValue(v.asInstanceOf[Int]))
+        case "boolean" => Right(BooleanValue(v.asInstanceOf[Boolean]))
+        case "string"  => Right(StringValue(v.asInstanceOf[String]))
+        case _         => Left("No value found")
+      }
     }, {
-      case StringValue(v)  => Right(Map("string"  -> v))
-      case IntValue(v)     => Right(Map("int"     -> v))
-      case BooleanValue(v) => Right(Map("boolean" -> v))
+      case StringValue(v)  => Right("string"  -> v)
+      case IntValue(v)     => Right("int"     -> v)
+      case BooleanValue(v) => Right("boolean" -> v)
     }
   )
 


### PR DESCRIPTION
Work in process to implement `Generic` to fix #36. Currently includes implementation of `Generic` for primitive types and record types. Still need to do implementation for enumerations as well as other more specialized types.

Copying @kitlangton.