### PR TITLE
POC: Prevent embedding optional schemas

### DIFF
--- a/zio-schema/shared/src/main/scala/zio/schema/CanBeOptional.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/CanBeOptional.scala
@@ -1,0 +1,25 @@
+package zio.schema
+
+import scala.annotation.implicitNotFound
+
+/**
+ * A value of type `CanBeOptional[A]` provides implicit evidence that a schema for
+ * type `A` can be made optional. That is, `A` is not already an `Option[_]`.
+ */
+@implicitNotFound(
+  "An Optional schema cannot be embedded within an Optional schema. " + "This operation is not permitted since there is no way to distinguish " + "the encoding of `Some(None)` from the encoding of `None`."
+)
+sealed trait CanBeOptional[-A]
+
+object CanBeOptional extends CanBeOptional[Any] {
+
+  sealed trait Impl[-A]
+
+  object Impl extends Impl[Any] {
+    implicit def impl[A]: Impl[A]                = Impl
+    implicit val implAmbiguous1: Impl[Option[_]] = Impl
+    implicit val implAmbiguous2: Impl[Option[_]] = Impl
+  }
+
+  implicit def canBeOptional[A: Impl]: CanBeOptional[A] = CanBeOptional
+}

--- a/zio-schema/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
@@ -388,13 +388,13 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
           ed2 <- encodeAndDecodeNS(Schema.Optional(schemaOneOf), value)
         } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
       },
-      testM("option within option") {
-        val value = Some(Some(true))
-        for {
-          ed  <- encodeAndDecode(Schema.option(Schema.option(Schema[Boolean])), value)
-          ed2 <- encodeAndDecodeNS(Schema.option(Schema.option(Schema[Boolean])), value)
-        } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
-      },
+      // testM("option within option") {
+      //   val value = Some(Some(true))
+      //   for {
+      //     ed  <- encodeAndDecode(Schema.option(Schema.option(Schema[Boolean])), value)
+      //     ed2 <- encodeAndDecodeNS(Schema.option(Schema.option(Schema[Boolean])), value)
+      //   } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
+      // },
       testM("product type with inner product type") {
         val richProduct = RichProduct(StringValue("sum_type"), BasicString("string"), Record("value", 47))
         for {
@@ -437,20 +437,20 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
           ed2 <- encodeAndDecodeNS(Schema.Optional(Record.schemaRecord), value)
         } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
       },
-      testM("optional of product type within optional") {
-        val value = Some(Some(Record("hello", 10)))
-        for {
-          ed  <- encodeAndDecode(Schema.Optional(Schema.Optional(Record.schemaRecord)), value)
-          ed2 <- encodeAndDecodeNS(Schema.Optional(Schema.Optional(Record.schemaRecord)), value)
-        } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
-      },
-      testM("optional of sum type within optional") {
-        val value = Some(Some(BooleanValue(true)))
-        for {
-          ed  <- encodeAndDecode(Schema.Optional(Schema.Optional(schemaOneOf)), value)
-          ed2 <- encodeAndDecodeNS(Schema.Optional(Schema.Optional(schemaOneOf)), value)
-        } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
-      },
+      // testM("optional of product type within optional") {
+      //   val value = Some(Some(Record("hello", 10)))
+      //   for {
+      //     ed  <- encodeAndDecode(Schema.Optional(Schema.Optional(Record.schemaRecord)), value)
+      //     ed2 <- encodeAndDecodeNS(Schema.Optional(Schema.Optional(Record.schemaRecord)), value)
+      //   } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
+      // },
+      // testM("optional of sum type within optional") {
+      //   val value = Some(Some(BooleanValue(true)))
+      //   for {
+      //     ed  <- encodeAndDecode(Schema.Optional(Schema.Optional(schemaOneOf)), value)
+      //     ed2 <- encodeAndDecodeNS(Schema.Optional(Schema.Optional(schemaOneOf)), value)
+      //   } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
+      // },
       testM("either within either") {
         val either = Right(Left(BooleanValue(true)))
         val schema = Schema.either(Schema[Int], Schema.either(schemaOneOf, Schema[String]))


### PR DESCRIPTION
Fixes #68 

@jdegoes @adamgfraser 
What do you think of this? This will prevent the "embedding" of optional schemas so that `Schema.Optional(Schema.Optional(someSchema))` will not compile. 

There is one drawback (feature?) in that Magnolia will still derive schemas for something like `case class Foo(field: Option[Option[String]])` by falling back to encoding `field` as an `Enum2`. So you end up with a weird JSON encoding of `Foo`. That might actually be good though since the "standard" JSON null encoding is ambiguous anyway (both `Some(None)` and `None` get encoded as `null` in JSON). With this encoding you end up being able to actually differentiate the JSON representations so `Some(None)` becomes `"some": {"none": {}}` whereas `None` becomes `"none":{}`. If there is some semantic distinction between `Some(None)` and `None` then you can actually faithfully preserve the distinction when serializing to JSON. 