### PR TITLE
Add primitive uuid support

### DIFF
--- a/zio-schema/shared/src/main/scala/zio/schema/Diff.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Diff.scala
@@ -1,24 +1,26 @@
 package zio.schema
 
 import java.math.BigInteger
-import java.time.temporal.{ ChronoUnit, TemporalAmount, TemporalUnit, Temporal => JTemporal }
+import java.time.temporal.{ ChronoUnit, Temporal => JTemporal, TemporalAmount, TemporalUnit }
 import java.time.{
   DayOfWeek,
+  Duration => JDuration,
   Instant,
   LocalDate,
   LocalDateTime,
   LocalTime,
+  Month => JMonth,
   MonthDay,
   OffsetDateTime,
   OffsetTime,
   Year,
   YearMonth,
   ZoneId,
-  ZonedDateTime,
-  Duration => JDuration,
-  Month => JMonth
+  ZonedDateTime
 }
+
 import scala.collection.immutable.ListMap
+
 import zio.Chunk
 import zio.schema.internal.MyersDiff
 

--- a/zio-schema/shared/src/main/scala/zio/schema/Diff.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Diff.scala
@@ -1,26 +1,24 @@
 package zio.schema
 
 import java.math.BigInteger
-import java.time.temporal.{ ChronoUnit, Temporal => JTemporal, TemporalAmount, TemporalUnit }
+import java.time.temporal.{ ChronoUnit, TemporalAmount, TemporalUnit, Temporal => JTemporal }
 import java.time.{
   DayOfWeek,
-  Duration => JDuration,
   Instant,
   LocalDate,
   LocalDateTime,
   LocalTime,
-  Month => JMonth,
   MonthDay,
   OffsetDateTime,
   OffsetTime,
   Year,
   YearMonth,
   ZoneId,
-  ZonedDateTime
+  ZonedDateTime,
+  Duration => JDuration,
+  Month => JMonth
 }
-
 import scala.collection.immutable.ListMap
-
 import zio.Chunk
 import zio.schema.internal.MyersDiff
 
@@ -79,6 +77,7 @@ object Differ {
     case Schema.Primitive(StandardType.BigDecimalType) => bigDecimal
     case Schema.Primitive(StandardType.BigIntegerType) => bigInt
     case Schema.Primitive(StandardType.StringType)     => string
+    case Schema.Primitive(StandardType.UUIDType)       => string.transform(_.toString)
     case Schema.Primitive(StandardType.DayOfWeekType)  => dayOfWeek
     case Schema.Primitive(StandardType.Month)          => month
     case Schema.Primitive(StandardType.MonthDay)       => monthDay

--- a/zio-schema/shared/src/main/scala/zio/schema/StandardType.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/StandardType.scala
@@ -42,6 +42,7 @@ object StandardType {
     final val OFFSET_TIME      = "offsetTime"
     final val OFFSET_DATE_TIME = "offsetDateTime"
     final val ZONED_DATE_TIME  = "zonedDateTime"
+    final val UUID             = "uuid"
   }
 
   def fromString(tag: String): Option[StandardType[_]] =
@@ -73,6 +74,7 @@ object StandardType {
       case Tags.OFFSET_TIME      => Some(OffsetTime(DateTimeFormatter.ISO_OFFSET_TIME))
       case Tags.OFFSET_DATE_TIME => Some(OffsetDateTime(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
       case Tags.ZONED_DATE_TIME  => Some(ZonedDateTime(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+      case Tags.UUID             => Some(UUIDType)
       case units =>
         try {
           Some(Duration(ChronoUnit.valueOf(units)))
@@ -82,16 +84,17 @@ object StandardType {
   def fromTemporalUnits(units: String): Option[StandardType[java.time.Duration]] =
     ChronoUnit.values().find(_.toString == units).map(Duration(_))
 
-  implicit object UnitType   extends StandardType[Unit]        { override def tag = Tags.UNIT   }
-  implicit object StringType extends StandardType[String]      { override def tag = Tags.STRING }
-  implicit object BoolType   extends StandardType[Boolean]     { override def tag = Tags.BOOL   }
-  implicit object ShortType  extends StandardType[Short]       { override def tag = Tags.SHORT  }
-  implicit object IntType    extends StandardType[Int]         { override def tag = Tags.INT    }
-  implicit object LongType   extends StandardType[Long]        { override def tag = Tags.LONG   }
-  implicit object FloatType  extends StandardType[Float]       { override def tag = Tags.FLOAT  }
-  implicit object DoubleType extends StandardType[Double]      { override def tag = Tags.DOUBLE }
-  implicit object BinaryType extends StandardType[Chunk[Byte]] { override def tag = Tags.BINARY }
-  implicit object CharType   extends StandardType[Char]        { override def tag = Tags.CHAR   }
+  implicit object UnitType   extends StandardType[Unit]           { override def tag = Tags.UNIT   }
+  implicit object StringType extends StandardType[String]         { override def tag = Tags.STRING }
+  implicit object BoolType   extends StandardType[Boolean]        { override def tag = Tags.BOOL   }
+  implicit object ShortType  extends StandardType[Short]          { override def tag = Tags.SHORT  }
+  implicit object IntType    extends StandardType[Int]            { override def tag = Tags.INT    }
+  implicit object LongType   extends StandardType[Long]           { override def tag = Tags.LONG   }
+  implicit object FloatType  extends StandardType[Float]          { override def tag = Tags.FLOAT  }
+  implicit object DoubleType extends StandardType[Double]         { override def tag = Tags.DOUBLE }
+  implicit object BinaryType extends StandardType[Chunk[Byte]]    { override def tag = Tags.BINARY }
+  implicit object CharType   extends StandardType[Char]           { override def tag = Tags.CHAR   }
+  implicit object UUIDType   extends StandardType[java.util.UUID] { override def tag = Tags.UUID   }
 
   implicit object BigDecimalType extends StandardType[java.math.BigDecimal] { override def tag = Tags.BIG_DECIMAL }
   implicit object BigIntegerType extends StandardType[java.math.BigInteger] { override def tag = Tags.BIG_INTEGER }
@@ -129,4 +132,5 @@ object StandardType {
   final case class ZonedDateTime(formatter: DateTimeFormatter) extends StandardType[java.time.ZonedDateTime] {
     override def tag = Tags.ZONED_DATE_TIME
   }
+
 }

--- a/zio-schema/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -63,6 +63,7 @@ object JsonCodec extends Codec {
         case StandardType.CharType          => ZJsonCodec.char
         case StandardType.BigIntegerType    => ZJsonCodec.bigInteger
         case StandardType.BigDecimalType    => ZJsonCodec.bigDecimal
+        case StandardType.UUIDType          => ZJsonCodec.uuid
         case StandardType.DayOfWeekType     => ZJsonCodec.dayOfWeek // ZJsonCodec[java.time.DayOfWeek]
         case StandardType.Duration(_)       => ZJsonCodec.duration //ZJsonCodec[java.time.Duration]
         case StandardType.Instant(_)        => ZJsonCodec.instant //ZJsonCodec[java.time.Instant]

--- a/zio-schema/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
@@ -3,16 +3,17 @@ package zio.schema.codec
 import java.nio.charset.StandardCharsets
 import java.nio.{ ByteBuffer, ByteOrder }
 import java.time._
+import java.util.UUID
+
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
+import scala.util.control.NonFatal
+
 import zio.schema._
 import zio.schema.ast.SchemaAst
 import zio.schema.codec.ProtobufCodec.Protobuf.WireType.LengthDelimited
 import zio.stream.ZTransducer
 import zio.{ Chunk, ZIO }
-
-import java.util.UUID
-import scala.util.control.NonFatal
 
 object ProtobufCodec extends Codec {
   override def encoder[A](schema: Schema[A]): ZTransducer[Any, Nothing, A, Byte] =

--- a/zio-schema/shared/src/test/scala/zio/schema/DynamicValueGen.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/DynamicValueGen.scala
@@ -40,6 +40,7 @@ object DynamicValueGen {
       case typ: StandardType.ZoneId.type         => gen(typ, JavaTimeGen.anyZoneId)
       case typ: StandardType.ZoneOffset.type     => gen(typ, JavaTimeGen.anyZoneOffset)
       case typ: StandardType.UnitType.type       => Gen.const(DynamicValue.Primitive((), typ))
+      case typ: StandardType.UUIDType.type       => gen(typ, Gen.anyUUID)
     }
   }
 

--- a/zio-schema/shared/src/test/scala/zio/schema/StandardTypeGen.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/StandardTypeGen.scala
@@ -21,6 +21,7 @@ object StandardTypeGen {
       (StandardType.BigDecimalType),
       (StandardType.BigIntegerType),
       (StandardType.CharType),
+      (StandardType.UUIDType),
       (StandardType.DayOfWeekType),
       (StandardType.Duration(ChronoUnit.SECONDS)),
       (StandardType.Instant(DateTimeFormatter.ISO_DATE_TIME)),
@@ -54,6 +55,7 @@ object StandardTypeGen {
       case typ: StandardType.DoubleType.type     => typ -> Gen.anyDouble
       case typ: StandardType.BinaryType.type     => typ -> Gen.chunkOf(Gen.anyByte)
       case typ: StandardType.CharType.type       => typ -> Gen.anyASCIIChar
+      case typ: StandardType.UUIDType.type       => typ -> Gen.anyUUID
       case typ: StandardType.BigDecimalType.type => typ -> Gen.anyDouble.map(d => java.math.BigDecimal.valueOf(d))
       case typ: StandardType.BigIntegerType.type => typ -> Gen.anyLong.map(n => java.math.BigInteger.valueOf(n))
       case typ: StandardType.DayOfWeekType.type  => typ -> JavaTimeGen.anyDayOfWeek

--- a/zio-schema/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
@@ -3,16 +3,16 @@ package zio.schema.codec
 import java.time._
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-
 import scala.collection.immutable.ListMap
 import scala.util.Try
-
 import zio._
 import zio.console._
 import zio.schema.{ DeriveSchema, Schema, SchemaGen, StandardType }
 import zio.stream.{ ZSink, ZStream }
 import zio.test.Assertion._
 import zio.test._
+
+import java.util.UUID
 
 // TODO: use generators instead of manual encode/decode
 object ProtobufCodecSpec extends DefaultRunnableSpec {
@@ -177,6 +177,13 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
         for {
           ed  <- encodeAndDecode(Schema[Char], value)
           ed2 <- encodeAndDecodeNS(Schema[Char], value)
+        } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
+      },
+      testM("uuids") {
+        val value = UUID.randomUUID
+        for {
+          ed  <- encodeAndDecode(Schema[UUID], value)
+          ed2 <- encodeAndDecodeNS(Schema[UUID], value)
         } yield assert(ed)(equalTo(Chunk(value))) && assert(ed2)(equalTo(value))
       },
       testM("day of weeks") {

--- a/zio-schema/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
@@ -3,16 +3,17 @@ package zio.schema.codec
 import java.time._
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import java.util.UUID
+
 import scala.collection.immutable.ListMap
 import scala.util.Try
+
 import zio._
 import zio.console._
 import zio.schema.{ DeriveSchema, Schema, SchemaGen, StandardType }
 import zio.stream.{ ZSink, ZStream }
 import zio.test.Assertion._
 import zio.test._
-
-import java.util.UUID
 
 // TODO: use generators instead of manual encode/decode
 object ProtobufCodecSpec extends DefaultRunnableSpec {


### PR DESCRIPTION
Adds a new primitive for UUIDs. While there is no special support in protobuf or json for them, other potential codec's like BSON have special handling for UUID's.