### PR TITLE
Improve Ergonomics of Annotations

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
@@ -146,7 +146,6 @@ object DefaultValueSpec extends DefaultRunnableSpec {
       test("basic") {
         val schema: Schema[UserId] =
           Schema.CaseClass1(
-            annotations = Chunk.empty,
             field = Schema.Field("id", Schema.Primitive(StandardType.StringType)),
             UserId.apply,
             (uid: UserId) => uid.id
@@ -156,11 +155,9 @@ object DefaultValueSpec extends DefaultRunnableSpec {
       test("recursive") {
         val expected: Schema[User] =
           Schema.CaseClass3(
-            annotations = Chunk.empty,
             field1 = Schema.Field(
               "id",
               Schema.CaseClass1(
-                annotations = Chunk.empty,
                 field = Schema.Field("id", Schema.Primitive(StandardType.StringType)),
                 UserId.apply,
                 (uid: UserId) => uid.id

--- a/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
@@ -227,7 +227,6 @@ object DeriveSchemaSpec extends DefaultRunnableSpec {
         val derived: Schema[UserId] = DeriveSchema.gen[UserId]
         val expected: Schema[UserId] =
           Schema.CaseClass1(
-            annotations = Chunk.empty,
             field = Schema.Field("id", Schema.Primitive(StandardType.StringType)),
             UserId.apply,
             (uid: UserId) => uid.id
@@ -245,12 +244,10 @@ object DeriveSchemaSpec extends DefaultRunnableSpec {
         val derived: Schema[User] = Schema[User]
         val expected: Schema[User] = {
           Schema.CaseClass2(
-            annotations = Chunk(new annotation3),
             field1 = Schema.Field("name", Schema.Primitive(StandardType.StringType)),
             field2 = Schema.Field(
               "id",
               Schema.CaseClass1(
-                annotations = Chunk.empty,
                 field = Schema.Field("id", Schema.Primitive(StandardType.StringType)),
                 UserId.apply,
                 (uid: UserId) => uid.id
@@ -259,7 +256,8 @@ object DeriveSchemaSpec extends DefaultRunnableSpec {
             ),
             User.apply,
             (u: User) => u.name,
-            (u: User) => u.id
+            (u: User) => u.id,
+            annotations = Chunk(new annotation3)
           )
         }
         assert(derived)(hasSameSchema(expected))

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -115,47 +115,47 @@ object JsonCodec extends Codec {
       case EitherSchema(left, right, _)                          => JsonEncoder.either(schemaEncoder(left), schemaEncoder(right))
       case l @ Schema.Lazy(_)                                    => schemaEncoder(l.schema)
       case Schema.Meta(_, _)                                     => astEncoder
-      case Schema.CaseClass1(_, f, _, ext)                       => caseClassEncoder(f -> ext)
-      case Schema.CaseClass2(_, f1, f2, _, ext1, ext2)           => caseClassEncoder(f1 -> ext1, f2 -> ext2)
-      case Schema.CaseClass3(_, f1, f2, f3, _, ext1, ext2, ext3) => caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3)
-      case Schema.CaseClass4(_, f1, f2, f3, f4, _, ext1, ext2, ext3, ext4) =>
+      case Schema.CaseClass1(f, _, ext, _)                       => caseClassEncoder(f -> ext)
+      case Schema.CaseClass2(f1, f2, _, ext1, ext2, _)           => caseClassEncoder(f1 -> ext1, f2 -> ext2)
+      case Schema.CaseClass3(f1, f2, f3, _, ext1, ext2, ext3, _) => caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3)
+      case Schema.CaseClass4(f1, f2, f3, f4, _, ext1, ext2, ext3, ext4, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4)
-      case Schema.CaseClass5(_, f1, f2, f3, f4, f5, _, ext1, ext2, ext3, ext4, ext5) =>
+      case Schema.CaseClass5(f1, f2, f3, f4, f5, _, ext1, ext2, ext3, ext4, ext5, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5)
-      case Schema.CaseClass6(_, f1, f2, f3, f4, f5, f6, _, ext1, ext2, ext3, ext4, ext5, ext6) =>
+      case Schema.CaseClass6(f1, f2, f3, f4, f5, f6, _, ext1, ext2, ext3, ext4, ext5, ext6, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6)
-      case Schema.CaseClass7(_, f1, f2, f3, f4, f5, f6, f7, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7) =>
+      case Schema.CaseClass7(f1, f2, f3, f4, f5, f6, f7, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7)
-      case Schema.CaseClass8(_, f1, f2, f3, f4, f5, f6, f7, f8, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8) =>
+      case Schema.CaseClass8(f1, f2, f3, f4, f5, f6, f7, f8, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8)
       case Schema
-            .CaseClass9(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9) =>
+            .CaseClass9(f1, f2, f3, f4, f5, f6, f7, f8, f9, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9)
-      case Schema.CaseClass10(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10) =>
+      case Schema.CaseClass10(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10)
-      case Schema.CaseClass11(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11) =>
+      case Schema.CaseClass11(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11)
-      case Schema.CaseClass12(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12) =>
+      case Schema.CaseClass12(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12)
-      case Schema.CaseClass13(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13) =>
+      case Schema.CaseClass13(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13)
-      case Schema.CaseClass14(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14) =>
+      case Schema.CaseClass14(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14)
-      case Schema.CaseClass15(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15) =>
+      case Schema.CaseClass15(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15)
-      case Schema.CaseClass16(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16) =>
+      case Schema.CaseClass16(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16)
-      case Schema.CaseClass17(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17) =>
+      case Schema.CaseClass17(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17)
-      case Schema.CaseClass18(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18) =>
+      case Schema.CaseClass18(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18)
-      case Schema.CaseClass19(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19) =>
+      case Schema.CaseClass19(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19)
-      case Schema.CaseClass20(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20) =>
+      case Schema.CaseClass20(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20)
-      case Schema.CaseClass21(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21) =>
+      case Schema.CaseClass21(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20, f21 -> ext21)
-      case Schema.CaseClass22(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, ext22) =>
+      case Schema.CaseClass22(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, ext22, _) =>
         caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20, f21 -> ext21, f22 -> ext22)
       case Schema.Enum1(c, _)                                  => enumEncoder(c)
       case Schema.Enum2(c1, c2, _)                             => enumEncoder(c1, c2)

--- a/zio-schema-protobuf/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
+++ b/zio-schema-protobuf/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
@@ -147,47 +147,47 @@ object ProtobufCodec extends Codec {
         case (Schema.EitherSchema(left, right, _), v: Either[_, _]) => encodeEither(fieldNumber, left, right, v)
         case (lzy @ Schema.Lazy(_), v)                              => encode(fieldNumber, lzy.schema, v)
         case (Schema.Meta(ast, _), _)                               => encode(fieldNumber, Schema[SchemaAst], ast)
-        case (Schema.CaseClass1(_, f, _, ext), v)                   => encodeCaseClass(v, f -> ext)(fieldNumber)
-        case (Schema.CaseClass2(_, f1, f2, _, ext1, ext2), v)       => encodeCaseClass(v, f1 -> ext1, f2 -> ext2)(fieldNumber)
-        case (Schema.CaseClass3(_, f1, f2, f3, _, ext1, ext2, ext3), v) =>
+        case (Schema.CaseClass1(f, _, ext, _), v)                   => encodeCaseClass(v, f -> ext)(fieldNumber)
+        case (Schema.CaseClass2(f1, f2, _, ext1, ext2, _), v)       => encodeCaseClass(v, f1 -> ext1, f2 -> ext2)(fieldNumber)
+        case (Schema.CaseClass3(f1, f2, f3, _, ext1, ext2, ext3, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3)(fieldNumber)
-        case (Schema.CaseClass4(_, f1, f2, f3, f4, _, ext1, ext2, ext3, ext4), v) =>
+        case (Schema.CaseClass4(f1, f2, f3, f4, _, ext1, ext2, ext3, ext4, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4)(fieldNumber)
-        case (Schema.CaseClass5(_, f1, f2, f3, f4, f5, _, ext1, ext2, ext3, ext4, ext5), v) =>
+        case (Schema.CaseClass5(f1, f2, f3, f4, f5, _, ext1, ext2, ext3, ext4, ext5, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5)(fieldNumber)
-        case (Schema.CaseClass6(_, f1, f2, f3, f4, f5, f6, _, ext1, ext2, ext3, ext4, ext5, ext6), v) =>
+        case (Schema.CaseClass6(f1, f2, f3, f4, f5, f6, _, ext1, ext2, ext3, ext4, ext5, ext6, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6)(fieldNumber)
-        case (Schema.CaseClass7(_, f1, f2, f3, f4, f5, f6, f7, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7), v) =>
+        case (Schema.CaseClass7(f1, f2, f3, f4, f5, f6, f7, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7)(fieldNumber)
-        case (Schema.CaseClass8(_, f1, f2, f3, f4, f5, f6, f7, f8, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8), v) =>
+        case (Schema.CaseClass8(f1, f2, f3, f4, f5, f6, f7, f8, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8)(fieldNumber)
-        case (Schema.CaseClass9(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9), v) =>
+        case (Schema.CaseClass9(f1, f2, f3, f4, f5, f6, f7, f8, f9, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9)(fieldNumber)
-        case (Schema.CaseClass10(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10), v) =>
+        case (Schema.CaseClass10(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10)(fieldNumber)
-        case (Schema.CaseClass11(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11), v) =>
+        case (Schema.CaseClass11(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11)(fieldNumber)
-        case (Schema.CaseClass12(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12), v) =>
+        case (Schema.CaseClass12(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12)(fieldNumber)
-        case (Schema.CaseClass13(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13), v) =>
+        case (Schema.CaseClass13(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13)(fieldNumber)
-        case (Schema.CaseClass14(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14), v) =>
+        case (Schema.CaseClass14(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14)(fieldNumber)
-        case (Schema.CaseClass15(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15), v) =>
+        case (Schema.CaseClass15(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15)(fieldNumber)
-        case (Schema.CaseClass16(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16), v) =>
+        case (Schema.CaseClass16(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16)(fieldNumber)
-        case (Schema.CaseClass17(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17), v) =>
+        case (Schema.CaseClass17(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17)(fieldNumber)
-        case (Schema.CaseClass18(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18), v) =>
+        case (Schema.CaseClass18(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18)(fieldNumber)
-        case (Schema.CaseClass19(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19), v) =>
+        case (Schema.CaseClass19(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19)(fieldNumber)
-        case (Schema.CaseClass20(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20), v) =>
+        case (Schema.CaseClass20(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20)(fieldNumber)
-        case (Schema.CaseClass21(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21), v) =>
+        case (Schema.CaseClass21(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20, f21 -> ext21)(fieldNumber)
-        case (Schema.CaseClass22(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, ext22), v) =>
+        case (Schema.CaseClass22(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, ext22, _), v) =>
           encodeCaseClass(v, f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20, f21 -> ext21, f22 -> ext22)(fieldNumber)
         case (Schema.Enum1(c, _), v)                                                                                                    => encodeEnum(fieldNumber, v, c)
         case (Schema.Enum2(c1, c2, _), v)                                                                                               => encodeEnum(fieldNumber, v, c1, c2)

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -982,17 +982,17 @@ object DynamicValue {
 
       case Schema.Meta(ast, _) => DynamicValue.DynamicAst(ast)
 
-      case Schema.CaseClass1(_, f, _, ext) =>
+      case Schema.CaseClass1(f, _, ext, _) =>
         DynamicValue.Record(ListMap(f.label -> fromSchemaAndValue(f.schema, ext(value))))
 
-      case Schema.CaseClass2(_, f1, f2, _, ext1, ext2) =>
+      case Schema.CaseClass2(f1, f2, _, ext1, ext2, _) =>
         DynamicValue.Record(
           ListMap(
             f1.label -> fromSchemaAndValue(f1.schema, ext1(value)),
             f2.label -> fromSchemaAndValue(f2.schema, ext2(value))
           )
         )
-      case Schema.CaseClass3(_, f1, f2, f3, _, ext1, ext2, ext3) =>
+      case Schema.CaseClass3(f1, f2, f3, _, ext1, ext2, ext3, _) =>
         DynamicValue.Record(
           ListMap(
             f1.label -> fromSchemaAndValue(f1.schema, ext1(value)),
@@ -1000,7 +1000,7 @@ object DynamicValue {
             f3.label -> fromSchemaAndValue(f3.schema, ext3(value))
           )
         )
-      case Schema.CaseClass4(_, f1, f2, f3, f4, _, ext1, ext2, ext3, ext4) =>
+      case Schema.CaseClass4(f1, f2, f3, f4, _, ext1, ext2, ext3, ext4, _) =>
         DynamicValue.Record(
           ListMap(
             f1.label -> fromSchemaAndValue(f1.schema, ext1(value)),
@@ -1009,7 +1009,7 @@ object DynamicValue {
             f4.label -> fromSchemaAndValue(f4.schema, ext4(value))
           )
         )
-      case Schema.CaseClass5(_, f1, f2, f3, f4, f5, _, ext1, ext2, ext3, ext4, ext5) =>
+      case Schema.CaseClass5(f1, f2, f3, f4, f5, _, ext1, ext2, ext3, ext4, ext5, _) =>
         DynamicValue.Record(
           ListMap(
             f1.label -> fromSchemaAndValue(f1.schema, ext1(value)),
@@ -1019,7 +1019,7 @@ object DynamicValue {
             f5.label -> fromSchemaAndValue(f5.schema, ext5(value))
           )
         )
-      case Schema.CaseClass6(_, f1, f2, f3, f4, f5, f6, _, ext1, ext2, ext3, ext4, ext5, ext6) =>
+      case Schema.CaseClass6(f1, f2, f3, f4, f5, f6, _, ext1, ext2, ext3, ext4, ext5, ext6, _) =>
         DynamicValue.Record(
           ListMap(
             f1.label -> fromSchemaAndValue(f1.schema, ext1(value)),
@@ -1030,7 +1030,7 @@ object DynamicValue {
             f6.label -> fromSchemaAndValue(f6.schema, ext6(value))
           )
         )
-      case Schema.CaseClass7(_, f1, f2, f3, f4, f5, f6, f7, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7) =>
+      case Schema.CaseClass7(f1, f2, f3, f4, f5, f6, f7, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, _) =>
         DynamicValue.Record(
           ListMap(
             f1.label -> fromSchemaAndValue(f1.schema, ext1(value)),
@@ -1042,7 +1042,7 @@ object DynamicValue {
             f7.label -> fromSchemaAndValue(f7.schema, ext7(value))
           )
         )
-      case Schema.CaseClass8(_, f1, f2, f3, f4, f5, f6, f7, f8, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8) =>
+      case Schema.CaseClass8(f1, f2, f3, f4, f5, f6, f7, f8, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, _) =>
         DynamicValue.Record(
           ListMap(
             f1.label -> fromSchemaAndValue(f1.schema, ext1(value)),
@@ -1056,7 +1056,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass9(
-          _,
           f1,
           f2,
           f3,
@@ -1075,7 +1074,8 @@ object DynamicValue {
           ext6,
           ext7,
           ext8,
-          ext9
+          ext9,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1091,7 +1091,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass10(
-          _,
           f1,
           f2,
           f3,
@@ -1112,7 +1111,8 @@ object DynamicValue {
           ext7,
           ext8,
           ext9,
-          ext10
+          ext10,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1129,7 +1129,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass11(
-          _,
           f1,
           f2,
           f3,
@@ -1152,7 +1151,8 @@ object DynamicValue {
           ext8,
           ext9,
           ext10,
-          ext11
+          ext11,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1170,7 +1170,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass12(
-          _,
           f1,
           f2,
           f3,
@@ -1195,7 +1194,8 @@ object DynamicValue {
           ext9,
           ext10,
           ext11,
-          ext12
+          ext12,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1214,7 +1214,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass13(
-          _,
           f1,
           f2,
           f3,
@@ -1241,7 +1240,8 @@ object DynamicValue {
           ext10,
           ext11,
           ext12,
-          ext13
+          ext13,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1261,7 +1261,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass14(
-          _,
           f1,
           f2,
           f3,
@@ -1290,7 +1289,8 @@ object DynamicValue {
           ext11,
           ext12,
           ext13,
-          ext14
+          ext14,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1311,7 +1311,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass15(
-          _,
           f1,
           f2,
           f3,
@@ -1342,7 +1341,8 @@ object DynamicValue {
           ext12,
           ext13,
           ext14,
-          ext15
+          ext15,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1364,7 +1364,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass16(
-          _,
           f1,
           f2,
           f3,
@@ -1397,7 +1396,8 @@ object DynamicValue {
           ext13,
           ext14,
           ext15,
-          ext16
+          ext16,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1420,7 +1420,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass17(
-          _,
           f1,
           f2,
           f3,
@@ -1455,7 +1454,8 @@ object DynamicValue {
           ext14,
           ext15,
           ext16,
-          ext17
+          ext17,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1479,7 +1479,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass18(
-          _,
           f1,
           f2,
           f3,
@@ -1516,7 +1515,8 @@ object DynamicValue {
           ext15,
           ext16,
           ext17,
-          ext18
+          ext18,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1541,7 +1541,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass19(
-          _,
           f1,
           f2,
           f3,
@@ -1580,7 +1579,8 @@ object DynamicValue {
           ext16,
           ext17,
           ext18,
-          ext19
+          ext19,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1606,7 +1606,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass20(
-          _,
           f1,
           f2,
           f3,
@@ -1647,7 +1646,8 @@ object DynamicValue {
           ext17,
           ext18,
           ext19,
-          ext20
+          ext20,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1674,7 +1674,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass21(
-          _,
           f1,
           f2,
           f3,
@@ -1717,7 +1716,8 @@ object DynamicValue {
           ext18,
           ext19,
           ext20,
-          ext21
+          ext21,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(
@@ -1745,7 +1745,6 @@ object DynamicValue {
           )
         )
       case Schema.CaseClass22(
-          _,
           f1,
           f2,
           f3,
@@ -1790,7 +1789,8 @@ object DynamicValue {
           ext19,
           ext20,
           ext21,
-          ext22
+          ext22,
+          _
           ) =>
         DynamicValue.Record(
           ListMap(

--- a/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
@@ -1854,7 +1854,7 @@ sealed trait RecordSchemas { self: Schema.type =>
 
   }
 
-  sealed case class CaseClass1[A, Z](override val annotations: Chunk[Any] = Chunk.empty, field: Field[A], construct: A => Z, extractField: Z => A) extends Record[Z] { self =>
+  sealed case class CaseClass1[A, Z](field: Field[A], construct: A => Z, extractField: Z => A, override val annotations: Chunk[Any] = Chunk.empty) extends Record[Z] { self =>
 
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = Lens[Z, A]
 
@@ -1876,7 +1876,7 @@ sealed trait RecordSchemas { self: Schema.type =>
     override def toString: String = s"CaseClass1(${structure.mkString(",")})"
   }
 
-  sealed case class CaseClass2[A1, A2, Z](override val annotations: Chunk[Any] = Chunk.empty, field1: Field[A1], field2: Field[A2], construct: (A1, A2) => Z, extractField1: Z => A1, extractField2: Z => A2) extends Record[Z] { self =>
+  sealed case class CaseClass2[A1, A2, Z](field1: Field[A1], field2: Field[A2], construct: (A1, A2) => Z, extractField1: Z => A1, extractField2: Z => A2, override val annotations: Chunk[Any] = Chunk.empty) extends Record[Z] { self =>
 
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2])
 
@@ -1898,7 +1898,7 @@ sealed trait RecordSchemas { self: Schema.type =>
 
   }
 
-  sealed case class CaseClass3[A1, A2, A3, Z](override val annotations: Chunk[Any] = Chunk.empty, field1: Field[A1], field2: Field[A2], field3: Field[A3], construct: (A1, A2, A3) => Z, extractField1: Z => A1, extractField2: Z => A2, extractField3: Z => A3) extends Record[Z] { self =>
+  sealed case class CaseClass3[A1, A2, A3, Z](field1: Field[A1], field2: Field[A2], field3: Field[A3], construct: (A1, A2, A3) => Z, extractField1: Z => A1, extractField2: Z => A2, extractField3: Z => A3, override val annotations: Chunk[Any] = Chunk.empty) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3])
 
     override def annotate(annotation: Any): CaseClass3[A1, A2, A3, Z] = copy(annotations = annotations :+ annotation)
@@ -1921,7 +1921,7 @@ sealed trait RecordSchemas { self: Schema.type =>
 
   }
 
-  sealed case class CaseClass4[A1, A2, A3, A4, Z](override val annotations: Chunk[Any] = Chunk.empty, field1: Field[A1], field2: Field[A2], field3: Field[A3], field4: Field[A4], construct: (A1, A2, A3, A4) => Z, extractField1: Z => A1, extractField2: Z => A2, extractField3: Z => A3, extractField4: Z => A4) extends Record[Z] { self =>
+  sealed case class CaseClass4[A1, A2, A3, A4, Z](field1: Field[A1], field2: Field[A2], field3: Field[A3], field4: Field[A4], construct: (A1, A2, A3, A4) => Z, extractField1: Z => A1, extractField2: Z => A2, extractField3: Z => A3, extractField4: Z => A4, override val annotations: Chunk[Any] = Chunk.empty) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4])
 
     override def annotate(annotation: Any): CaseClass4[A1, A2, A3, A4, Z] = copy(annotations = annotations :+ annotation)
@@ -1944,7 +1944,7 @@ sealed trait RecordSchemas { self: Schema.type =>
 
   }
 
-  sealed case class CaseClass5[A1, A2, A3, A4, A5, Z](override val annotations: Chunk[Any] = Chunk.empty, field1: Field[A1], field2: Field[A2], field3: Field[A3], field4: Field[A4], field5: Field[A5], construct: (A1, A2, A3, A4, A5) => Z, extractField1: Z => A1, extractField2: Z => A2, extractField3: Z => A3, extractField4: Z => A4, extractField5: Z => A5) extends Record[Z] { self =>
+  sealed case class CaseClass5[A1, A2, A3, A4, A5, Z](field1: Field[A1], field2: Field[A2], field3: Field[A3], field4: Field[A4], field5: Field[A5], construct: (A1, A2, A3, A4, A5) => Z, extractField1: Z => A1, extractField2: Z => A2, extractField3: Z => A3, extractField4: Z => A4, extractField5: Z => A5, override val annotations: Chunk[Any] = Chunk.empty) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5])
 
     override def annotate(annotation: Any): CaseClass5[A1, A2, A3, A4, A5, Z] = copy(annotations = annotations :+ annotation)
@@ -1967,7 +1967,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass6[A1, A2, A3, A4, A5, A6, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -1980,7 +1979,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField3: Z => A3,
     extractField4: Z => A4,
     extractField5: Z => A5,
-    extractField6: Z => A6
+    extractField6: Z => A6,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6])
 
@@ -2005,7 +2005,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass7[A1, A2, A3, A4, A5, A6, A7, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2020,7 +2019,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField4: Z => A4,
     extractField5: Z => A5,
     extractField6: Z => A6,
-    extractField7: Z => A7
+    extractField7: Z => A7,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7])
 
@@ -2045,7 +2045,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass8[A1, A2, A3, A4, A5, A6, A7, A8, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2062,7 +2061,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField5: Z => A5,
     extractField6: Z => A6,
     extractField7: Z => A7,
-    extractField8: Z => A8
+    extractField8: Z => A8,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8])
 
@@ -2087,7 +2087,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass9[A1, A2, A3, A4, A5, A6, A7, A8, A9, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2106,7 +2105,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField6: Z => A6,
     extractField7: Z => A7,
     extractField8: Z => A8,
-    extractField9: Z => A9
+    extractField9: Z => A9,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9])
 
@@ -2131,7 +2131,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2152,7 +2151,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField7: Z => A7,
     extractField8: Z => A8,
     extractField9: Z => A9,
-    extractField10: Z => A10
+    extractField10: Z => A10,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10])
 
@@ -2177,7 +2177,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2200,7 +2199,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField8: Z => A8,
     extractField9: Z => A9,
     extractField10: Z => A10,
-    extractField11: Z => A11
+    extractField11: Z => A11,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11])
 
@@ -2225,7 +2225,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2250,7 +2249,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField9: Z => A9,
     extractField10: Z => A10,
     extractField11: Z => A11,
-    extractField12: Z => A12
+    extractField12: Z => A12,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12])
 
@@ -2275,7 +2275,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2302,7 +2301,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField10: Z => A10,
     extractField11: Z => A11,
     extractField12: Z => A12,
-    extractField13: Z => A13
+    extractField13: Z => A13,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13])
 
@@ -2327,7 +2327,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass14[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2356,7 +2355,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField11: Z => A11,
     extractField12: Z => A12,
     extractField13: Z => A13,
-    extractField14: Z => A14
+    extractField14: Z => A14,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14])
 
@@ -2399,7 +2399,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass15[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2430,7 +2429,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField12: Z => A12,
     extractField13: Z => A13,
     extractField14: Z => A14,
-    extractField15: Z => A15
+    extractField15: Z => A15,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15])
 
@@ -2490,7 +2490,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass16[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2523,7 +2522,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField13: Z => A13,
     extractField14: Z => A14,
     extractField15: Z => A15,
-    extractField16: Z => A16
+    extractField16: Z => A16,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15], Lens[Z, A16])
 
@@ -2585,7 +2585,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass17[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2620,7 +2619,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField14: Z => A14,
     extractField15: Z => A15,
     extractField16: Z => A16,
-    extractField17: Z => A17
+    extractField17: Z => A17,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15], Lens[Z, A16], Lens[Z, A17])
 
@@ -2684,7 +2684,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass18[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2721,7 +2720,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField15: Z => A15,
     extractField16: Z => A16,
     extractField17: Z => A17,
-    extractField18: Z => A18
+    extractField18: Z => A18,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15], Lens[Z, A16], Lens[Z, A17], Lens[Z, A18])
 
@@ -2787,7 +2787,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass19[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2826,7 +2825,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField16: Z => A16,
     extractField17: Z => A17,
     extractField18: Z => A18,
-    extractField19: Z => A19
+    extractField19: Z => A19,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15], Lens[Z, A16], Lens[Z, A17], Lens[Z, A18], Lens[Z, A19])
 
@@ -2894,7 +2894,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass20[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -2935,7 +2934,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField17: Z => A17,
     extractField18: Z => A18,
     extractField19: Z => A19,
-    extractField20: Z => A20
+    extractField20: Z => A20,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15], Lens[Z, A16], Lens[Z, A17], Lens[Z, A18], Lens[Z, A19], Lens[Z, A20])
 
@@ -3005,7 +3005,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass21[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -3048,7 +3047,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField18: Z => A18,
     extractField19: Z => A19,
     extractField20: Z => A20,
-    extractField21: Z => A21
+    extractField21: Z => A21,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15], Lens[Z, A16], Lens[Z, A17], Lens[Z, A18], Lens[Z, A19], Lens[Z, A20], Lens[Z, A21])
 
@@ -3120,7 +3120,6 @@ sealed trait RecordSchemas { self: Schema.type =>
   }
 
   sealed case class CaseClass22[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, Z](
-    override val annotations: Chunk[Any] = Chunk.empty,
     field1: Field[A1],
     field2: Field[A2],
     field3: Field[A3],
@@ -3165,7 +3164,8 @@ sealed trait RecordSchemas { self: Schema.type =>
     extractField19: Z => A19,
     extractField20: Z => A20,
     extractField21: Z => A21,
-    extractField22: Z => A22
+    extractField22: Z => A22,
+    override val annotations: Chunk[Any] = Chunk.empty
   ) extends Record[Z] { self =>
     type Accessors[Lens[_, _], Prism[_, _], Traversal[_, _]] = (Lens[Z, A1], Lens[Z, A2], Lens[Z, A3], Lens[Z, A4], Lens[Z, A5], Lens[Z, A6], Lens[Z, A7], Lens[Z, A8], Lens[Z, A9], Lens[Z, A10], Lens[Z, A11], Lens[Z, A12], Lens[Z, A13], Lens[Z, A14], Lens[Z, A15], Lens[Z, A16], Lens[Z, A17], Lens[Z, A18], Lens[Z, A19], Lens[Z, A20], Lens[Z, A21], Lens[Z, A22])
 

--- a/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
@@ -35,7 +35,6 @@ object SchemaAst {
   object Product {
     implicit val schema: Schema[Product] = {
       Schema.CaseClass4(
-        annotations = Chunk.empty,
         field1 = Schema.Field("path", Schema[String].repeated),
         field2 = Schema.Field("fields", Schema[Labelled].repeated),
         field3 = Schema.Field("optional", Schema[Boolean]),
@@ -59,7 +58,6 @@ object SchemaAst {
   object Sum {
     implicit val schema: Schema[Sum] =
       Schema.CaseClass4(
-        annotations = Chunk.empty,
         field1 = Schema.Field("path", Schema[String].repeated),
         field2 = Schema.Field("cases", Schema[Labelled].repeated),
         field3 = Schema.Field("optional", Schema[Boolean]),
@@ -81,7 +79,6 @@ object SchemaAst {
 
   object FailNode {
     implicit val schema: Schema[FailNode] = Schema.CaseClass4(
-      annotations = Chunk.empty,
       field1 = Schema.Field("message", Schema[String]),
       field2 = Schema.Field("path", Schema[String].repeated),
       field3 = Schema.Field("optional", Schema[Boolean]),
@@ -105,7 +102,6 @@ object SchemaAst {
     implicit val schema: Schema[Value] =
       Schema
         .CaseClass4[String, Chunk[String], Boolean, Int, (String, Chunk[String], Boolean, Int)](
-          annotations = Chunk.empty,
           field1 = Schema.Field("valueType", Schema[String]),
           field2 = Schema.Field("path", Schema[String].repeated),
           field3 = Schema.Field("optional", Schema[Boolean]),
@@ -139,7 +135,6 @@ object SchemaAst {
   object Ref {
     implicit val schema: Schema[Ref] =
       Schema.CaseClass4(
-        annotations = Chunk.empty,
         field1 = Schema.Field("refPath", Schema[String].repeated),
         field2 = Schema.Field("path", Schema[String].repeated),
         field3 = Schema.Field("optional", Schema[Boolean]),


### PR DESCRIPTION
Annotations have a default value of an empty chunk but appear as the first argument in case class constructors. By moving them to being the last argument we can avoid users having to use named arguments or specify this argument.