### PR TITLE
Fix bug in enum schema derivation

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-2/zio/schema/macros.scala
+++ b/zio-schema-derivation/shared/src/main/scala-2/zio/schema/macros.scala
@@ -530,15 +530,14 @@ object DeriveSchema {
         case 22 =>
           q"""{lazy val $selfRefIdent: zio.schema.Schema.Enum22[..$typeArgs] = zio.schema.Schema.Enum22[..$typeArgs](..$applyArgs); $selfRefIdent}"""
         case _ =>
-          val caseSet     = q"zio.schema.CaseSet.apply(..$cases).asInstanceOf[zio.schema.CaseSet.Aux[$tpe]]"
-          val caseSetType = c.typecheck(caseSet, c.TYPEmode).tpe
+          val caseSet = q"zio.schema.CaseSet.apply(..$cases).asInstanceOf[zio.schema.CaseSet.Aux[$tpe]]"
 
           if (typeAnnotations.isEmpty)
-            q"""{lazy val $selfRefIdent: zio.schema.Schema.EnumN[$tpe,$caseSetType] = zio.schema.Schema.EnumN.apply[$tpe,$caseSetType]($caseSet); $selfRefIdent}"""
+            q"""{lazy val $selfRefIdent: zio.schema.Schema.EnumN[$tpe,zio.schema.CaseSet.Aux[$tpe]] = zio.schema.Schema.EnumN.apply[$tpe,zio.schema.CaseSet.Aux[$tpe]]($caseSet); $selfRefIdent}"""
           else {
             val annotationArg = q"zio.Chunk.apply(..$typeAnnotations)"
 
-            q"""{lazy val $selfRefIdent: zio.schema.Schema.EnumN[$tpe,$caseSetType] = zio.schema.Schema.EnumN.apply[$tpe,$caseSetType]($caseSet,$annotationArg); $selfRefIdent}"""
+            q"""{lazy val $selfRefIdent: zio.schema.Schema.EnumN[$tpe,zio.schema.CaseSet.Aux[$tpe]] = zio.schema.Schema.EnumN.apply[$tpe,zio.schema.CaseSet.Aux[$tpe]]($caseSet,$annotationArg); $selfRefIdent}"""
           }
       }
     }

--- a/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
@@ -210,7 +210,7 @@ object DeriveSchemaSpec extends DefaultRunnableSpec {
     case object C20                     extends Enum23
     case object C21                     extends Enum23
     case object C22                     extends Enum23
-    case object C23                     extends Enum23
+    case class C23(recursive: Enum23)   extends Enum23
 
     implicit lazy val schema: Schema.EnumN[Enum23, CaseSet.Aux[Enum23]] = DeriveSchema.gen[Enum23]
 


### PR DESCRIPTION
There was a bug in the macro derivation causing a compile-time failure for derivation of `EnumN` that included recursive types. Before constructing the Schema we would type check the `CaseSet` declaration like so:

`val caseSetType = c.typecheck(caseSet, c.TYPEmode).tpe`

In instances where the cases include recursive references to the `EnumN` type, this won't type check as the named `EnumN` instance hasn't been defined yet. Fortunately we already know what type this `CaseSet` should be so we can avoid the type check. 