### PR TITLE
Add special encoding for List and Map types in SchemaAst

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -82,7 +82,9 @@ object BuildHelper {
       if (sys.env.contains("CI")) {
         Seq("-Xfatal-warnings", "-Ypatmat-exhaust-depth", "80")
       } else {
-        Seq("-Ypatmat-exhaust-depth", "80")
+        Seq("-Xfatal-warnings", "-Ypatmat-exhaust-depth", "80")
+
+//        Seq("-Ypatmat-exhaust-depth", "80")
 //        Nil // to enable Scalafix locally
       }
     }

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -82,10 +82,7 @@ object BuildHelper {
       if (sys.env.contains("CI")) {
         Seq("-Xfatal-warnings", "-Ypatmat-exhaust-depth", "80")
       } else {
-        Seq("-Xfatal-warnings", "-Ypatmat-exhaust-depth", "80")
-
-//        Seq("-Ypatmat-exhaust-depth", "80")
-//        Nil // to enable Scalafix locally
+        Seq("-Ypatmat-exhaust-depth", "80")
       }
     }
 

--- a/tests/shared/src/test/scala/zio/schema/MigrationSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/MigrationSpec.scala
@@ -41,21 +41,23 @@ object MigrationSpec extends DefaultRunnableSpec {
           )
         },
         test("increment dimensions") {
-          val from = SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true, dimensions = 0)
-          val to   = SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true, dimensions = 2)
+          val from = SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true)
+          val to =
+            SchemaAst.ListNode(SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true), NodePath.root)
 
           assertTrue(
             Migration
-              .derive(from, to) == Right(Chunk(Migration.IncrementDimensions(NodePath.root, 2)))
+              .derive(from, to) == Right(Chunk(Migration.IncrementDimensions(NodePath.root, 1)))
           )
         },
         test("decrement dimensions") {
-          val from = SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true, dimensions = 2)
-          val to   = SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true, dimensions = 0)
+          val from =
+            SchemaAst.ListNode(SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true), NodePath.root)
+          val to = SchemaAst.Value(StandardType.IntType, NodePath.root, optional = true)
 
           assertTrue(
             Migration
-              .derive(from, to) == Right(Chunk(Migration.DecrementDimensions(NodePath.root, 2)))
+              .derive(from, to) == Right(Chunk(Migration.DecrementDimensions(NodePath.root, 1)))
           )
         }
       ),

--- a/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
@@ -29,7 +29,10 @@ object SchemaAstSpec extends DefaultRunnableSpec {
       testM("primitive") {
         check(SchemaGen.anyPrimitive) {
           case s @ Schema.Primitive(typ, _) =>
-            assertTrue(SchemaAst.fromSchema(Schema.chunk(s)) == SchemaAst.Value(typ, dimensions = 1))
+            assertTrue(
+              SchemaAst.fromSchema(Schema.chunk(s)) == SchemaAst
+                .ListNode(SchemaAst.Value(typ, path = NodePath.root / "item"), NodePath.root)
+            )
         }
       }
     ),
@@ -75,7 +78,7 @@ object SchemaAstSpec extends DefaultRunnableSpec {
         val ast    = SchemaAst.fromSchema(schema)
 
         val recursiveRef: Option[SchemaAst] = ast match {
-          case SchemaAst.Product(_, elements, _, _) =>
+          case SchemaAst.Product(_, elements, _) =>
             elements.find {
               case ("r", _) => true
               case _        => false
@@ -84,8 +87,8 @@ object SchemaAstSpec extends DefaultRunnableSpec {
         }
         assertTrue(
           recursiveRef.exists {
-            case SchemaAst.Ref(pathRef, _, _, _) => pathRef == Chunk.empty
-            case _                               => false
+            case SchemaAst.Ref(pathRef, _, _) => pathRef == Chunk.empty
+            case _                            => false
           }
         )
       }
@@ -202,7 +205,12 @@ object SchemaAstSpec extends DefaultRunnableSpec {
         check(SchemaGen.anySchema) { schema =>
           assert(SchemaAst.fromSchema(schema).toSchema)(hasSameSchemaStructure(schema))
         }
-      } @@ TestAspect.shrinks(0)
+      } @@ TestAspect.shrinks(0),
+      test("sequence of optional primitives") {
+        val schema       = Schema[List[Option[Int]]]
+        val materialized = SchemaAst.fromSchema(schema).toSchema
+        assert(materialized)(hasSameSchemaStructure(schema))
+      }
     )
   )
 

--- a/tests/shared/src/test/scala/zio/schema/SchemaMigrationSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaMigrationSpec.scala
@@ -72,6 +72,20 @@ object SchemaMigrationSpec extends DefaultRunnableSpec {
           }
         }
       }
+    ),
+    suite("map")(
+      testM("map keys") {
+        check(Gen.mapOf(Gen.int(0, 100), Gen.int(1, 100))) { map =>
+          val expected: Map[Option[Int], Int] = map.map { case (k, v) => Some(k) -> v }.toMap
+          assert(map)(migratesTo(expected))
+        }
+      },
+      testM("map values") {
+        check(Gen.mapOf(Gen.int(0, 100), Gen.int(1, 100))) { map =>
+          val expected: Map[Int, Option[Int]] = map.map { case (k, v) => k -> Some(v) }
+          assert(map)(migratesTo(expected))
+        }
+      } @@ TestAspect.shrinks(0)
     )
   )
 

--- a/zio-schema/shared/src/main/scala/zio/schema/ast/Migration.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/ast/Migration.scala
@@ -118,35 +118,47 @@ object Migration {
             else
               transformShape(path, f, t) :+ UpdateFail(path, t.message)
           )
-        case (f @ SchemaAst.Product(_, ffields, _, _), t @ SchemaAst.Product(_, tfields, _, _)) =>
+        case (f @ SchemaAst.Product(_, ffields, _), t @ SchemaAst.Product(_, tfields, _)) =>
           goProduct(f, t, ffields, tfields)
-        case (f @ SchemaAst.Tuple(_, fleft, fright, _, _), t @ SchemaAst.Tuple(_, tleft, tright, _, _)) =>
+        case (f @ SchemaAst.Tuple(_, fleft, fright, _), t @ SchemaAst.Tuple(_, tleft, tright, _)) =>
           val ffields = Chunk("left" -> fleft, "right" -> fright)
           val tfields = Chunk("left" -> tleft, "right" -> tright)
           goProduct(f, t, ffields, tfields)
-        case (f @ SchemaAst.Product(_, ffields, _, _), t @ SchemaAst.Tuple(_, tleft, tright, _, _)) =>
+        case (f @ SchemaAst.Product(_, ffields, _), t @ SchemaAst.Tuple(_, tleft, tright, _)) =>
           val tfields = Chunk("left" -> tleft, "right" -> tright)
           goProduct(f, t, ffields, tfields)
-        case (f @ SchemaAst.Tuple(_, fleft, fright, _, _), t @ SchemaAst.Product(_, tfields, _, _)) =>
+        case (f @ SchemaAst.Tuple(_, fleft, fright, _), t @ SchemaAst.Product(_, tfields, _)) =>
           val ffields = Chunk("left" -> fleft, "right" -> fright)
           goProduct(f, t, ffields, tfields)
-        case (f @ SchemaAst.Sum(_, fcases, _, _), t @ SchemaAst.Sum(_, tcases, _, _)) =>
+        case (f @ SchemaAst.ListNode(fitem, _, _), t @ SchemaAst.ListNode(titem, _, _)) =>
+          val ffields = Chunk("item" -> fitem)
+          val tfields = Chunk("item" -> titem)
+          goProduct(f, t, ffields, tfields)
+        case (SchemaAst.ListNode(fitem, _, _), titem) =>
+          derive(fitem, titem).map(migrations => DecrementDimensions(titem.path, 1) +: migrations)
+        case (fitem, SchemaAst.ListNode(titem, _, _)) =>
+          derive(fitem, titem).map(migrations => IncrementDimensions(titem.path, 1) +: migrations)
+        case (f @ SchemaAst.Dictionary(fkeys, fvalues, _, _), t @ SchemaAst.Dictionary(tkeys, tvalues, _, _)) =>
+          val ffields = Chunk("keys" -> fkeys, "values" -> fvalues)
+          val tfields = Chunk("keys" -> tkeys, "values" -> tvalues)
+          goProduct(f, t, ffields, tfields)
+        case (f @ SchemaAst.Sum(_, fcases, _), t @ SchemaAst.Sum(_, tcases, _)) =>
           goSum(f, t, fcases, tcases)
-        case (f @ SchemaAst.Either(_, fleft, fright, _, _), t @ SchemaAst.Either(_, tleft, tright, _, _)) =>
+        case (f @ SchemaAst.Either(_, fleft, fright, _), t @ SchemaAst.Either(_, tleft, tright, _)) =>
           val fcases = Chunk("left" -> fleft, "right" -> fright)
           val tcases = Chunk("left" -> tleft, "right" -> tright)
           goSum(f, t, fcases, tcases)
-        case (f @ SchemaAst.Sum(_, fcases, _, _), t @ SchemaAst.Either(_, tleft, tright, _, _)) =>
+        case (f @ SchemaAst.Sum(_, fcases, _), t @ SchemaAst.Either(_, tleft, tright, _)) =>
           val tcases = Chunk("left" -> tleft, "right" -> tright)
           goSum(f, t, fcases, tcases)
-        case (f @ SchemaAst.Either(_, fleft, fright, _, _), t @ SchemaAst.Sum(_, tcases, _, _)) =>
+        case (f @ SchemaAst.Either(_, fleft, fright, _), t @ SchemaAst.Sum(_, tcases, _)) =>
           val fcases = Chunk("left" -> fleft, "right" -> fright)
           goSum(f, t, fcases, tcases)
-        case (f @ SchemaAst.Value(ftype, _, _, _), t @ SchemaAst.Value(ttype, _, _, _)) if ttype != ftype =>
+        case (f @ SchemaAst.Value(ftype, _, _), t @ SchemaAst.Value(ttype, _, _)) if ttype != ftype =>
           Right(transformShape(path, f, t) :+ ChangeType(path, ttype))
-        case (f @ SchemaAst.Value(_, _, _, _), t @ SchemaAst.Value(_, _, _, _)) =>
+        case (f @ SchemaAst.Value(_, _, _), t @ SchemaAst.Value(_, _, _)) =>
           Right(transformShape(path, f, t))
-        case (f @ SchemaAst.Ref(fromRef, nodePath, _, _), t @ SchemaAst.Ref(toRef, _, _, _)) if fromRef == toRef =>
+        case (f @ SchemaAst.Ref(fromRef, nodePath, _), t @ SchemaAst.Ref(toRef, _, _)) if fromRef == toRef =>
           if (ignoreRefs) Right(Chunk.empty)
           else {
             val recursiveMigrations = acc
@@ -252,12 +264,6 @@ object Migration {
     if (to.optional && !from.optional)
       builder += Optional(path)
 
-    if (to.dimensions > from.dimensions)
-      builder += IncrementDimensions(path, to.dimensions - from.dimensions)
-
-    if (from.dimensions > to.dimensions)
-      builder += DecrementDimensions(path, from.dimensions - to.dimensions)
-
     builder.result()
   }
 
@@ -265,16 +271,15 @@ object Migration {
     value: DynamicValue,
     path: List[String],
     trace: Chunk[String] = Chunk.empty
-  )(op: (String, DynamicValue) => Either[String, Option[(String, DynamicValue)]]): Either[String, DynamicValue] =
+  )(op: (String, DynamicValue) => Either[String, Option[(String, DynamicValue)]]): Either[String, DynamicValue] = {
     (value, path) match {
       case (DynamicValue.Transform(value), _) =>
         updateLeaf(value, path, trace)(op).map(DynamicValue.Transform(_))
       case (DynamicValue.SomeValue(value), _) =>
         updateLeaf(value, path, trace)(op).map(DynamicValue.SomeValue(_))
       case (DynamicValue.NoneValue, _) => Right(DynamicValue.NoneValue)
-      case (DynamicValue.Sequence(values), _) =>
-        values
-          .map(v => updateLeaf(v, path, trace)(op))
+      case (DynamicValue.Sequence(values), "item" :: remainder) =>
+        values.zipWithIndex.map { case (v, idx) => updateLeaf(v, remainder, trace :+ s"item[$idx]")(op) }
           .foldRight[Either[String, DynamicValue.Sequence]](Right(DynamicValue.Sequence(Chunk.empty))) {
             case (Left(e1), Left(e2)) => Left(s"$e1;\n$e2")
             case (Left(e), Right(_))  => Left(e)
@@ -321,9 +326,88 @@ object Migration {
         updateLeaf(caseValue, remainder, trace :+ nextLabel)(op).map { updatedValue =>
           DynamicValue.Enumeration(nextLabel -> updatedValue)
         }
+      case (DynamicValue.Dictionary(entries), "keys" :: Nil) =>
+        entries
+          .map(_._1)
+          .zipWithIndex
+          .map {
+            case (k, idx) =>
+              op(s"key[$idx]", k).flatMap {
+                case Some((_, migrated)) => Right(migrated)
+                case None                => Left(s"invalid update at $path, cannot remove map key")
+              }
+          }
+          .foldRight[Either[String, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+            case (Left(e1), Left(e2)) => Left(s"$e1;\n$e2")
+            case (Left(e), Right(_))  => Left(e)
+            case (Right(_), Left(e))  => Left(e)
+            case (Right(value), Right(chunk)) =>
+              Right(value +: chunk)
+          }
+          .map { keys =>
+            DynamicValue.Dictionary(keys.zip(entries.map(_._2)))
+          }
+      case (DynamicValue.Dictionary(entries), "keys" :: remainder) =>
+        entries
+          .map(_._1)
+          .zipWithIndex
+          .map {
+            case (k, idx) =>
+              updateLeaf(k, remainder, trace :+ s"key[$idx]")(op)
+          }
+          .foldRight[Either[String, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+            case (Left(e1), Left(e2)) => Left(s"$e1;\n$e2")
+            case (Left(e), Right(_))  => Left(e)
+            case (Right(_), Left(e))  => Left(e)
+            case (Right(value), Right(chunk)) =>
+              Right(value +: chunk)
+          }
+          .map { keys =>
+            DynamicValue.Dictionary(keys.zip(entries.map(_._2)))
+          }
+      case (DynamicValue.Dictionary(entries), "values" :: Nil) =>
+        entries
+          .map(_._2)
+          .zipWithIndex
+          .map {
+            case (k, idx) =>
+              op(s"key[$idx]", k).flatMap {
+                case Some((_, migrated)) => Right(migrated)
+                case None                => Left(s"invalid update at $path, cannot remove map value")
+              }
+          }
+          .foldRight[Either[String, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+            case (Left(e1), Left(e2)) => Left(s"$e1;\n$e2")
+            case (Left(e), Right(_))  => Left(e)
+            case (Right(_), Left(e))  => Left(e)
+            case (Right(value), Right(chunk)) =>
+              Right(value +: chunk)
+          }
+          .map { values =>
+            DynamicValue.Dictionary(entries.map(_._1).zip(values))
+          }
+      case (DynamicValue.Dictionary(entries), "values" :: remainder) =>
+        entries
+          .map(_._2)
+          .zipWithIndex
+          .map {
+            case (k, idx) =>
+              updateLeaf(k, remainder, trace :+ s"value[$idx]")(op)
+          }
+          .foldRight[Either[String, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+            case (Left(e1), Left(e2)) => Left(s"$e1;\n$e2")
+            case (Left(e), Right(_))  => Left(e)
+            case (Right(_), Left(e))  => Left(e)
+            case (Right(value), Right(chunk)) =>
+              Right(value +: chunk)
+          }
+          .map { values =>
+            DynamicValue.Dictionary(entries.map(_._1).zip(values))
+          }
       case _ =>
         Left(s"Failed to update leaf at path ${renderPath(trace ++ path)}: Unexpected node at ${renderPath(trace)}")
     }
+  }
 
   private def spliceRecord(
     fields: ListMap[String, DynamicValue],

--- a/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
@@ -318,15 +318,16 @@ object SchemaAst {
               optional
             )
           case Schema.Sequence(schema, _, _, _, _) =>
-            ListNode(item = subtree(path / "item", lineage, schema, optional = false), path)
+            ListNode(item = subtree(path / "item", lineage, schema, optional), path)
           case Schema.MapSchema(ks, vs, _) =>
             Dictionary(
               keys = subtree(path / "keys", Chunk.empty, ks, optional = false),
               values = subtree(path / "values", Chunk.empty, vs, optional = false),
-              path
+              path,
+              optional
             )
           case Schema.SetSchema(schema @ _, _) =>
-            ListNode(item = subtree(path / "item", lineage, schema, optional = false), path)
+            ListNode(item = subtree(path / "item", lineage, schema, optional), path)
           case Schema.Transform(schema, _, _, _, _) => subtree(path, lineage, schema, optional)
           case lzy @ Schema.Lazy(_)                 => subtree(path, lineage, lzy.schema, optional)
           case s: Schema.Record[_] =>

--- a/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
@@ -10,7 +10,6 @@ import zio.{ Chunk, ChunkBuilder }
 sealed trait SchemaAst { self =>
   def path: NodePath
   def optional: Boolean
-  def dimensions: Int
 
   def toSchema: Schema[_] = {
     val refMap = mutable.HashMap.empty[NodePath, Schema[_]]
@@ -33,23 +32,19 @@ object SchemaAst {
   final case class Product(
     override val path: NodePath,
     fields: Chunk[Labelled] = Chunk.empty,
-    override val optional: Boolean = false,
-    override val dimensions: Int = 0
+    override val optional: Boolean = false
   ) extends SchemaAst
 
   object Product {
     implicit val schema: Schema[Product] = {
-      Schema.CaseClass4(
+      Schema.CaseClass3(
         field1 = Schema.Field("path", Schema[String].repeated),
         field2 = Schema.Field("fields", Schema[Labelled].repeated),
         field3 = Schema.Field("optional", Schema[Boolean]),
-        field4 = Schema.Field("dimensions", Schema[Int]),
-        (path: Chunk[String], fields: Chunk[Labelled], optional: Boolean, dimensions: Int) =>
-          Product(NodePath(path), fields, optional, dimensions),
+        (path: Chunk[String], fields: Chunk[Labelled], optional: Boolean) => Product(NodePath(path), fields, optional),
         _.path,
         _.fields,
-        _.optional,
-        _.dimensions
+        _.optional
       )
     }
   }
@@ -58,25 +53,22 @@ object SchemaAst {
     override val path: NodePath,
     left: SchemaAst,
     right: SchemaAst,
-    override val optional: Boolean = false,
-    override val dimensions: Int = 0
+    override val optional: Boolean = false
   ) extends SchemaAst
 
   object Tuple {
     implicit val schema: Schema[Tuple] = {
-      Schema.CaseClass5(
+      Schema.CaseClass4(
         field1 = Schema.Field("path", Schema[String].repeated),
         field2 = Schema.Field("left", Schema[SchemaAst]),
         field3 = Schema.Field("right", Schema[SchemaAst]),
         field4 = Schema.Field("optional", Schema[Boolean]),
-        field5 = Schema.Field("dimensions", Schema[Int]),
-        (path: Chunk[String], left: SchemaAst, right: SchemaAst, optional: Boolean, dimensions: Int) =>
-          Tuple(NodePath(path), left, right, optional, dimensions),
+        (path: Chunk[String], left: SchemaAst, right: SchemaAst, optional: Boolean) =>
+          Tuple(NodePath(path), left, right, optional),
         _.path,
         _.left,
         _.right,
-        _.optional,
-        _.dimensions
+        _.optional
       )
     }
   }
@@ -84,23 +76,19 @@ object SchemaAst {
   final case class Sum(
     override val path: NodePath,
     cases: Chunk[Labelled] = Chunk.empty,
-    override val optional: Boolean = false,
-    override val dimensions: Int = 0
+    override val optional: Boolean = false
   ) extends SchemaAst
 
   object Sum {
     implicit val schema: Schema[Sum] =
-      Schema.CaseClass4(
+      Schema.CaseClass3(
         field1 = Schema.Field("path", Schema[String].repeated),
         field2 = Schema.Field("cases", Schema[Labelled].repeated),
         field3 = Schema.Field("optional", Schema[Boolean]),
-        field4 = Schema.Field("dimensions", Schema[Int]),
-        (path: Chunk[String], fields: Chunk[Labelled], optional: Boolean, dimensions: Int) =>
-          Sum(NodePath(path), fields, optional, dimensions),
+        (path: Chunk[String], fields: Chunk[Labelled], optional: Boolean) => Sum(NodePath(path), fields, optional),
         _.path,
         _.cases,
-        _.optional,
-        _.dimensions
+        _.optional
       )
   }
 
@@ -108,25 +96,22 @@ object SchemaAst {
     override val path: NodePath,
     left: SchemaAst,
     right: SchemaAst,
-    override val optional: Boolean = false,
-    override val dimensions: Int = 0
+    override val optional: Boolean = false
   ) extends SchemaAst
 
   object Either {
     implicit val schema: Schema[Either] = {
-      Schema.CaseClass5(
+      Schema.CaseClass4(
         field1 = Schema.Field("path", Schema[String].repeated),
         field2 = Schema.Field("left", Schema[SchemaAst]),
         field3 = Schema.Field("right", Schema[SchemaAst]),
         field4 = Schema.Field("optional", Schema[Boolean]),
-        field5 = Schema.Field("dimensions", Schema[Int]),
-        (path: Chunk[String], left: SchemaAst, right: SchemaAst, optional: Boolean, dimensions: Int) =>
-          Either(NodePath(path), left, right, optional, dimensions),
+        (path: Chunk[String], left: SchemaAst, right: SchemaAst, optional: Boolean) =>
+          Either(NodePath(path), left, right, optional),
         _.path,
         _.left,
         _.right,
-        _.optional,
-        _.dimensions
+        _.optional
       )
     }
   }
@@ -134,86 +119,116 @@ object SchemaAst {
   final case class FailNode(
     message: String,
     override val path: NodePath,
-    override val optional: Boolean = false,
-    override val dimensions: Int = 0
+    override val optional: Boolean = false
   ) extends SchemaAst
 
   object FailNode {
-    implicit val schema: Schema[FailNode] = Schema.CaseClass4(
+    implicit val schema: Schema[FailNode] = Schema.CaseClass3(
       field1 = Schema.Field("message", Schema[String]),
       field2 = Schema.Field("path", Schema[String].repeated),
       field3 = Schema.Field("optional", Schema[Boolean]),
-      field4 = Schema.Field("dimensions", Schema[Int]),
-      (m: String, path: Chunk[String], optional: Boolean, dimensions: Int) =>
-        FailNode(m, NodePath(path), optional, dimensions),
+      (m: String, path: Chunk[String], optional: Boolean) => FailNode(m, NodePath(path), optional),
       _.message,
       _.path,
-      _.optional,
-      _.dimensions
+      _.optional
     )
   }
+
+  final case class ListNode(
+    item: SchemaAst,
+    override val path: NodePath,
+    override val optional: Boolean = false
+  ) extends SchemaAst
+
+  object ListNode {
+    implicit val schema: Schema[ListNode] = Schema.CaseClass3(
+      field1 = Schema.Field("item", Schema[SchemaAst]),
+      field2 = Schema.Field("path", Schema[String].repeated),
+      field3 = Schema.Field("optional", Schema[Boolean]),
+      (item: SchemaAst, path: Chunk[String], optional: Boolean) => ListNode(item, NodePath(path), optional),
+      _.item,
+      _.path,
+      _.optional
+    )
+  }
+
+  final case class Dictionary(
+    keys: SchemaAst,
+    values: SchemaAst,
+    override val path: NodePath,
+    override val optional: Boolean = false
+  ) extends SchemaAst
+
+  object Dictionary {
+    implicit val schema: Schema[Dictionary] = Schema.CaseClass4(
+      field1 = Schema.Field("keys", Schema[SchemaAst]),
+      field2 = Schema.Field("values", Schema[SchemaAst]),
+      field3 = Schema.Field("path", Schema[String].repeated),
+      field4 = Schema.Field("optional", Schema[Boolean]),
+      (keys: SchemaAst, values: SchemaAst, path: Chunk[String], optional: Boolean) =>
+        Dictionary(keys, values, NodePath(path), optional),
+      _.keys,
+      _.values,
+      _.path,
+      _.optional
+    )
+  }
+
   final case class Value(
     valueType: StandardType[_],
     override val path: NodePath = NodePath.root,
-    override val optional: Boolean = false,
-    override val dimensions: Int = 0
+    override val optional: Boolean = false
   ) extends SchemaAst
 
   object Value {
     implicit val schema: Schema[Value] =
       Schema
-        .CaseClass4[String, Chunk[String], Boolean, Int, (String, Chunk[String], Boolean, Int)](
+        .CaseClass3[String, Chunk[String], Boolean, (String, Chunk[String], Boolean)](
           field1 = Schema.Field("valueType", Schema[String]),
           field2 = Schema.Field("path", Schema[String].repeated),
           field3 = Schema.Field("optional", Schema[Boolean]),
-          field4 = Schema.Field("dimensions", Schema[Int]),
-          construct = (v, p, o, d) => (v, p, o, d),
+          construct = (v, p, o) => (v, p, o),
           extractField1 = _._1,
           extractField2 = _._2,
-          extractField3 = _._3,
-          extractField4 = _._4
+          extractField3 = _._3
         )
         .transformOrFail(fromTuple, tupled)
 
-    private def tupled(value: Value): scala.Either[String, (String, Chunk[String], Boolean, Int)] =
-      Right((value.valueType.tag, value.path, value.optional, value.dimensions))
+    private def tupled(value: Value): scala.Either[String, (String, Chunk[String], Boolean)] =
+      Right((value.valueType.tag, value.path, value.optional))
 
-    private def fromTuple(tuple: (String, Chunk[String], Boolean, Int)): scala.Either[String, Value] = tuple match {
-      case (s, path, optional, dimensions) =>
+    private def fromTuple(tuple: (String, Chunk[String], Boolean)): scala.Either[String, Value] = tuple match {
+      case (s, path, optional) =>
         StandardType
           .fromString(s)
-          .map(typ => Value(typ, NodePath(path), optional, dimensions))
+          .map(typ => Value(typ, NodePath(path), optional))
           .toRight(s"unkown standard type $s")
     }
   }
   final case class Ref(
     refPath: NodePath,
     override val path: NodePath,
-    optional: Boolean = false,
-    dimensions: Int = 0
+    optional: Boolean = false
   ) extends SchemaAst
 
   object Ref {
     implicit val schema: Schema[Ref] =
-      Schema.CaseClass4(
+      Schema.CaseClass3(
         field1 = Schema.Field("refPath", Schema[String].repeated),
         field2 = Schema.Field("path", Schema[String].repeated),
         field3 = Schema.Field("optional", Schema[Boolean]),
-        field4 = Schema.Field("dimensions", Schema[Int]),
-        (refPath: Chunk[String], path: Chunk[String], optional: Boolean, dimensions: Int) =>
-          Ref(NodePath(refPath), NodePath(path), optional, dimensions),
+        (refPath: Chunk[String], path: Chunk[String], optional: Boolean) =>
+          Ref(NodePath(refPath), NodePath(path), optional),
         _.refPath,
         _.path,
-        _.optional,
-        _.dimensions
+        _.optional
       )
   }
 
   final private[schema] case class NodeBuilder(
     path: NodePath,
     lineage: Lineage,
-    optional: Boolean = false,
-    dimensions: Int = 0
+    optional: Boolean = false
   ) { self =>
     private val children: ChunkBuilder[Labelled] = ChunkBuilder.make[Labelled]()
 
@@ -222,9 +237,9 @@ object SchemaAst {
       self
     }
 
-    def buildProduct(): Product = Product(path, children.result(), optional, dimensions)
+    def buildProduct(): Product = Product(path, children.result(), optional)
 
-    def buildSum(): Sum = Sum(path, children.result(), optional, dimensions)
+    def buildSum(): Sum = Sum(path, children.result(), optional)
   }
 
   @tailrec
@@ -245,14 +260,15 @@ object SchemaAst {
         subtree(NodePath.root / "right", Chunk.empty, right)
       )
     case Schema.Sequence(schema, _, _, _, _) =>
-      subtree(NodePath.root, Chunk.empty, schema, dimensions = 1)
+      ListNode(item = subtree(NodePath.root / "item", Chunk.empty, schema), NodePath.root)
     case Schema.MapSchema(ks, vs, _) =>
-      NodeBuilder(NodePath.root, Chunk.empty, optional = false, dimensions = 1)
-        .addLabelledSubtree("key", ks)
-        .addLabelledSubtree("value", vs)
-        .buildProduct()
+      Dictionary(
+        keys = subtree(NodePath.root / "keys", Chunk.empty, ks),
+        values = subtree(NodePath.root / "values", Chunk.empty, vs),
+        NodePath.root
+      )
     case Schema.SetSchema(schema, _) =>
-      subtree(NodePath.root, Chunk.empty, schema, dimensions = 1)
+      ListNode(item = subtree(NodePath.root / "item", Chunk.empty, schema), NodePath.root)
     case Schema.Transform(schema, _, _, _, _) => subtree(NodePath.root, Chunk.empty, schema)
     case lzy @ Schema.Lazy(_)                 => fromSchema(lzy.schema)
     case s: Schema.Record[A] =>
@@ -275,52 +291,53 @@ object SchemaAst {
     path: NodePath,
     lineage: Lineage,
     schema: Schema[_],
-    optional: Boolean = false,
-    dimensions: Int = 0
+    optional: Boolean = false
   ): SchemaAst =
     lineage
       .find(_._1 == schema.hashCode())
       .map {
         case (_, refPath) =>
-          Ref(refPath, path, optional, dimensions)
+          Ref(refPath, path, optional)
       }
       .getOrElse {
         schema match {
-          case Schema.Primitive(typ, _)   => Value(typ, path, optional, dimensions)
-          case Schema.Optional(schema, _) => subtree(path, lineage, schema, optional = true, dimensions)
+          case Schema.Primitive(typ, _)   => Value(typ, path, optional)
+          case Schema.Optional(schema, _) => subtree(path, lineage, schema, optional = true)
           case Schema.EitherSchema(left, right, _) =>
             Either(
               path,
-              subtree(path / "left", lineage, left, optional = false, dimensions = 0),
-              subtree(path / "right", lineage, right, optional = false, dimensions = 0),
-              optional,
-              dimensions
+              subtree(path / "left", lineage, left, optional = false),
+              subtree(path / "right", lineage, right, optional = false),
+              optional
             )
           case Schema.Tuple(left, right, _) =>
             Tuple(
               path,
-              subtree(path / "left", lineage, left, optional = false, dimensions = 0),
-              subtree(path / "right", lineage, right, optional = false, dimensions = 0),
-              optional,
-              dimensions
+              subtree(path / "left", lineage, left, optional = false),
+              subtree(path / "right", lineage, right, optional = false),
+              optional
             )
           case Schema.Sequence(schema, _, _, _, _) =>
-            subtree(path, lineage, schema, optional, dimensions + 1)
+            ListNode(item = subtree(path / "item", lineage, schema, optional = false), path)
           case Schema.MapSchema(ks, vs, _) =>
-            subtree(path, lineage, ks <*> vs, optional = false, dimensions + 1)
+            Dictionary(
+              keys = subtree(path / "keys", Chunk.empty, ks, optional = false),
+              values = subtree(path / "values", Chunk.empty, vs, optional = false),
+              path
+            )
           case Schema.SetSchema(schema @ _, _) =>
-            subtree(path, lineage, schema, optional = false, dimensions + 1)
-          case Schema.Transform(schema, _, _, _, _) => subtree(path, lineage, schema, optional, dimensions)
-          case lzy @ Schema.Lazy(_)                 => subtree(path, lineage, lzy.schema, optional, dimensions)
+            ListNode(item = subtree(path / "item", lineage, schema, optional = false), path)
+          case Schema.Transform(schema, _, _, _, _) => subtree(path, lineage, schema, optional)
+          case lzy @ Schema.Lazy(_)                 => subtree(path, lineage, lzy.schema, optional)
           case s: Schema.Record[_] =>
             s.structure
-              .foldLeft(NodeBuilder(path, lineage :+ (s.hashCode() -> path), optional, dimensions)) { (node, field) =>
+              .foldLeft(NodeBuilder(path, lineage :+ (s.hashCode() -> path), optional)) { (node, field) =>
                 node.addLabelledSubtree(field.label, field.schema)
               }
               .buildProduct()
           case s: Schema.Enum[_] =>
             s.structure
-              .foldLeft(NodeBuilder(path, lineage :+ (s.hashCode() -> path), optional, dimensions)) {
+              .foldLeft(NodeBuilder(path, lineage :+ (s.hashCode() -> path), optional)) {
                 case (node, (id, schema)) =>
                   node.addLabelledSubtree(id, schema)
               }
@@ -332,26 +349,26 @@ object SchemaAst {
 
   private[schema] def materialize(ast: SchemaAst, refs: mutable.Map[NodePath, Schema[_]]): Schema[_] = {
     val baseSchema = ast match {
-      case SchemaAst.Value(typ, _, _, _) =>
+      case SchemaAst.Value(typ, _, _) =>
         Schema.Primitive(typ, Chunk.empty)
-      case SchemaAst.FailNode(msg, _, _, _) => Schema.Fail(msg)
-      case SchemaAst.Ref(refPath, _, _, _) =>
+      case SchemaAst.FailNode(msg, _, _) => Schema.Fail(msg)
+      case SchemaAst.Ref(refPath, _, _) =>
         Schema.defer(
           refs.getOrElse(refPath, Schema.Fail(s"invalid ref path $refPath"))
         )
-      case SchemaAst.Product(_, elems, _, _) =>
+      case SchemaAst.Product(_, elems, _) =>
         Schema.record(
           elems.map {
             case (label, ast) =>
               Schema.Field(label, materialize(ast, refs))
           }: _*
         )
-      case SchemaAst.Tuple(_, left, right, _, _) =>
+      case SchemaAst.Tuple(_, left, right, _) =>
         Schema.tuple2(
           materialize(left, refs),
           materialize(right, refs)
         )
-      case SchemaAst.Sum(_, elems, _, _) =>
+      case SchemaAst.Sum(_, elems, _) =>
         Schema.enumeration[Any, CaseSet.Aux[Any]](
           elems.foldRight[CaseSet.Aux[Any]](CaseSet.Empty[Any]()) {
             case ((label, ast), acc) =>
@@ -365,22 +382,21 @@ object SchemaAst {
               CaseSet.Cons(_case, acc)
           }
         )
-      case SchemaAst.Either(_, left, right, _, _) =>
+      case SchemaAst.Either(_, left, right, _) =>
         Schema.either(
           materialize(left, refs),
           materialize(right, refs)
         )
+      case SchemaAst.ListNode(itemAst, _, _) =>
+        Schema.chunk(materialize(itemAst, refs))
+      case SchemaAst.Dictionary(keyAst, valueAst, _, _) =>
+        Schema.MapSchema(materialize(keyAst, refs), materialize(valueAst, refs), Chunk.empty)
       case ast => Schema.Fail(s"AST cannot be materialized to a Schema:\n$ast")
     }
+
     refs += ast.path -> baseSchema
-    ast.optional -> ast.dimensions match {
-      case (false, 0) => baseSchema
-      case (true, 0)  => baseSchema.optional
-      case (false, n) =>
-        (0 until n).foldRight[Schema[_]](baseSchema)((_, schema) => schema.repeated)
-      case (true, n) =>
-        (0 until n).foldRight[Schema[_]](baseSchema)((_, schema) => schema.repeated).optional
-    }
+
+    if (ast.optional) baseSchema.optional else baseSchema
   }
 
   implicit lazy val schema: Schema[SchemaAst] =
@@ -388,7 +404,10 @@ object SchemaAst {
       caseOf[Value, SchemaAst]("Value")(_.asInstanceOf[Value]) ++
         caseOf[Sum, SchemaAst]("Sum")(_.asInstanceOf[Sum]) ++
         caseOf[Product, SchemaAst]("Product")(_.asInstanceOf[Product]) ++
-        caseOf[Ref, SchemaAst]("Ref")(_.asInstanceOf[Ref]),
+        caseOf[Ref, SchemaAst]("Ref")(_.asInstanceOf[Ref]) ++ caseOf[ListNode, SchemaAst]("ListNode")(
+        _.asInstanceOf[ListNode]
+      ) ++
+        caseOf[Dictionary, SchemaAst]("Dictionary")(_.asInstanceOf[Dictionary]),
       Chunk.empty
     )
 
@@ -401,36 +420,52 @@ private[schema] object AstRenderer {
   def render(ast: SchemaAst): String = ast match {
     case v: SchemaAst.Value    => renderValue(v, 0, None)
     case f: SchemaAst.FailNode => renderFail(f, 0, None)
-    case SchemaAst.Product(_, fields, optional, dimensions) =>
+    case SchemaAst.Product(_, fields, optional) =>
       val buffer = new StringBuffer()
+      buffer.append(s"product")
       if (optional) buffer.append("?")
-      buffer.append(s"record").append(renderDimensions(dimensions))
       buffer.append("\n").append(fields.map(renderField(_, INDENT_STEP)).mkString("\n")).toString
-    case SchemaAst.Tuple(_, left, right, optional, dimensions) =>
+    case SchemaAst.Tuple(_, left, right, optional) =>
       val buffer = new StringBuffer()
+      buffer.append(s"tuple")
       if (optional) buffer.append("?")
-      buffer.append(s"tuple").append(renderDimensions(dimensions))
       buffer
         .append("\n")
         .append(Chunk("left" -> left, "right" -> right).map(renderField(_, INDENT_STEP)).mkString("\n"))
         .toString
-    case SchemaAst.Sum(_, cases, optional, dimensions) =>
+    case SchemaAst.Sum(_, cases, optional) =>
       val buffer = new StringBuffer()
+      buffer.append(s"enum")
       if (optional) buffer.append("?")
-      buffer.append(s"enumN").append(renderDimensions(dimensions))
       buffer.append("\n").append(cases.map(renderField(_, INDENT_STEP)).mkString("\n")).toString
-    case SchemaAst.Either(_, left, right, optional, dimensions) =>
+    case SchemaAst.Either(_, left, right, optional) =>
       val buffer = new StringBuffer()
+      buffer.append(s"either")
       if (optional) buffer.append("?")
-      buffer.append(s"either").append(renderDimensions(dimensions))
       buffer
         .append("\n")
         .append(Chunk("left" -> left, "right" -> right).map(renderField(_, INDENT_STEP)).mkString("\n"))
         .toString
-    case SchemaAst.Ref(refPath, _, optional, dimensions) =>
+    case SchemaAst.ListNode(items, _, optional) =>
       val buffer = new StringBuffer()
+      buffer.append(s"list")
       if (optional) buffer.append("?")
-      buffer.append(s"{ref#${refPath.render}}").append(renderDimensions(dimensions))
+      buffer
+        .append("\n")
+        .append(Chunk("item" -> items).map(renderField(_, INDENT_STEP)).mkString("\n"))
+        .toString
+    case SchemaAst.Dictionary(keys, values, _, optional) =>
+      val buffer = new StringBuffer()
+      buffer.append(s"map")
+      if (optional) buffer.append("?")
+      buffer
+        .append("\n")
+        .append(Chunk("keys" -> keys, "values" -> values).map(renderField(_, INDENT_STEP)).mkString("\n"))
+        .toString
+    case SchemaAst.Ref(refPath, _, optional) =>
+      val buffer = new StringBuffer()
+      buffer.append(s"ref#$refPath")
+      if (optional) buffer.append("?")
       buffer.toString
   }
 
@@ -441,41 +476,54 @@ private[schema] object AstRenderer {
         renderValue(value, indent, Some(label))
       case (label, fail: SchemaAst.FailNode) =>
         renderFail(fail, indent, Some(label))
-      case (label, SchemaAst.Product(_, fields, optional, dimensions)) =>
+      case (label, SchemaAst.Product(_, fields, optional)) =>
         pad(buffer, indent)
-        buffer.append(s"$label: ")
+        buffer.append(s"$label: record")
         if (optional) buffer.append("?")
-        buffer.append(s"record").append(renderDimensions(dimensions))
         buffer.append("\n").append(fields.map(renderField(_, indent + INDENT_STEP)).mkString("\n")).toString
-      case (label, SchemaAst.Tuple(_, left, right, optional, dimensions)) =>
+      case (label, SchemaAst.Tuple(_, left, right, optional)) =>
         pad(buffer, indent)
-        buffer.append(s"$label: ")
+        buffer.append(s"$label: tuple")
         if (optional) buffer.append("?")
-        buffer.append(s"tuple").append(renderDimensions(dimensions))
         buffer
           .append("\n")
           .append(Chunk("left" -> left, "right" -> right).map(renderField(_, indent + INDENT_STEP)).mkString("\n"))
           .toString
-      case (label, SchemaAst.Sum(_, cases, optional, dimensions)) =>
+      case (label, SchemaAst.Sum(_, cases, optional)) =>
         pad(buffer, indent)
-        buffer.append(s"$label: ")
+        buffer.append(s"$label: enum")
         if (optional) buffer.append("?")
-        buffer.append(s"enumN").append(renderDimensions(dimensions))
         buffer.append("\n").append(cases.map(renderField(_, indent + INDENT_STEP)).mkString("\n")).toString
-      case (label, SchemaAst.Either(_, left, right, optional, dimensions)) =>
+      case (label, SchemaAst.Either(_, left, right, optional)) =>
         pad(buffer, indent)
-        buffer.append(s"$label: ")
+        buffer.append(s"$label: either")
         if (optional) buffer.append("?")
-        buffer.append(s"either").append(renderDimensions(dimensions))
         buffer
           .append("\n")
           .append(Chunk("left" -> left, "right" -> right).map(renderField(_, indent + INDENT_STEP)).mkString("\n"))
           .toString
-      case (label, SchemaAst.Ref(refPath, _, optional, dimensions)) =>
+      case (label, SchemaAst.ListNode(items, _, optional)) =>
+        val buffer = new StringBuffer()
+        buffer.append(s"$label: list")
+        if (optional) buffer.append("?")
+        buffer
+          .append("\n")
+          .append(Chunk("item" -> items).map(renderField(_, INDENT_STEP)).mkString("\n"))
+          .toString
+      case (label, SchemaAst.Dictionary(keys, values, _, optional)) =>
+        val buffer = new StringBuffer()
+        buffer.append(s"$label: map")
+        if (optional) buffer.append("?")
+        buffer
+          .append("\n")
+          .append(Chunk("keys" -> keys, "values" -> values).map(renderField(_, INDENT_STEP)).mkString("\n"))
+          .toString
+      case (label, SchemaAst.Ref(refPath, _, optional)) =>
         pad(buffer, indent)
         buffer.append(s"$label: ")
         if (optional) buffer.append("?")
-        buffer.append(s"{ref#${refPath.render}}").append(renderDimensions(dimensions)).toString
+        buffer.append(s"{ref#${refPath.render}}").toString
+      case _ => ???
     }
   }
 
@@ -484,7 +532,7 @@ private[schema] object AstRenderer {
     pad(buffer, indent)
     label.foreach(l => buffer.append(s"$l: "))
     if (value.optional) buffer.append("?")
-    buffer.append(value.valueType.tag).append(renderDimensions(value.dimensions)).toString
+    buffer.append(value.valueType.tag).toString
   }
 
   def renderFail(fail: SchemaAst.FailNode, indent: Int, label: Option[String]): String = {
@@ -492,12 +540,8 @@ private[schema] object AstRenderer {
     pad(buffer, indent)
     label.foreach(l => buffer.append(s"$l: "))
     if (fail.optional) buffer.append("?")
-    buffer.append(s"FAIL${renderDimensions(fail.dimensions)}: ${fail.message}").toString
+    buffer.append(s"FAIL: ${fail.message}").toString
   }
-
-  def renderDimensions(dimensions: Int): String =
-    if (dimensions > 0) (0 until dimensions).map(_ => "[]").mkString("")
-    else ""
 
   private def pad(buffer: StringBuffer, indent: Int): StringBuffer = {
     if (indent > 0) {


### PR DESCRIPTION
Fixes issue with `SchemaAst` encoding found by the eagle-eyed @vigoo . Because we were using attributes `dimension` and `optional` on AST nodes to encode `List` and `Option` we had no way of distinguishing `List[Option[T]]` from `Option[List[T]]` when materializing. This PR adds a special `ListNode` AST node to encode `Schema.Sequence` and also `Dictionary` to encode `Schema.MapSchema`. 

Today's lesson in "I should have known better" is to not get too clever with encodings because it will come back to bite you! 

Also found that `DynamicValue.toTypedValue` was not handling `DynamicValue.Dictionary` so fixed that as well. 

The test coverage on Schema migrations is pretty lacking at the moment. Working on a separate PR to add a more robust set of test cases. 