### PR TITLE
Fix bug in AST

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
@@ -2,6 +2,7 @@ package zio.schema
 
 import zio._
 import zio.schema.CaseSet._
+import zio.schema.Schema.Field
 import zio.schema.SchemaAssertions._
 import zio.schema.ast._
 import zio.test._
@@ -208,6 +209,11 @@ object SchemaAstSpec extends DefaultRunnableSpec {
       } @@ TestAspect.shrinks(0),
       test("sequence of optional primitives") {
         val schema       = Schema[List[Option[Int]]]
+        val materialized = SchemaAst.fromSchema(schema).toSchema
+        assert(materialized)(hasSameSchemaStructure(schema))
+      },
+      test("optional sequence of primitives") {
+        val schema       = Schema[Option[List[String]]]
         val materialized = SchemaAst.fromSchema(schema).toSchema
         assert(materialized)(hasSameSchemaStructure(schema))
       }

--- a/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
@@ -2,7 +2,6 @@ package zio.schema
 
 import zio._
 import zio.schema.CaseSet._
-import zio.schema.Schema.Field
 import zio.schema.SchemaAssertions._
 import zio.schema.ast._
 import zio.test._

--- a/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/ast/SchemaAst.scala
@@ -318,7 +318,7 @@ object SchemaAst {
               optional
             )
           case Schema.Sequence(schema, _, _, _, _) =>
-            ListNode(item = subtree(path / "item", lineage, schema, optional), path)
+            ListNode(item = subtree(path / "item", lineage, schema, optional = false), path, optional)
           case Schema.MapSchema(ks, vs, _) =>
             Dictionary(
               keys = subtree(path / "keys", Chunk.empty, ks, optional = false),
@@ -327,7 +327,7 @@ object SchemaAst {
               optional
             )
           case Schema.SetSchema(schema @ _, _) =>
-            ListNode(item = subtree(path / "item", lineage, schema, optional), path)
+            ListNode(item = subtree(path / "item", lineage, schema, optional = false), path, optional)
           case Schema.Transform(schema, _, _, _, _) => subtree(path, lineage, schema, optional)
           case lzy @ Schema.Lazy(_)                 => subtree(path, lineage, lzy.schema, optional)
           case s: Schema.Record[_] =>


### PR DESCRIPTION
Fixes bug with AST for `Option[List[A]]` schema. We were incorrectly making the item type optional which gets materialized to `List[Option[A]]`