### PR TITLE
Remove DynamicValue.Transform

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueGen.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueGen.scala
@@ -79,7 +79,7 @@ object DynamicValueGen {
       case Schema.Tuple(left, right, _)                                                                                                                                                            => anyDynamicTupleValue(left, right)
       case Schema.EitherSchema(left, right, _) =>
         Gen.oneOf(anyDynamicLeftValueOfSchema(left), anyDynamicRightValueOfSchema(right))
-      case Schema.Transform(schema, _, _, _, _) => anyDynamicValueOfSchema(schema).map(DynamicValue.Transform(_))
+      case Schema.Transform(schema, _, _, _, _) => anyDynamicValueOfSchema(schema)
       case Schema.Fail(message, _)              => Gen.const(DynamicValue.Error(message))
       case l @ Schema.Lazy(_)                   => anyDynamicValueOfSchema(l.schema)
       case Schema.Meta(meta, _)                 => anyDynamicValueOfSchema(meta.toSchema)

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -66,10 +66,7 @@ sealed trait DynamicValue { self =>
       case (DynamicValue.NoneValue, Schema.Optional(_, _)) =>
         Right(None)
 
-      case (DynamicValue.Transform(DynamicValue.Error(message)), Schema.Transform(_, _, _, _, _)) =>
-        Left(message)
-
-      case (DynamicValue.Transform(value), Schema.Transform(schema, f, _, _, _)) =>
+      case (value, Schema.Transform(schema, f, _, _, _)) =>
         value.toTypedValue(schema).flatMap(f)
 
       case (DynamicValue.Dictionary(entries), schema: Schema.MapSchema[k, v]) =>
@@ -995,8 +992,8 @@ object DynamicValue {
 
       case Schema.Transform(schema, _, g, _, _) =>
         g(value) match {
-          case Left(message) => DynamicValue.Transform(DynamicValue.Error(message))
-          case Right(a)      => DynamicValue.Transform(fromSchemaAndValue(schema, a))
+          case Left(message) => DynamicValue.Error(message)
+          case Right(a)      => fromSchemaAndValue(schema, a)
         }
 
       case Schema.Meta(ast, _) => DynamicValue.DynamicAst(ast)
@@ -1874,8 +1871,6 @@ object DynamicValue {
 
   final case class SomeValue(value: DynamicValue) extends DynamicValue
 
-  final case class Transform(value: DynamicValue) extends DynamicValue
-
   case object NoneValue extends DynamicValue
 
   sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue
@@ -1900,7 +1895,6 @@ private[schema] object DynamicValueSchema { self =>
         .:+:(rightValueCase)
         .:+:(leftValueCase)
         .:+:(tupleCase)
-        .:+:(transformCase)
         .:+:(someValueCase)
         .:+:(dictionaryCase)
         .:+:(sequenceCase)
@@ -2011,17 +2005,6 @@ private[schema] object DynamicValueSchema { self =>
         tuple => tuple.right
       ),
       _.asInstanceOf[DynamicValue.Tuple]
-    )
-
-  private val transformCase: Schema.Case[DynamicValue.Transform, DynamicValue] =
-    Schema.Case(
-      "Transform",
-      Schema.CaseClass1[DynamicValue, DynamicValue.Transform](
-        Schema.Field("value", Schema.defer(DynamicValueSchema())),
-        dv => DynamicValue.Transform(dv),
-        transform => transform.value
-      ),
-      _.asInstanceOf[DynamicValue.Transform]
     )
 
   private val someValueCase: Schema.Case[DynamicValue.SomeValue, DynamicValue] =

--- a/zio-schema/shared/src/main/scala/zio/schema/SchemaOrdering.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/SchemaOrdering.scala
@@ -38,11 +38,11 @@ object SchemaOrdering {
     }
     case (Schema.Sequence(schema, _, _, _, _), Sequence(lVal), Sequence(rVal)) =>
       compareSequences(lVal, rVal, compareBySchema(schema))
-    case (Schema.Fail(_, _), Error(lVal), Error(rVal))                                     => lVal.compareTo(rVal)
-    case (Schema.Transform(_, _, _, _, _), Transform(Error(lval)), Transform(Error(rVal))) => lval.compareTo(rVal)
-    case (Schema.Transform(_, _, _, _, _), Transform(Error(_)), Transform(_))              => -1
-    case (Schema.Transform(_, _, _, _, _), Transform(_), Transform(Error(_)))              => 1
-    case (Schema.Transform(schemaA, _, _, _, _), Transform(lVal), Transform(rVal)) =>
+    case (Schema.Fail(_, _), Error(lVal), Error(rVal))               => lVal.compareTo(rVal)
+    case (Schema.Transform(_, _, _, _, _), Error(lval), Error(rVal)) => lval.compareTo(rVal)
+    case (Schema.Transform(_, _, _, _, _), Error(_), _)              => -1
+    case (Schema.Transform(_, _, _, _, _), _, Error(_))              => 1
+    case (Schema.Transform(schemaA, _, _, _, _), lVal, rVal) =>
       compareBySchema(schemaA)(lVal, rVal)
     case (e: Schema.Enum[_], Enumeration((lField, lVal)), Enumeration((rField, rVal))) if lField == rField =>
       compareBySchema(e.structure(lField))(lVal, rVal)

--- a/zio-schema/shared/src/main/scala/zio/schema/ast/Migration.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/ast/Migration.scala
@@ -273,8 +273,6 @@ object Migration {
     trace: Chunk[String] = Chunk.empty
   )(op: (String, DynamicValue) => Either[String, Option[(String, DynamicValue)]]): Either[String, DynamicValue] = {
     (value, path) match {
-      case (DynamicValue.Transform(value), _) =>
-        updateLeaf(value, path, trace)(op).map(DynamicValue.Transform(_))
       case (DynamicValue.SomeValue(value), _) =>
         updateLeaf(value, path, trace)(op).map(DynamicValue.SomeValue(_))
       case (DynamicValue.NoneValue, _) => Right(DynamicValue.NoneValue)


### PR DESCRIPTION
`DynamicValue.Transform` causes some complications and doesn't serve any particular purpose (since we don't actually capture anything relevant to the transformation) so removing it. 