### PR TITLE
Upgrade to ZIO 2.0.0-RC6

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -26,10 +26,10 @@ object BuildHelper {
   val Scala213: String   = versions("2.13")
   val ScalaDotty: String = "3.1.0" //versions.getOrElse("3.0", versions("3.1"))
 
-  val zioVersion        = "2.0.0-RC5"
-  val zioJsonVersion    = "0.3.0-RC7"
-  val zioPreludeVersion = "1.0.0-RC13"
-  val zioOpticsVersion  = "2.0.0-RC4"
+  val zioVersion        = "2.0.0-RC6"
+  val zioJsonVersion    = "0.3.0-RC8"
+  val zioPreludeVersion = "1.0.0-RC14"
+  val zioOpticsVersion  = "0.2.0-RC4"
   val silencerVersion   = "1.7.8"
 
   private val testDeps = Seq(

--- a/tests/shared/src/test/scala/zio/schema/AccessorBuilderSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/AccessorBuilderSpec.scala
@@ -10,7 +10,7 @@ object AccessorBuilderSpec extends ZIOSpecDefault {
 
   private val builder: TestAccessorBuilder = new TestAccessorBuilder
 
-  override def spec: ZSpec[Environment, Any] = suite("AccessorBuilder")(
+  override def spec: Spec[Environment, Any] = suite("AccessorBuilder")(
     test("fail") {
       assert(Schema.fail("error").makeAccessors(builder).asInstanceOf[Unit])(isUnit)
     },

--- a/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
@@ -6,7 +6,7 @@ import zio.Chunk
 import zio.schema.CaseSet.caseOf
 import zio.schema.Schema.{ Lazy, Primitive }
 import zio.test.Assertion._
-import zio.test.{ ZIOSpecDefault, ZSpec, assert }
+import zio.test.{ Spec, ZIOSpecDefault, assert }
 
 object DefaultValueSpec extends ZIOSpecDefault {
   // Record Tests
@@ -32,7 +32,7 @@ object DefaultValueSpec extends ZIOSpecDefault {
     implicit lazy val schema: Schema[Status] = DeriveSchema.gen[Status]
   }
 
-  def spec: ZSpec[Environment, Any] = suite("Default Value Spec")(
+  def spec: Spec[Environment, Any] = suite("Default Value Spec")(
     suite("Primitive")(
       test("UnitType default value") {
         assert(Primitive(StandardType.UnitType).defaultValue)(isRight(equalTo(())))

--- a/tests/shared/src/test/scala/zio/schema/DiffSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DiffSpec.scala
@@ -9,7 +9,7 @@ import zio.{ Chunk, URIO, ZIO }
 
 object DiffSpec extends ZIOSpecDefault with DefaultJavaTimeSchemas {
 
-  def spec: ZSpec[Environment, Any] = suite("DiffSpec")(
+  def spec: Spec[Environment, Any] = suite("DiffSpec")(
     suite("identity law")(
       suite("standard types")(
         test("Int")(diffIdentityLaw[Int]),

--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -8,7 +8,7 @@ import zio.test.{ Sized, TestConfig, _ }
 
 object DynamicValueSpec extends ZIOSpecDefault {
 
-  def spec: ZSpec[Environment, Any] =
+  def spec: Spec[Environment, Any] =
     suite("DynamicValueSpec")(
       suite("Primitives")(primitiveTests: _*),
       test("round-trips Records") {
@@ -85,7 +85,7 @@ object DynamicValueSpec extends ZIOSpecDefault {
       }
     )
 
-  val primitiveTests: List[ZSpec[Sized with TestConfig, Nothing]] = schemasAndGens.map {
+  val primitiveTests: List[Spec[Sized with TestConfig, Nothing]] = schemasAndGens.map {
     case SchemaTest(name, standardType, gen) =>
       test(s"round-trips $name") {
         dynamicValueLaw(gen, Primitive(standardType, Chunk.empty))

--- a/tests/shared/src/test/scala/zio/schema/MigrationSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/MigrationSpec.scala
@@ -5,12 +5,11 @@ import scala.collection.immutable.ListMap
 import zio._
 import zio.schema.ast._
 import zio.schema.syntax._
-import zio.test.AssertionM.Render.param
 import zio.test._
 
 object MigrationSpec extends ZIOSpecDefault {
 
-  override def spec: ZSpec[Environment, Any] = suite("Migration Spec")(
+  override def spec: Spec[Environment, Any] = suite("Migration Spec")(
     suite("Derivation")(
       suite("Value")(
         test("change type") {
@@ -257,13 +256,13 @@ object MigrationSpec extends ZIOSpecDefault {
       .getOrElse(false)
 
   def transformsValueTo[A: Schema](value: A, expected: DynamicValue): Assertion[Migration] =
-    Assertion.assertion("transformsValueTo")(param(value), param(expected)) { transform =>
+    Assertion.assertion("transformsValueTo") { transform =>
       val transformed = transform.migrate(value.dynamic)
       transformed == Right(expected)
     }
 
   def failsToTransform[A: Schema](value: A): Assertion[Migration] =
-    Assertion.assertion("failsToTransform")(param(value)) { transform =>
+    Assertion.assertion("failsToTransform") { transform =>
       transform.migrate(value.dynamic).isLeft
     }
 

--- a/tests/shared/src/test/scala/zio/schema/OrderingSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/OrderingSpec.scala
@@ -10,7 +10,7 @@ import zio.{ Chunk, URIO }
 
 object OrderingSpec extends ZIOSpecDefault {
 
-  override def spec: ZSpec[Environment, Any] =
+  override def spec: Spec[Environment, Any] =
     suite("schemas should generate correct orderings")(
       suite("primitives")(primitiveOrderingTests: _*),
       suite("structures")(structureTestCases.map(structureOrderingTest): _*),
@@ -56,7 +56,7 @@ object OrderingSpec extends ZIOSpecDefault {
       )
     )
 
-  val primitiveOrderingTests: List[ZSpec[Sized with TestConfig, Nothing]] =
+  val primitiveOrderingTests: List[Spec[Sized with TestConfig, Nothing]] =
     schemasAndGens.map {
       case SchemaTest(name, schema, gen) =>
         test(s"$name") {
@@ -89,7 +89,7 @@ object OrderingSpec extends ZIOSpecDefault {
       StructureTestCase("enumN", genAnyOrderedPairEnum)
     )
 
-  def structureOrderingTest(t: StructureTestCase): ZSpec[TestConfig with Sized, Nothing] =
+  def structureOrderingTest(t: StructureTestCase): Spec[TestConfig with Sized, Nothing] =
     test(t.name)(check(t.increasingPairGen)(_ match {
       case (schema, l, r) =>
         assert(schema.ordering.compare(l, r))(isLessThan(0))

--- a/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaAstSpec.scala
@@ -8,7 +8,7 @@ import zio.test._
 
 object SchemaAstSpec extends ZIOSpecDefault {
 
-  def spec: ZSpec[Environment, Any] = suite("SchemaAst")(
+  def spec: Spec[Environment, Any] = suite("SchemaAst")(
     suite("from schema")(
       test("primitive") {
         check(SchemaGen.anyPrimitive) {

--- a/tests/shared/src/test/scala/zio/schema/SchemaMigrationSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaMigrationSpec.scala
@@ -8,7 +8,7 @@ import zio.test._
 object SchemaMigrationSpec extends ZIOSpecDefault {
   import SchemaAssertions._
 
-  override def spec: ZSpec[TestEnvironment, Any] = suite("Schema Migration Spec")(
+  override def spec: Spec[TestEnvironment, Any] = suite("Schema Migration Spec")(
     suite("case class")(
       suite("isomorphisms")(isomorphismTests: _*),
       test("delete field recursively") {
@@ -87,7 +87,7 @@ object SchemaMigrationSpec extends ZIOSpecDefault {
     )
   )
 
-  val isomorphismTests: List[ZSpec[TestEnvironment with Sized with TestConfig, Nothing]] =
+  val isomorphismTests: List[Spec[TestEnvironment with Sized with TestConfig, Nothing]] =
     List(
       test("DogFood <-> CatFood")(
         isomorphismLaw[TestEnvironment, PetFood.DogFood, PetFood.CatFood](

--- a/tests/shared/src/test/scala/zio/schema/SchemaSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaSpec.scala
@@ -5,11 +5,11 @@ import scala.collection.immutable.ListMap
 import zio.Chunk
 import zio.schema.CaseSet._
 import zio.test.Assertion._
-import zio.test.{ ZSpec, _ }
+import zio.test._
 
 object SchemaSpec extends ZIOSpecDefault {
 
-  def spec: ZSpec[Environment, Any] = suite("Schema Spec")(
+  def spec: Spec[Environment, Any] = suite("Schema Spec")(
     suite("Should have valid equals")(
       test("primitive") {
         assert(schemaUnit)(equalTo(schemaUnit))

--- a/tests/shared/src/test/scala/zio/schema/ast/NodePathSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/ast/NodePathSpec.scala
@@ -4,7 +4,7 @@ import zio.test._
 
 object NodePathSpec extends ZIOSpecDefault {
 
-  override def spec: ZSpec[Environment, Any] = suite("NodePath")(
+  override def spec: Spec[Environment, Any] = suite("NodePath")(
     suite("relativeTo")(
       test("compute relative subpath") {
         val path    = NodePath.root / "foo" / "bar"

--- a/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
@@ -229,7 +229,7 @@ object DeriveSchemaSpec extends ZIOSpecDefault {
 
   }
 
-  override def spec: ZSpec[Environment, Any] = suite("DeriveSchemaSpec")(
+  override def spec: Spec[Environment, Any] = suite("DeriveSchemaSpec")(
     suite("Derivation")(
       test("correctly derives case class") {
         assert(Schema[User].toString)(not(containsString("null")) && not(equalTo("$Lazy$")))

--- a/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-2/zio/schema/DeriveSchemaSpec.scala
@@ -320,10 +320,12 @@ object DeriveSchemaSpec extends ZIOSpecDefault {
         assert(b0)(isRight(equalTo(b)))
       },
       test("correctly derives recursive Enum with type parameters") {
-        assert(DeriveSchema.gen[Tree[Recursive]])(anything)
+        val derived: Schema[Tree[Recursive]] = DeriveSchema.gen[Tree[Recursive]]
+        assert(derived)(anything)
       },
       test("correctly derives recursive Enum with multiple type parameters") {
-        assert(DeriveSchema.gen[RBTree[String, Int]])(anything)
+        val derived: Schema[RBTree[String, Int]] = DeriveSchema.gen[RBTree[String, Int]]
+        assert(derived)(anything)
       },
       test("correctly derives recursive Enum") {
         assert(Schema[RecursiveEnum].toString)(not(containsString("null")) && not(equalTo("$Lazy$")))

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -23,7 +23,7 @@ object JsonCodec extends Codec {
     )
 
   override def decoder[A](schema: Schema[A]): ZPipeline[Any, String, Byte, A] =
-    ZPipeline.utfDecode >>> ZPipeline.mapZIO(
+    ZPipeline.fromChannel(ZPipeline.utfDecode.channel.mapError(_.toString)) >>> ZPipeline.mapZIO(
       (s: String) => ZIO.fromEither(Decoder.decode(schema, s))
     )
 

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -2,16 +2,15 @@ package zio.schema.codec
 
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
-
 import scala.collection.immutable.ListMap
-
 import zio.json.JsonCodec._
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 import zio.json.internal.{ Lexer, RecordingReader, RetractReader, StringMatrix, Write }
-import zio.json.{ JsonCodec => ZJsonCodec, JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder }
+import zio.json.{ JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder, JsonCodec => ZJsonCodec }
 import zio.schema.Schema.EitherSchema
 import zio.schema.ast.SchemaAst
 import zio.schema.{ StandardType, _ }
+import zio.stream.ZChannel
 import zio.stream.ZPipeline
 import zio.{ Chunk, ChunkBuilder, ZIO }
 
@@ -23,7 +22,7 @@ object JsonCodec extends Codec {
     )
 
   override def decoder[A](schema: Schema[A]): ZPipeline[Any, String, Byte, A] =
-    ZPipeline.fromChannel(ZPipeline.utfDecode.channel.mapError(_.toString)) >>> ZPipeline.mapZIO(
+    ZPipeline.suspend(ZPipeline.fromChannel(ZPipeline.utf8Decode.channel.mapError(_.toString))) >>> ZPipeline.mapZIO(
       (s: String) => ZIO.fromEither(Decoder.decode(schema, s))
     )
 

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -2,11 +2,13 @@ package zio.schema.codec
 
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
+
 import scala.collection.immutable.ListMap
+
 import zio.json.JsonCodec._
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 import zio.json.internal.{ Lexer, RecordingReader, RetractReader, StringMatrix, Write }
-import zio.json.{ JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder, JsonCodec => ZJsonCodec }
+import zio.json.{ JsonCodec => ZJsonCodec, JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder }
 import zio.schema.Schema.EitherSchema
 import zio.schema.ast.SchemaAst
 import zio.schema.{ StandardType, _ }

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -10,9 +10,8 @@ import zio.json.{ JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder, 
 import zio.schema.Schema.EitherSchema
 import zio.schema.ast.SchemaAst
 import zio.schema.{ StandardType, _ }
-import zio.stream.ZChannel
 import zio.stream.ZPipeline
-import zio.{ Chunk, ChunkBuilder, ZIO }
+import zio.{ Chunk, ChunkBuilder, NonEmptyChunk, ZIO }
 
 object JsonCodec extends Codec {
 
@@ -22,9 +21,13 @@ object JsonCodec extends Codec {
     )
 
   override def decoder[A](schema: Schema[A]): ZPipeline[Any, String, Byte, A] =
-    ZPipeline.suspend(ZPipeline.fromChannel(ZPipeline.utf8Decode.channel.mapError(_.toString))) >>> ZPipeline.mapZIO(
-      (s: String) => ZIO.fromEither(Decoder.decode(schema, s))
-    )
+    ZPipeline.fromChannel(ZPipeline.utfDecode.channel.mapError(_.toString)) >>>
+      ZPipeline.groupAdjacentBy[String, Unit](_ => ()) >>>
+      ZPipeline.map[(Unit, NonEmptyChunk[String]), String] {
+        case (_, fragments) => fragments.mkString
+      } >>> ZPipeline.mapZIO { (s: String) =>
+      ZIO.fromEither(Decoder.decode(schema, s))
+    }
 
   override def encode[A](schema: Schema[A]): A => Chunk[Byte] = Encoder.encode(schema, _)
 
@@ -84,7 +87,8 @@ object JsonCodec extends Codec {
   object Encoder {
 
     import Codecs._
-    import JsonEncoder.{ bump, pad }
+    import JsonEncoder.bump
+    import JsonEncoder.pad
     import ProductEncoder._
 
     private[codec] val CHARSET = StandardCharsets.UTF_8
@@ -490,7 +494,8 @@ object JsonCodec extends Codec {
 
   //scalafmt: { maxColumn = 400, optIn.configStyleArguments = false }
   private[codec] object ProductEncoder {
-    import JsonEncoder.{ bump, pad }
+    import JsonEncoder.bump
+    import JsonEncoder.pad
 
     private[codec] def caseClassEncoder[Z](fields: (Schema.Field[_], Z => Any)*): JsonEncoder[Z] = { (a: Z, indent: Option[Int], out: Write) =>
       {

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -19,7 +19,7 @@ import zio.test._
 
 object JsonCodecSpec extends ZIOSpecDefault {
 
-  def spec: ZSpec[TestEnvironment, Any] =
+  def spec: Spec[TestEnvironment, Any] =
     suite("JsonCodec Spec")(
       encoderSuite,
       decoderSuite,
@@ -681,7 +681,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
       .succeed(value)
       .via(JsonCodec.encoder(schema))
       .runCollect
-    assertM(stream)(equalTo(chunk))
+    assertZIO(stream)(equalTo(chunk))
   }
 
   private def assertEncodesJson[A](schema: Schema[A], value: A, json: String) = {
@@ -690,7 +690,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
       .via(JsonCodec.encoder(schema))
       .runCollect
       .map(chunk => new String(chunk.toArray))
-    assertM(stream)(equalTo(json))
+    assertZIO(stream)(equalTo(json))
   }
 
   private def assertEncodesJson[A](schema: Schema[A], value: A)(implicit enc: JsonEncoder[A]) = {
@@ -698,7 +698,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
       .succeed(value)
       .via(JsonCodec.encoder(schema))
       .runCollect
-    assertM(stream)(equalTo(jsonEncoded(value)))
+    assertZIO(stream)(equalTo(jsonEncoded(value)))
   }
 
   private def assertDecodesToError[A](schema: Schema[A], json: CharSequence, errors: List[JsonError]) = {
@@ -707,12 +707,12 @@ object JsonCodecSpec extends ZIOSpecDefault {
       .via(JsonCodec.decoder(schema))
       .catchAll(ZStream.succeed[String](_))
       .runHead
-    assertM(stream)(isSome(equalTo(JsonError.render(errors))))
+    assertZIO(stream)(isSome(equalTo(JsonError.render(errors))))
   }
 
   private def assertDecodes[A](schema: Schema[A], value: A, chunk: Chunk[Byte]) = {
     val result = ZStream.fromChunk(chunk).via(JsonCodec.decoder(schema)).runCollect
-    assertM(result)(equalTo(Chunk(value)))
+    assertZIO(result)(equalTo(Chunk(value)))
   }
 
   private def assertEncodesThenDecodes[A](schema: Schema[A], value: A, print: Boolean = false) =

--- a/zio-schema-optics/shared/src/test/scala/zio/schema/optics/LensSpec.scala
+++ b/zio-schema-optics/shared/src/test/scala/zio/schema/optics/LensSpec.scala
@@ -8,7 +8,7 @@ import zio.test._
 
 object LensSpec extends ZIOSpecDefault {
 
-  def spec: ZSpec[Environment, Any] = suite("LensSpec")(
+  def spec: Spec[Environment, Any] = suite("LensSpec")(
     suite("constructors")(
       test("first")(lensLaws(Gen.int.zip(Gen.int), Gen.int)(Lens.first)),
       test("second")(lensLaws(Gen.int.zip(Gen.int), Gen.int)(Lens.second)),

--- a/zio-schema-protobuf/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
+++ b/zio-schema-protobuf/shared/src/test/scala/zio/schema/codec/ProtobufCodecSpec.scala
@@ -19,7 +19,7 @@ import zio.test._
 object ProtobufCodecSpec extends ZIOSpecDefault {
   import Schema._
 
-  def spec: Spec[TestConfig with Sized, TestFailure[Any], TestSuccess] =
+  def spec: Spec[TestConfig with Sized, Any] =
     suite("ProtobufCodec Spec")(
       suite("Should correctly encode")(
         test("integers") {
@@ -585,12 +585,12 @@ object ProtobufCodecSpec extends ZIOSpecDefault {
       ),
       suite("Should successfully decode")(
         test("empty input") {
-          assertM(decode(Schema[Int], ""))(
+          assertZIO(decode(Schema[Int], ""))(
             equalTo(Chunk.empty)
           )
         },
         test("empty input by non streaming variant") {
-          assertM(decodeNS(Schema[Int], "").exit)(
+          assertZIO(decodeNS(Schema[Int], "").exit)(
             fails(equalTo("Failed to decode VarInt. Unexpected end of chunk"))
           )
         }
@@ -636,14 +636,14 @@ object ProtobufCodecSpec extends ZIOSpecDefault {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.IntType)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic instant") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.InstantType(DateTimeFormatter.ISO_INSTANT))
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic zoned date time") {
@@ -652,62 +652,62 @@ object ProtobufCodecSpec extends ZIOSpecDefault {
               StandardType.ZonedDateTimeType(DateTimeFormatter.ISO_ZONED_DATE_TIME)
             )
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic duration") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.DurationType)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic string") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.StringType)
           ) { dynamicValue =>
-            assertM(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
+            assertZIO(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
           }
         },
         test("dynamic unit") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.UnitType)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic json") {
           check(
             DynamicValueGen.anyDynamicValueOfSchema(SchemaGen.Json.schema)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic tuple") {
           check(
             DynamicValueGen.anyDynamicTupleValue(Schema[String], Schema[Int])
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic record") {
           check(
             SchemaGen.anyRecord.flatMap(DynamicValueGen.anyDynamicValueOfSchema)
           ) { dynamicValue =>
-            assertM(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
+            assertZIO(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
           }
         },
         test("dynamic record example") {
           val dynamicValue = DynamicValue.Record(
             ListMap("0" -> DynamicValue.Primitive(new java.math.BigDecimal(0.0), StandardType[java.math.BigDecimal]))
           )
-          assertM(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
+          assertZIO(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
         },
         test("dynamic (string, record)") {
           check(
             SchemaGen.anyRecord.flatMap(record => DynamicValueGen.anyDynamicTupleValue(Schema[String], record))
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         }
       ),

--- a/zio-schema-thrift/shared/src/test/scala/zio/schema/codec/ThriftCodecSpec.scala
+++ b/zio-schema-thrift/shared/src/test/scala/zio/schema/codec/ThriftCodecSpec.scala
@@ -665,14 +665,14 @@ object ThriftCodecSpec extends ZIOSpecDefault {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.IntType)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic instant") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.InstantType(DateTimeFormatter.ISO_INSTANT))
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic zoned date time") {
@@ -681,49 +681,49 @@ object ThriftCodecSpec extends ZIOSpecDefault {
               StandardType.ZonedDateTimeType(DateTimeFormatter.ISO_ZONED_DATE_TIME)
             )
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic duration") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.DurationType)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic string") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.StringType)
           ) { dynamicValue =>
-            assertM(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
+            assertZIO(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
           }
         },
         test("dynamic unit") {
           check(
             DynamicValueGen.anyPrimitiveDynamicValue(StandardType.UnitType)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic json") {
           check(
             DynamicValueGen.anyDynamicValueOfSchema(SchemaGen.Json.schema)
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic tuple") {
           check(
             DynamicValueGen.anyDynamicTupleValue(Schema[String], Schema[Int])
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         },
         test("dynamic record") {
           check(
             SchemaGen.anyRecord.flatMap(DynamicValueGen.anyDynamicValueOfSchema)
           ) { dynamicValue =>
-            assertM(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
+            assertZIO(encodeAndDecodeNS(Schema.dynamicValue, dynamicValue))(equalTo(dynamicValue))
           }
         },
         test("dynamic record example") {
@@ -738,7 +738,7 @@ object ThriftCodecSpec extends ZIOSpecDefault {
           check(
             SchemaGen.anyRecord.flatMap(record => DynamicValueGen.anyDynamicTupleValue(Schema[String], record))
           ) { dynamicValue =>
-            assertM(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+            assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
           }
         }
       ),
@@ -764,12 +764,12 @@ object ThriftCodecSpec extends ZIOSpecDefault {
     ),
     suite("Should successfully decode")(
       test("empty input") {
-        assertM(decode(Schema[Int], ""))(
+        assertZIO(decode(Schema[Int], ""))(
           equalTo(Chunk.empty)
         )
       },
       test("empty input by non streaming variant") {
-        assertM(decodeNS(Schema[Int], "").exit)(
+        assertZIO(decodeNS(Schema[Int], "").exit)(
           fails(equalTo("No bytes to decode"))
         )
       },
@@ -829,7 +829,7 @@ object ThriftCodecSpec extends ZIOSpecDefault {
     )
   )
 
-  def writeManually(f: TBinaryProtocol => Unit): Task[String] = Task.attempt {
+  def writeManually(f: TBinaryProtocol => Unit): Task[String] = ZIO.attempt {
     val writeRecord = new ChunkTransport.Write()
     f(new TBinaryProtocol(writeRecord))
     toHex(writeRecord.chunk)

--- a/zio-schema-zio-test/shared/src/test/scala/zio/schema/DeriveGenSpec.scala
+++ b/zio-schema-zio-test/shared/src/test/scala/zio/schema/DeriveGenSpec.scala
@@ -6,7 +6,7 @@ import zio.test.Assertion._
 import zio.test._
 
 object DeriveGenSpec extends ZIOSpecDefault {
-  override def spec: ZSpec[Environment, Any] = suite("DeriveGenSpec")(
+  override def spec: Spec[Environment, Any] = suite("DeriveGenSpec")(
     test("correctly derives Primitives") {
       for {
         unit           <- generateValue(DeriveGen.gen(unitSchema))
@@ -75,5 +75,5 @@ object DeriveGenSpec extends ZIOSpecDefault {
   )
 
   private def generateValue[R, A](gen: Gen[R, A]): ZIO[R, Nothing, TestResult] =
-    assertM(gen.runCollect)(isNonEmpty)
+    assertZIO(gen.runCollect)(isNonEmpty)
 }

--- a/zio-schema/shared/src/test/scala/zio/schema/SchemaAssertions.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/SchemaAssertions.scala
@@ -3,12 +3,11 @@ package zio.schema
 import zio.Chunk
 import zio.schema.syntax._
 import zio.test.Assertion
-import zio.test.AssertionM.Render.param
 
 object SchemaAssertions {
 
   def migratesTo[A: Schema, B: Schema](expected: B): Assertion[A] =
-    Assertion.assertion("migratesTo")(param(expected)) { value =>
+    Assertion.assertion("migratesTo") { value =>
       value.migrate[B] match {
         case Left(_)                   => false
         case Right(m) if m != expected => false
@@ -18,22 +17,22 @@ object SchemaAssertions {
     }
 
   def cannotMigrateValue[A: Schema, B: Schema]: Assertion[A] =
-    Assertion.assertion("cannotMigrateTo")() { value =>
+    Assertion.assertion("cannotMigrateTo") { value =>
       value.migrate[B].isLeft
     }
 
   def hasSameSchema(expected: Schema[_]): Assertion[Schema[_]] =
-    Assertion.assertion("hasSameSchema")(param(expected))(
+    Assertion.assertion("hasSameSchema")(
       actual => Schema.strictEquality.equal(expected, actual)
     )
 
   def hasSameSchemaStructure(expected: Schema[_]): Assertion[Schema[_]] =
-    Assertion.assertion("hasSameSchemaStructure")(param(expected))(
+    Assertion.assertion("hasSameSchemaStructure")(
       actual => Schema.structureEquality.equal(expected, actual)
     )
 
   def hasSameAst(expected: Schema[_]): Assertion[Schema[_]] =
-    Assertion.assertion("hasSameAst")(param(expected))(actual => equalsAst(expected, actual))
+    Assertion.assertion("hasSameAst")(actual => equalsAst(expected, actual))
 
   private def equalsAst(expected: Schema[_], actual: Schema[_], depth: Int = 0): Boolean = (expected, actual) match {
     case (Schema.Primitive(StandardType.DurationType, _), Schema.Primitive(StandardType.DurationType, _))     => true


### PR DESCRIPTION
This is not yet working, not sure how to handle the changes to `ZPipeline.utfDecode` in `JsonCodec.scala`.  The changes were made in this PR https://github.com/zio/zio/pull/6627.
I think I have to use a `ZSink.mkString` to convert the bytes into a Scala string but that would consume the stream. Is that the right approach?