### PR TITLE
Implemented #253 - Added time validation

### DIFF
--- a/zio-schema/shared/src/main/scala/zio/schema/validation/Time.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/validation/Time.scala
@@ -1,0 +1,150 @@
+package zio.schema.validation
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+trait Time {
+
+  /**
+   * Format is almost the same as the one used by the java.time.format.DateTimeFormatter class.
+   *
+   *  a           AM/PM always 2 letters
+   *  h           1-12 hour 1 or 2 digits
+   *  hh          01-12 hour always 2 digits
+   *  H           0-23 hour 1 or 2 digits
+   *  HH          00-23 hour always 2 digits
+   *  m           0-59 minute 1 or 2 digits
+   *  mm          00-59 minute always 2 digits
+   *  s           0-59 second 1 or 2 digits
+   *  ss          00-59 second always 2 digits
+   *
+   *  S           0-9 fraction of seconds 1 digits
+   *  ..
+   *  SSSSSSSSS   000000000-999999999 maximum number of digits is 9
+   *
+   * All other letters are reserved.
+   *
+   * Examples:
+   * HH:mm
+   * 01:10
+   * HH:mm:ss
+   * 11:10:30
+   * HH:mm:ss.SSSSSSSSS
+   * 21:10:30.123456789
+   * HH:mm a
+   * 01:10 AM
+   * h:mm:ss
+   * 1:10:30
+   *
+   */
+  def time(format: String): Validation[String] = {
+    val regex = parseFormat(format)
+    Validation.regex(regex)
+  }
+
+  sealed private trait Field
+  private case class TimeField(letter: Char, length: Int, maxLength: Int) extends Field
+  private case class Literal(value: String)                               extends Field
+
+  private val fields = Map[Char, Field](
+    'H' -> TimeField('H', 1, 2),
+    'h' -> TimeField('h', 1, 2),
+    'm' -> TimeField('m', 1, 2),
+    's' -> TimeField('s', 1, 2),
+    'a' -> TimeField('a', 1, 1),
+    'S' -> TimeField('S', 1, 9)
+  )
+
+  private def parseFormat(format: String): Regex = {
+    val length               = format.length
+    var pos                  = 0
+    var field: Option[Field] = None
+    val usedFields           = mutable.ListBuffer.empty[Field]
+    val result               = mutable.ListBuffer.empty[Field]
+
+    def setField(cur: Char): Unit = {
+      field = fields.get(cur)
+
+      field.fold {
+        if (cur >= 'a' && cur <= 'z' || cur >= 'A' && cur <= 'Z') {
+          throw new IllegalArgumentException(s"Invalid time format: $format. All letters are reserved.")
+        } else {
+          field = Some(Literal(cur.toString))
+        }
+      } { f =>
+        if (usedFields.contains(f)) {
+          throw new IllegalArgumentException(s"Character $cur already used in format $format")
+        } else {
+          usedFields += f
+        }
+      }
+    }
+
+    while (pos < length) {
+      val cur = format.charAt(pos)
+
+      field match {
+        case None => setField(cur)
+        case Some(f @ TimeField(letter, _, _)) if (letter != cur) =>
+          result += f
+          setField(cur)
+        case Some(TimeField(letter, length, maxLength)) if (length == maxLength) =>
+          throw new IllegalArgumentException(s"Invalid time format: $format max length for ${letter} is ${maxLength}")
+        case Some(f @ TimeField(_, length, _)) =>
+          field = Some(f.copy(length = length + 1))
+        case Some(l @ Literal(_)) if fields.contains(cur) =>
+          result += l
+          setField(cur)
+        case Some(l @ Literal(value)) =>
+          field = Some(l.copy(value = value + cur))
+
+      }
+
+      pos += 1
+
+    }
+    field.foreach(f => result += f)
+
+    @tailrec
+    def loop(list: List[Field], regex: Seq[Regex]): Seq[Regex] = list match {
+      case Nil          => regex
+      case head :: tail => loop(tail, regex :+ fieldToRegex(head))
+    }
+
+    if (usedFields.isEmpty) {
+      throw new IllegalArgumentException(s"There is no time field (${fields.keySet.mkString(",")}) in format $format")
+    }
+
+    val regexes = loop(result.toList, Seq.empty)
+
+    if (regexes.isEmpty) {
+      throw new IllegalArgumentException(s"Invalid time format: $format")
+    } else {
+      regexes.reduce(_ ~ _)
+    }
+  }
+
+  private val from20to24 = Regex.oneOf('2') ~ Regex.between('0', '4')
+  private val from10to19 = Regex.oneOf('1') ~ Regex.digit
+  private val from00to09 = Regex.oneOf('0') ~ Regex.digit
+  private val from00to19 = Regex.oneOf('0', '1') ~ Regex.digit
+  private val from10to12 = Regex.oneOf('1') ~ Regex.oneOf('0', '1', '2')
+  private val from10to59 = Regex.between('1', '5') ~ Regex.digit
+  private val from00to59 = Regex.between('0', '5') ~ Regex.digit
+  private val from0to9   = Regex.digit
+
+  private def fieldToRegex(field: Field): Regex = field match {
+    case TimeField('H', 1, _)                        => from20to24 | from10to19 | from00to09 | from0to9
+    case TimeField('H', 2, _)                        => from00to19 | from20to24
+    case TimeField('h', 1, _)                        => from10to12 | from00to09 | from0to9
+    case TimeField('h', 2, _)                        => from00to09 | from10to12
+    case TimeField('m', 1, _) | TimeField('s', 1, _) => from10to59 | from00to09 | from0to9
+    case TimeField('m', 2, _) | TimeField('s', 2, _) => from00to59
+    case TimeField('S', length, _)                   => Regex.digit.between(length, length)
+    case TimeField('a', _, _)                        => Regex.oneOf('A', 'P').between(1, 1) ~ Regex.oneOf('M').between(1, 1)
+    case TimeField(_, _, _) =>
+      throw new IllegalArgumentException(s"Something went terribly wrong. This is a bug. Please report it.")
+    case Literal(l) => l.map(c => Regex.oneOf(c)).reduce(_ ~ _)
+  }
+
+}

--- a/zio-schema/shared/src/main/scala/zio/schema/validation/Validation.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/validation/Validation.scala
@@ -44,7 +44,7 @@ final case class Validation[A](bool: Bool[Predicate[A]]) { self =>
   }
 }
 
-object Validation extends Regexs {
+object Validation extends Regexs with Time {
   import Predicate._
 
   // String operations

--- a/zio-schema/shared/src/test/scala/zio/schema/ValidationSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/ValidationSpec.scala
@@ -1,7 +1,17 @@
 package zio.schema.validation
+
+import java.time.format.DateTimeFormatter
+
+import scala.util.Try
+
 import zio.test._
 
 object ValidationSpec extends DefaultRunnableSpec {
+  import zio.schema.validation.ValidationSpec.Hour._
+  import zio.schema.validation.ValidationSpec.Minute._
+  import zio.schema.validation.ValidationSpec.Second._
+  import zio.schema.validation.ValidationSpec.Fraction._
+  import zio.schema.validation.ValidationSpec.AmPm._
 
   def spec: ZSpec[Environment, Failure] = suite("ValidationSpec")(
     test("Greater than") {
@@ -131,6 +141,246 @@ object ValidationSpec extends DefaultRunnableSpec {
       assertTrue(validation.validate("-36-30-123-45-67").isLeft) &&
       assertTrue(validation.validate("+36-30-123-45-678").isLeft) &&
       assertTrue(validation.validate("30-123-45-678").isLeft)
+    },
+    test("Time Validation HH") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, "", NoMinute, "", NoSecond, "", NoFraction, "", NoAmPm), "HH")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation H") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, "", NoMinute, "", NoSecond, "", NoFraction, "", NoAmPm), "H")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation mm") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(NoHour, "", HasMinute, "", NoSecond, "", NoFraction, "", NoAmPm), "mm")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation m") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(NoHour, "", HasMinute, "", NoSecond, "", NoFraction, "", NoAmPm), "m")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation HHmm") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, "", HasMinute, "", NoSecond, "", NoFraction, "", NoAmPm), "HHmm")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation HH:mm") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, ":", HasMinute, "", NoSecond, "", NoFraction, "", NoAmPm), "HH:mm")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation HH:mm:ss") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, "", NoAmPm), "HH:mm:ss")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation HH:mm:ss a") {
+      val parsedTimes = parseTimes(
+        CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, " ", HasAmPm),
+        "HH:mm:ss a"
+      )
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation H:m:s") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, "", NoAmPm), "H:m:s")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation H:m:s a") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, " ", HasAmPm), "H:m:s a")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation hh:mm:ss") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, "", NoAmPm), "hh:mm:ss")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation hh:mm:ss a") {
+      val parsedTimes = parseTimes(
+        CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, " ", HasAmPm),
+        "hh:mm:ss a"
+      )
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation h:m:s") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, "", NoAmPm), "h:m:s")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation h:m:s a") {
+      val parsedTimes =
+        parseTimes(CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, "", NoFraction, " ", HasAmPm), "h:m:s a")
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation HH:mm:ss S") {
+      val parsedTimes = parseTimes(
+        CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, " ", HasFraction, "", NoAmPm),
+        "HH:mm:ss S"
+      )
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation HH:mm:ss.SSS") {
+      val parsedTimes = parseTimes(
+        CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, ".", HasFraction, "", NoAmPm),
+        "HH:mm:ss.SSS"
+      )
+      assertParsedTimes(parsedTimes)
+    },
+    test("Time Validation HH:mm:ss SSSSSSSSS a") {
+      val parsedTimes = parseTimes(
+        CreateTimesConfig(HasHour, ":", HasMinute, ":", HasSecond, " ", HasFraction, " ", HasAmPm),
+        "HH:mm:ss SSSSSSSSS a"
+      )
+      assertParsedTimes(parsedTimes)
     }
   )
+
+  private def assertParsedTimes(parsedTimes: ParsedTimes) =
+    parsedTimes.enoughParsed && parsedTimes.allParseResultsCorrect && parsedTimes.allWrongNotParsed && parsedTimes.allWrongParseResultsCorrect
+
+  private case class ParsedTimes(properTimeResults: Seq[ParsedTime], wrongTimeResults: Seq[ParsedTime]) {
+
+    def enoughParsed: Assert =
+      assertTrue(properTimeResults.count(result => result.parsed) >= properTimeResults.size / 4)
+    def allParseResultsCorrect: Assert = assertTrue(properTimeResults.forall(result => result.valid == result.parsed))
+    def allWrongNotParsed: Assert      = assertTrue(wrongTimeResults.forall(result => !result.valid))
+
+    def allWrongParseResultsCorrect: Assert =
+      assertTrue(wrongTimeResults.forall(result => result.valid == result.parsed))
+  }
+
+  private case class ParsedTime(time: String, valid: Boolean, parsed: Boolean)
+
+  private def parseTimes(createTimesConfig: CreateTimesConfig, format: String): ParsedTimes = {
+    val times      = createTimes(exampleTimes, createTimesConfig)
+    val wrongTimes = createTimes(wrongExampleTimes, createTimesConfig)
+    val validation = Validation.time(format)
+    val formatter  = DateTimeFormatter.ofPattern(format)
+
+    def innerParse(times: Seq[String]) =
+      times.map { time =>
+        val valid  = validation.validate(time).isRight
+        val parsed = Try(formatter.parse(time)).isSuccess
+        ParsedTime(time, valid, parsed)
+      }
+
+    val results          = innerParse(times)
+    val wrongTimeResults = innerParse(wrongTimes)
+
+    ParsedTimes(results, wrongTimeResults)
+  }
+
+  private case class ExampleTime(hour: String, minute: String, second: String, fraction: String, amPm: String)
+
+  private val exampleTimes =
+    Seq(
+      ExampleTime("0", "0", "0", "0", "AM"),
+      ExampleTime("1", "1", "1", "1", "AM"),
+      ExampleTime("00", "00", "00", "0", "AM"),
+      ExampleTime("00", "00", "00", "000000000", "AM"),
+      ExampleTime("01", "01", "00", "1", "AM"),
+      ExampleTime("01", "01", "00", "000000001", "AM"),
+      // ExampleTime("01", "01", "00", "", "PM"), // TODO - good syntax but invalid time for format "HH:mm:ss a" and "H:m:s a"
+      ExampleTime("10", "00", "00", "123", "AM"),
+      ExampleTime("12", "00", "00", "0", "PM"),
+      ExampleTime("12", "09", "09", "000", "PM"),
+      ExampleTime("12", "59", "59", "555", "PM"),
+      ExampleTime("13", "09", "09", "100000000", "PM"),
+      ExampleTime("20", "20", "20", "123456789", "PM"),
+      ExampleTime("22", "22", "22", "2", "PM"),
+      ExampleTime("23", "59", "00", "222222222", "PM"),
+      ExampleTime("23", "59", "59", "999", "PM"),
+      ExampleTime("0", "00", "00", "00000", "AM"),
+      ExampleTime("1", "11", "00", "000", "AM"),
+      // ExampleTime("24", "00", "00", "", "PM"), // TODO - good syntax but invalid time for format "HH:mm:ss a" and "H:m:s a"
+      ExampleTime("24", "00", "00", "000000000", "AM")
+    )
+
+  private val wrongExampleTimes =
+    Seq(
+      ExampleTime("", "", "", "", ""),
+      ExampleTime("-1", "-1", "-1", "-1", "-"),
+      ExampleTime("25", "60", "60", "1000000000", "PM"),
+      ExampleTime("90", "90", "90", "9999999999", "PM"),
+      ExampleTime("05-05", "05-05", "05-05", "05-05", "PM"),
+      ExampleTime("0505", "0505", "0505", "050505050505", "PM"),
+      ExampleTime("123", "123", "123", "1231231231", "AM"),
+      ExampleTime("111", "111", "111", "0000000001", "XX")
+    )
+
+  sealed private trait Hour
+  private object Hour {
+    case object HasHour extends Hour
+    case object NoHour  extends Hour
+  }
+
+  sealed private trait Minute
+  private object Minute {
+    case object HasMinute extends Minute
+    case object NoMinute  extends Minute
+  }
+
+  sealed private trait Second
+  private object Second {
+    case object HasSecond extends Second
+    case object NoSecond  extends Second
+  }
+
+  sealed private trait Fraction
+  private object Fraction {
+    case object HasFraction extends Fraction
+    case object NoFraction  extends Fraction
+  }
+
+  sealed private trait AmPm
+  private object AmPm {
+    case object HasAmPm extends AmPm
+    case object NoAmPm  extends AmPm
+  }
+
+  private case class CreateTimesConfig(
+    hasHour: Hour,
+    minuteSeparator: String = "",
+    hasMinute: Minute,
+    secondSeparator: String = "",
+    hasSecond: Second,
+    fractionSeparator: String = "",
+    hasFraction: Fraction,
+    amPmSeparator: String = "",
+    hasAmPm: AmPm
+  )
+
+  private def createTimes(
+    exampleTimes: Seq[ExampleTime],
+    config: CreateTimesConfig
+  ): Seq[String] =
+    exampleTimes.map {
+      case ExampleTime(hour, minute, second, fraction, amPm) =>
+        val hourStr = config.hasHour match {
+          case HasHour => hour
+          case NoHour  => ""
+        }
+        val minuteStr = config.hasMinute match {
+          case HasMinute => minute
+          case NoMinute  => ""
+        }
+        val secondStr = config.hasSecond match {
+          case HasSecond => second
+          case NoSecond  => ""
+        }
+        val fractionStr = config.hasFraction match {
+          case HasFraction => fraction
+          case NoFraction  => ""
+        }
+        val amPmStr = config.hasAmPm match {
+          case HasAmPm => amPm
+          case NoAmPm  => ""
+        }
+        s"$hourStr${config.minuteSeparator}$minuteStr${config.secondSeparator}$secondStr${config.fractionSeparator}$fractionStr${config.amPmSeparator}$amPmStr"
+    }
+
 }

--- a/zio-schema/shared/src/test/scala/zio/schema/validation/TimeSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/validation/TimeSpec.scala
@@ -1,0 +1,54 @@
+package zio.schema.validation
+
+import zio.test.Assertion._
+import zio.test._
+
+object TimeSpec extends DefaultRunnableSpec {
+
+  def spec: ZSpec[Environment, Failure] = suite("TimeSpec")(
+    test("Valid formats") {
+      assert(Validation.time("H"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HH"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("h"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("hh"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("m"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("mm"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("s"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("ss"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("S"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("SS"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("SSS"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("SSSSSSSSS"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HHmm"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("H:m"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("H:m a"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HH:mm"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HH:mm a"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HHmmss"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HH:mm:ss"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HH:mm:ssa"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("HH:mm:ss a"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("a HH:mm:ss"))(isSubtype[Validation[String]](anything)) &&
+      assert(Validation.time("H:m:s a"))(isSubtype[Validation[String]](anything))
+    },
+    test("Invalid formats") {
+      assert(Validation.time("HHH"))(throws(hasMessage(containsString("max length for")))) &&
+      assert(Validation.time("hhh"))(throws(hasMessage(containsString("max length for")))) &&
+      assert(Validation.time("mmm"))(throws(hasMessage(containsString("max length for")))) &&
+      assert(Validation.time("sss"))(throws(hasMessage(containsString("max length for")))) &&
+      assert(Validation.time("SSSSSSSSSS"))(throws(hasMessage(containsString("max length for")))) &&
+      assert(Validation.time("aa"))(throws(hasMessage(containsString("max length for")))) &&
+      assert(Validation.time("HHmmH"))(throws(hasMessage(containsString("already used in format")))) &&
+      assert(Validation.time("HHmmsm"))(throws(hasMessage(containsString("already used in format")))) &&
+      assert(Validation.time("hhmmhh"))(throws(hasMessage(containsString("already used in format")))) &&
+      assert(Validation.time("a HH:mm:s a"))(throws(hasMessage(containsString("already used in format")))) &&
+      assert(Validation.time("HH:mm:ss.SS S"))(throws(hasMessage(containsString("already used in format")))) &&
+      assert(Validation.time(":"))(throws(hasMessage(containsString("There is no time field")))) &&
+      assert(Validation.time("b"))(throws(hasMessage(containsString("All letters are reserved")))) &&
+      assert(Validation.time("j"))(throws(hasMessage(containsString("All letters are reserved")))) &&
+      assert(Validation.time("B"))(throws(hasMessage(containsString("All letters are reserved")))) &&
+      assert(Validation.time("J"))(throws(hasMessage(containsString("All letters are reserved")))) &&
+      assert(Validation.time(""))(throws(hasMessage(containsString("There is no time field"))))
+    }
+  )
+}


### PR DESCRIPTION
Need suggestion if the approach is correct. @jdegoes suggested to use an ADT instead of the format string which might be a better approach. Right now I'm reimplementing DateTimeFormatBuilder but with less feature. DateTimeFormat(Builder) doesn't expose it's internals to get the parsed format from them.

The testing is also a bit special and I'm not sure if this is the proper way but I wanted to test a lot of things and this seemed an easy/fast way to validate parsing instead of manually creating all times. So I ended up comparing my validation to DateTimeFormat's parse for the same format and times. It doesn't completely match but I only left in the times which have the same parse result. For sanity I also check if I can correctly parse at least 25% of the example times so it can't happen that I think all is good but in reality neither my parser nor DTF could parse any of them. I'd like to add more formats but first I wanted to ask if this is okay?

I copied the symbol table javadoc and an error message from DTF and I don't know if that's "legal" :)

Also all other comments are welcome to help cleaning up the code :)