### PR TITLE
Remove Left/Right/None/Nil implicit schemas

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
@@ -245,11 +245,11 @@ object DefaultValueSpec extends ZIOSpecDefault {
         assert(eitherSchema.defaultValue)(isRight(isLeft(equalTo(0))))
       },
       test("left") {
-        val leftSchema: Schema[Left[Int, Nothing]] = Schema.left(Schema.primitive(StandardType.IntType))
+        val leftSchema = Schema.either(Schema.primitive(StandardType.IntType), Schema.fail("Nothing"))
         assert(leftSchema.defaultValue)(isRight(isLeft(equalTo(0))))
       },
       test("right") {
-        val rightSchema: Schema[Right[Nothing, String]] = Schema.right(Schema.primitive(StandardType.StringType))
+        val rightSchema = Schema.either(Schema.fail("Nothing"), Schema.primitive(StandardType.StringType))
         assert(rightSchema.defaultValue)(isRight(isRight(equalTo(""))))
       }
     )

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -268,48 +268,6 @@ object JsonCodecSpec extends ZIOSpecDefault {
             )
         }
       },
-      test("compatible with left/right") {
-        check(
-          for {
-            left  <- SchemaGen.anyPrimitiveAndValue
-            right <- SchemaGen.anyPrimitiveAndValue
-          } yield (
-            Schema.either(left._1, right._1),
-            Schema.left(left._1),
-            Schema.right(right._1),
-            Left(left._2),
-            Right(right._2)
-          )
-        ) {
-          case (eitherSchema, leftSchema, rightSchema, leftValue, rightValue) =>
-            for {
-              a1 <- assertEncodesThenDecodesWithDifferentSchemas[Either[Any, Any], Left[Any, Nothing]](
-                     eitherSchema.asInstanceOf[Schema[Either[Any, Any]]],
-                     leftSchema.asInstanceOf[Schema[Left[Any, Nothing]]],
-                     leftValue.asInstanceOf[Either[Any, Any]],
-                     (x: Either[Any, Any], y: Left[Any, Nothing]) => x == y
-                   )
-              a2 <- assertEncodesThenDecodesWithDifferentSchemas(
-                     eitherSchema.asInstanceOf[Schema[Either[Any, Any]]],
-                     rightSchema.asInstanceOf[Schema[Right[Nothing, Any]]],
-                     rightValue,
-                     (x: Either[Any, Any], y: Right[Nothing, Any]) => x == y
-                   )
-              a3 <- assertEncodesThenDecodesWithDifferentSchemas(
-                     leftSchema.asInstanceOf[Schema[Left[Any, Nothing]]],
-                     eitherSchema.asInstanceOf[Schema[Either[Any, Any]]],
-                     leftValue,
-                     (x: Left[Any, Nothing], y: Either[Any, Any]) => x == y
-                   )
-              a4 <- assertEncodesThenDecodesWithDifferentSchemas(
-                     rightSchema.asInstanceOf[Schema[Right[Nothing, Any]]],
-                     eitherSchema.asInstanceOf[Schema[Either[Any, Any]]],
-                     rightValue,
-                     (x: Right[Nothing, Any], y: Either[Any, Any]) => x == y
-                   )
-            } yield a1 && a2 && a3 && a4
-        }
-      },
       test("Map of complex keys and values") {
         assertEncodes(
           Schema.map[Key, Value],

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -1981,7 +1981,7 @@ private[schema] object DynamicValueSchema { self =>
   private val noneValueCase: Schema.Case[DynamicValue.NoneValue.type, DynamicValue] =
     Schema.Case(
       "NoneValue",
-      Schema.none.transform(_ => DynamicValue.NoneValue, _ => None),
+      Schema.singleton(None).transform(_ => DynamicValue.NoneValue, _ => None),
       _.asInstanceOf[DynamicValue.NoneValue.type],
       Chunk("case")
     )


### PR DESCRIPTION
Currently we have implicit schemas for
- `Left` and `Right`
- `None`
- `Nil`

and these schemas are not (necessarily) compatible with the schema of `Either`, `Option` and `List`. This leads to serialization errors in places where the schema is captured for polymorphic types such as in zio-flow:

https://github.com/zio/zio-flow/issues/191

In this example if some zio-flow function is called with `Nil` the implicit `Schema.nil` was used for serialization but that was later assumed to be a `List[A]` and deserialization of that raw value fails.

Previously I made `left` and `right` schemas compatible with the `either` schema. An alternative solution to the problem would be to try doing the same with `none` and `nil` but I felt like it's more correct to just get rid of these implicits and force the users (of zio-schema) to know exactly what type they need schema for. 

This means we can no longer get an implicit schema for `Nil` without having an implicit schema for a given `A` that would be the element type - but I think this is a valid assumption.

In polymorphic cases like the linked one, replacing `Nil` with `List.empty[A]` for example makes the compiler able to infer the proper types and find the implicit which I think is a good compromise.

I removed `left` and `right` too just to make the approach the same for all of these.