### PR TITLE
Upgrade to zio-prelude 1.0.0-RC8-1 (fixes `java.lang.NoClassDefFoundError: zio/prelude/NewtypeModule$Newtype`)

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -28,7 +28,7 @@ object BuildHelper {
 
   val zioVersion        = "1.0.13"
   val zioJsonVersion    = "0.2.0-M2"
-  val zioPreludeVersion = "1.0.0-RC7"
+  val zioPreludeVersion = "1.0.0-RC8-1"
   val zioOpticsVersion  = "0.1.0"
   val silencerVersion   = "1.7.8"
 


### PR DESCRIPTION
Latest release of zio-prelude for ZIO 1.x is incompatible with the latest release of zio-prelude 1.0.0-RC8-1, since some classes were reorganized (`zio.prelude.NewtypeModule.Newtype` was moved to `zio.prelude`).

So when we use zio-schema together with zio-prelude 1.0.0-RC8-1 in the classpath and we try to encode and decode some data with `ProtobufCodec`, we get an error:

```
java.lang.NoClassDefFoundError: zio/prelude/NewtypeModule$Newtype
```