### PR TITLE
In JsonCodec: skip fields with null values in caseClassEncoder (make it consistent with zio-json)

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -512,18 +512,20 @@ object JsonCodec extends Codec {
         fields.foreach {
           case (Schema.Field(key, schema, _, _), ext) =>
             val enc = Encoder.schemaEncoder(schema.asInstanceOf[Schema[Any]])
-            if (first)
-              first = false
-            else {
-              out.write(',')
-              if (indent.isDefined)
-                JsonEncoder.pad(indent_, out)
-            }
+            if (!enc.isNothing(ext(a))) {
+              if (first)
+                first = false
+              else {
+                out.write(',')
+                if (indent.isDefined)
+                  JsonEncoder.pad(indent_, out)
+              }
 
-            string.unsafeEncode(JsonFieldEncoder.string.unsafeEncodeField(key), indent_, out)
-            if (indent.isEmpty) out.write(':')
-            else out.write(" : ")
-            enc.unsafeEncode(ext(a), indent_, out)
+              string.unsafeEncode(JsonFieldEncoder.string.unsafeEncodeField(key), indent_, out)
+              if (indent.isEmpty) out.write(':')
+              else out.write(" : ")
+              enc.unsafeEncode(ext(a), indent_, out)
+            }
         }
         pad(indent, out)
         out.write('}')

--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -759,7 +759,7 @@ object JsonCodecSpec extends DefaultRunnableSpec {
     JsonCodec.Encoder.charSequenceToByteChunk(encoded)
   }
 
-  case class SearchRequest(query: String, pageNumber: Int, resultPerPage: Int)
+  case class SearchRequest(query: String, pageNumber: Int, resultPerPage: Int, nextPage: Option[String])
 
   object SearchRequest {
     implicit val encoder: JsonEncoder[SearchRequest] = DeriveJsonEncoder.gen[SearchRequest]
@@ -770,7 +770,8 @@ object JsonCodecSpec extends DefaultRunnableSpec {
       query      <- Gen.anyString
       pageNumber <- Gen.int(Int.MinValue, Int.MaxValue)
       results    <- Gen.int(Int.MinValue, Int.MaxValue)
-    } yield SearchRequest(query, pageNumber, results)
+      nextPage   <- Gen.option(Gen.anyASCIIString)
+    } yield SearchRequest(query, pageNumber, results, nextPage)
 
   val searchRequestSchema: Schema[SearchRequest] = DeriveSchema.gen[SearchRequest]
 


### PR DESCRIPTION
Thanks for this wonderful library!

This PR makes writing fields with null values for case classes consistent with zio-json.

For example, given the following code:
```scala
final case class Person(age: Option[Int], name: String)
val person = Person(None, "John")
```

existing code will encode the `person` instance as: `{"age": null, name: "John"}`, while zio-json would encode it as: `{"name":"John"}`. Code in the PR makes `JsonCodec` consistent with zio-json in this case.
