### PR TITLE
feature: add `toTypedPrimitive` operator to `StandardType`

### DIFF
--- a/zio-schema/shared/src/main/scala/zio/schema/StandardType.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/StandardType.scala
@@ -7,7 +7,7 @@ import java.time.format.DateTimeFormatter
 
 import zio.Chunk
 
-sealed trait StandardType[A] extends Ordering[A] {self =>
+sealed trait StandardType[A] extends Ordering[A] { self =>
   def tag: String
   def defaultValue: Either[String, A]
   override def toString: String = tag

--- a/zio-schema/shared/src/main/scala/zio/schema/StandardType.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/StandardType.scala
@@ -7,10 +7,16 @@ import java.time.format.DateTimeFormatter
 
 import zio.Chunk
 
-sealed trait StandardType[A] extends Ordering[A] {
+sealed trait StandardType[A] extends Ordering[A] {self =>
   def tag: String
   def defaultValue: Either[String, A]
   override def toString: String = tag
+
+  /**
+   * Converts a DynamicValue into a primitive type.
+   */
+  def toTypedPrimitive(value: DynamicValue): Either[String, A] =
+    value.toTypedValue(Schema.primitive[A](self))
 }
 
 object StandardType {


### PR DESCRIPTION
This is a simpler way of extracting a typed value from a DynamicValue.