### PR TITLE
#248: Respect RFC 3696 for email length limits

### DIFF
--- a/zio-schema/shared/src/main/scala/zio/schema/validation/Regexs.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/validation/Regexs.scala
@@ -5,20 +5,17 @@ trait Regexs {
   val identifier: Validation[String] =
     Validation.regex((Regex.digitOrLetter | Regex.oneOf('_')).atLeast(1))
 
-  //^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$
+  /**
+   * Checks whether a certain string represents a valid email address.
+   */
   lazy val email: Validation[String] = {
-    val username       = Regex.letter ~ (Regex.digitOrLetter | Regex.oneOf('_', '.', '+', '-')).atLeast(0)
-    val topLevelDomain = (Regex.digitOrLetter | Regex.oneOf('-')).between(2, 4)
-    val domain =
-      ((Regex.digitOrLetter | Regex.oneOf('-')).atLeast(1) ~
-        Regex.oneOf('.')).atLeast(1) ~
-        topLevelDomain
+    val localPart      = Regex.letter ~ (Regex.digitOrLetter | Regex.oneOf('_', '.', '+', '-')).atMost(63)
+    val domainSegment  = Regex.digitOrLetter | Regex.oneOf('-')
+    val topLevelDomain = domainSegment.between(2, 4)
+    val domainPart     = (domainSegment.atLeast(1) ~ Regex.oneOf('.')).atLeast(1) ~ topLevelDomain
+    val completeEmail  = localPart ~ Regex.oneOf('@') ~ domainPart
 
-    Validation.regex(
-      username ~
-        Regex.oneOf('@') ~
-        domain
-    )
+    Validation.regex(completeEmail) && Validation.maxLength(254)
   }
 
   /**

--- a/zio-schema/shared/src/test/scala/zio/schema/validation/ValidationSpec.scala
+++ b/zio-schema/shared/src/test/scala/zio/schema/validation/ValidationSpec.scala
@@ -73,22 +73,55 @@ object ValidationSpec extends DefaultRunnableSpec {
       assertTrue(validation.validate("").isLeft) &&
       assertTrue(validation.validate("*").isLeft)
     },
-    test("Regex email Validation") {
-      val validation = Validation.email
+    suite("Regex email Validation")(
+      testM("should reject an invalid email") {
+        val data = Gen.fromIterable {
+          Seq(
+            "bob101*@gmail.com",
+            "_",
+            "@",
+            "@.",
+            "b@.com",
+            "",
+            "1@.com",
+            "1@a.com",
+            "1@a.b.com",
+            "a@@a.com",
+            "a@a..b.com",
+            "john@doe..",
+            "john.doe@foo.bar,com",
+            "xy@email.is-too-long.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.a123",
+            "the-local-part-too-long-over-64-so.invalid.123456789.123456789.a1@even.broad.definition.of.RFC5322.accepts.it"
+          )
+        }
+        val validationResult = (value: String) => Validation.email.validate(value)
 
-      assertTrue(validation.validate("bob101@gmail.com").isRight) &&
-      assertTrue(validation.validate("bob_and_alice@gmail.com").isRight) &&
-      assertTrue(validation.validate("bob101*@gmail.com").isLeft) &&
-      assertTrue(validation.validate("_").isLeft) &&
-      assertTrue(validation.validate("@").isLeft) &&
-      assertTrue(validation.validate("@.").isLeft) &&
-      assertTrue(validation.validate("b@.com").isLeft) &&
-      assertTrue(validation.validate("").isLeft) &&
-      assertTrue(validation.validate("1@.com").isLeft) &&
-      assertTrue(validation.validate("1@a.com").isLeft) &&
-      assertTrue(validation.validate("1@a.b.com").isLeft) &&
-      assertTrue(validation.validate("a@a..b.com").isLeft)
-    },
+        checkAll(data) { email =>
+          assertTrue(validationResult(email).isLeft)
+        }
+      },
+      testM("should accept a correct email") {
+        val data = Gen.fromIterable {
+          Seq(
+            "bob101@gmail.com",
+            "bob+and-alice@gmail.com",
+            "bob_and_alice@gmail.com",
+            "johndoe@total.length.up.to.254-chars.so.still-valid.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.a1",
+            "the-local-part-is-below-64-so.valid.123456789.123456789.a1234567@foo.com",
+            "name@a--b.pl",
+            "bob-@foo.co.uk",
+            "bob+@foo.co.uk",
+            "a.b@a.com",
+            "a..b@a.com"
+          )
+        }
+        val validationResult = (value: String) => Validation.email.validate(value)
+
+        checkAll(data) { email =>
+          assertTrue(validationResult(email).isRight)
+        }
+      }
+    ),
     test("Regex IPv4 Validation") {
       val validation = Validation.ipV4
 


### PR DESCRIPTION
Related to #248 

This change improves email address validation and supports the [RFC 3696](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690) (including "[erratum 1003](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690)").

There is a length limit on email addresses. That limit is a maximum of 64 characters (octets) in the "local part" (before the "@") and the upper limit on address lengths - total size of 254 characters due to a restriction in RFC 2821.

Additionally:
- refactored test cases and introduced parametrized tests for clarity,
- added new test examples to cover this change,
- added some bonus tests to cover a few border cases that were luckily supported but not documented,
- a validation still has open points for separate PR (e.g. IP addresses support instead of domain - currently blocked by not-reviewed/unmerged PR #301; see also IP email examples: https://en.wikipedia.org/wiki/Email_address#Examples)