### PR TITLE
Add methods for getting JsonEncoder/Decoder directly

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -33,8 +33,17 @@ object JsonCodec extends Codec {
 
   override def encode[A](schema: Schema[A]): A => Chunk[Byte] = Encoder.encode(schema, _)
 
+  def jsonEncoder[A](schema: Schema[A]): JsonEncoder[A] =
+    Encoder.schemaEncoder(schema)
+
   override def decode[A](schema: Schema[A]): Chunk[Byte] => Either[String, A] =
     (chunk: Chunk[Byte]) => Decoder.decode(schema, new String(chunk.toArray, Encoder.CHARSET))
+
+  def jsonDecoder[A](schema: Schema[A]): JsonDecoder[A] =
+    Decoder.schemaDecoder(schema)
+
+  def jsonCodec[A](schema: Schema[A]): ZJsonCodec[A] =
+    ZJsonCodec(jsonEncoder(schema), jsonDecoder(schema))
 
   object Codecs {
     protected[codec] val unitEncoder: JsonEncoder[Unit] =


### PR DESCRIPTION
`JsonCodec.encode` currently generates a new `JsonDecoder` every time an `A` is decoded. For `zio-http` (and other libraries) it should be more efficient to precompute the `JsonCodec` and then call it directly.