### PR TITLE
Deriver fixes

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Derive.scala
+++ b/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Derive.scala
@@ -369,10 +369,7 @@ object Derive {
               $selfRef
             }"""
           } else
-            c.abort(
-              c.enclosingPosition,
-              s"Failed to derive type class for $tpe"
-            )
+            q"""$deriver.deriveUnknown[$tpe]($summoned)"""
       }
 
     val tree = recurse(weakTypeOf[A], schema.tree, List.empty[Frame[c.type]], top = true)

--- a/zio-schema-derivation/shared/src/main/scala-2/zio/schema/VersionSpecificDeriver.scala
+++ b/zio-schema-derivation/shared/src/main/scala-2/zio/schema/VersionSpecificDeriver.scala
@@ -1,0 +1,3 @@
+package zio.schema
+
+trait VersionSpecificDeriver[F[_]] {}

--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/Derive.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/Derive.scala
@@ -54,7 +54,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
 
         Expr.summon[StandardType[A]] match {
           case Some(st) =>
-            val summoned = summonOptional[F, A]
+            val summoned = summonOptionalIfNotTop[F, A](top)
 
             '{ $deriver.derivePrimitive[A]($st, $summoned) }
           case None =>                    
@@ -62,7 +62,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
             case '[List[a]] =>
               val (seqSchemaRef, seqSchemaRefExpr) = createSchemaRef[List[a], Schema.Sequence[List[a], a, _]](stack)              
 
-              val summoned = summonOptional[F, List[a]]
+              val summoned = summonOptionalIfNotTop[F, List[a]](top)
                                 
               val elemInstance = deriveInstance[F, a](deriver, '{$seqSchemaRefExpr.elementSchema}, stack)
               lazyVals[F[A]](selfRef,
@@ -71,7 +71,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
               )            
             case '[scala.util.Either[a, b]] =>
               val (schemaRef, schemaRefExpr) = createSchemaRef[scala.util.Either[a, b], Schema.Either[a, b]](stack)              
-              val summoned = summonOptional[F, scala.util.Either[a, b]]
+              val summoned = summonOptionalIfNotTop[F, scala.util.Either[a, b]](top)
 
               val instanceA = deriveInstance[F, a](deriver, '{$schemaRefExpr.left}, stack)
               val instanceB = deriveInstance[F, b](deriver, '{$schemaRefExpr.right}, stack)
@@ -81,7 +81,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
               )
             case '[Option[a]] =>
               val (schemaRef, schemaRefExpr) = createSchemaRef[Option[a], Schema.Optional[a]](stack)              
-              val summoned = summonOptional[F, Option[a]]
+              val summoned = summonOptionalIfNotTop[F, Option[a]](top)
 
               val instanceA = deriveInstance[F, a](deriver, '{$schemaRefExpr.schema}, stack)              
               lazyVals[F[A]](selfRef,
@@ -90,7 +90,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
               )
             case '[scala.collection.immutable.Set[a]] =>
               val (schemaRef, schemaRefExpr) = createSchemaRef[scala.collection.immutable.Set[a], Schema.Set[a]](stack)              
-              val summoned = summonOptional[F, scala.collection.immutable.Set[a]]
+              val summoned = summonOptionalIfNotTop[F, scala.collection.immutable.Set[a]](top)
 
               val instanceA = deriveInstance[F, a](deriver, '{$schemaRefExpr.elementSchema}, stack)              
               lazyVals[F[A]](selfRef,
@@ -99,7 +99,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
               )
             case '[Vector[a]] =>
               val (schemaRef, schemaRefExpr) = createSchemaRef[scala.collection.immutable.Vector[a], Schema.Sequence[Vector[a], a, _]](stack)              
-              val summoned = summonOptional[F, scala.collection.immutable.Vector[a]]
+              val summoned = summonOptionalIfNotTop[F, scala.collection.immutable.Vector[a]](top)
 
               val instanceA = deriveInstance[F, a](deriver, '{$schemaRefExpr.elementSchema}, stack)
               lazyVals[F[A]](selfRef,
@@ -108,7 +108,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
               )
             case '[scala.collection.immutable.Map[a, b]] =>
               val (schemaRef, schemaRefExpr) = createSchemaRef[scala.collection.immutable.Map[a, b], Schema.Map[a, b]](stack)              
-              val summoned = summonOptional[F, scala.collection.immutable.Map[a, b]]
+              val summoned = summonOptionalIfNotTop[F, scala.collection.immutable.Map[a, b]](top)
 
               val instanceA = deriveInstance[F, a](deriver, '{$schemaRefExpr.keySchema}, stack)
               val instanceB = deriveInstance[F, b](deriver, '{$schemaRefExpr.valueSchema}, stack)
@@ -118,7 +118,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
               )              
             case '[zio.Chunk[a]] =>
               val (schemaRef, schemaRefExpr) = createSchemaRef[Chunk[a], Schema.Sequence[Chunk[a], a, _]](stack)              
-              val summoned = summonOptional[F, Chunk[a]]
+              val summoned = summonOptionalIfNotTop[F, Chunk[a]](top)
 
               val instanceA = deriveInstance[F, a](deriver, '{$schemaRefExpr.elementSchema}, stack)              
               lazyVals[F[A]](selfRef,
@@ -130,12 +130,12 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                 case Some(mirror) =>
                   mirror.mirrorType match {
                     case MirrorType.Sum =>
-                      deriveEnum[F, A](mirror, stack, deriver, schema, selfRef)
+                      deriveEnum[F, A](top, mirror, stack, deriver, schema, selfRef)
                     case MirrorType.Product =>
                       typeRepr.asType match {
                         case '[(a, b)] =>
                           val (schemaRef, schemaRefExpr) = createSchemaRef[(a, b), Schema.Tuple2[a, b]](stack)              
-                          val summoned = summonOptional[F, (a, b)]
+                          val summoned = summonOptionalIfNotTop[F, (a, b)](top)
 
                           val instanceA = deriveInstance[F, a](deriver, '{$schemaRefExpr.left}, stack)
                           val instanceB = deriveInstance[F, b](deriver, '{$schemaRefExpr.right}, stack)
@@ -145,6 +145,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           )
                         case '[(t1, t2, t3)] =>
                           tupleN[F, (t1, t2, t3)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3)]],
@@ -153,6 +154,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4)] =>
                           tupleN[F, (t1, t2, t3, t4)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4)]],
@@ -161,6 +163,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5)] =>
                           tupleN[F, (t1, t2, t3, t4, t5)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5)]],
@@ -169,6 +172,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6)]],
@@ -177,6 +181,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7)]],
@@ -185,6 +190,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8)]],
@@ -193,6 +199,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9)]],
@@ -201,6 +208,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)]],
@@ -209,6 +217,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)]],
@@ -217,6 +226,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)]],
@@ -225,6 +235,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)]],
@@ -233,6 +244,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)]],
@@ -241,6 +253,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)]],
@@ -249,6 +262,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)]],
@@ -257,6 +271,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)]],
@@ -265,6 +280,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)]],
@@ -273,6 +289,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)]],
@@ -281,6 +298,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20)]],
@@ -289,6 +307,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21)]],
@@ -297,6 +316,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                           ).asExprOf[F[A]]
                         case '[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, t22)] =>
                           tupleN[F, (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, t22)](
+                            top,
                             selfRef,
                             deriver,
                             schema.asExprOf[Schema[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, t22)]],
@@ -304,13 +324,13 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
                             Chunk(TypeRepr.of[t1], TypeRepr.of[t2], TypeRepr.of[t3], TypeRepr.of[t4], TypeRepr.of[t5], TypeRepr.of[t6], TypeRepr.of[t7], TypeRepr.of[t8], TypeRepr.of[t9], TypeRepr.of[t10], TypeRepr.of[t11], TypeRepr.of[t12], TypeRepr.of[t13], TypeRepr.of[t14], TypeRepr.of[t15], TypeRepr.of[t16], TypeRepr.of[t17], TypeRepr.of[t18], TypeRepr.of[t19], TypeRepr.of[t20], TypeRepr.of[t21], TypeRepr.of[t22])
                           ).asExprOf[F[A]]
                         case _ =>
-                          deriveCaseClass[F, A](mirror, stack, deriver, schema, selfRef)
+                          deriveCaseClass[F, A](top, mirror, stack, deriver, schema, selfRef)
                       }
                   }
                 case None =>
                   val sym = typeRepr.typeSymbol
                   if (sym.isClassDef && sym.flags.is(Flags.Module)) {
-                    deriveCaseObject[F, A](deriver, schema)
+                    deriveCaseObject[F, A](top, deriver, schema)
                   }
                   else {
                     report.errorAndAbort(s"Deriving schema for ${typeRepr.show} is not supported")
@@ -323,12 +343,12 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
     result
   }
 
-  def deriveCaseObject[F[_]: Type, A: Type](deriver: Expr[Deriver[F]], schema: Expr[Schema[A]])(using Quotes) = {
-    val summoned = summonOptional[F, A]
+  def deriveCaseObject[F[_]: Type, A: Type](top: Boolean, deriver: Expr[Deriver[F]], schema: Expr[Schema[A]])(using Quotes) = {
+    val summoned = summonOptionalIfNotTop[F, A](top)
     '{$deriver.deriveRecord[A](Schema.force($schema).asInstanceOf[Schema.Record[A]], Chunk.empty, $summoned)}
    }
 
-  def deriveCaseClass[F[_]: Type, A: Type](mirror: Mirror, stack: Stack, deriver: Expr[Deriver[F]], schema: Expr[Schema[A]], selfRef: Ref)(using Quotes) = {
+  def deriveCaseClass[F[_]: Type, A: Type](top: Boolean, mirror: Mirror, stack: Stack, deriver: Expr[Deriver[F]], schema: Expr[Schema[A]], selfRef: Ref)(using Quotes) = {
     val newStack = stack.push(selfRef, TypeRepr.of[A])
 
     val labels = mirror.labels.toList
@@ -347,7 +367,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
         }
       }
 
-      val summoned = summonOptional[F, A]
+      val summoned = summonOptionalIfNotTop[F, A](top)
 
       lazyVals[F[A]](selfRef,
         schemaRef -> '{Schema.force($schema).asInstanceOf[Schema.Record[A]]},
@@ -366,7 +386,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
         }
       }
 
-      val summoned = summonOptional[F, A]
+      val summoned = summonOptionalIfNotTop[F, A](top)
 
       lazyVals[F[A]](selfRef,
         schemaRef -> '{Schema.force($schema).asInstanceOf[Schema.Transform[ListMap[String, _], A, _]]},
@@ -376,7 +396,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
     }
   }
 
-  def deriveEnum[F[_]: Type, A: Type](mirror: Mirror, stack: Stack, deriver: Expr[Deriver[F]], schema: Expr[Schema[A]], selfRef: Ref)(using Quotes) = {    
+  def deriveEnum[F[_]: Type, A: Type](top: Boolean, mirror: Mirror, stack: Stack, deriver: Expr[Deriver[F]], schema: Expr[Schema[A]], selfRef: Ref)(using Quotes) = {
     val newStack = stack.push(selfRef, TypeRepr.of[A])
 
     val labels = mirror.labels.toList
@@ -393,7 +413,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
       }
     }
 
-    val summoned = summonOptional[F, A]
+    val summoned = summonOptionalIfNotTop[F, A](top)
 
     lazyVals[F[A]](selfRef, 
       schemaRef -> '{Schema.force($schema).asInstanceOf[Schema.Enum[A]]},
@@ -427,7 +447,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
          lefts('{ $tschema.left.asInstanceOf[Schema.Tuple2[a, b]] }, tpes.init)
     }
 
-  def tupleN[F[_]: Type, A: Type](selfRef: Ref, deriver: Expr[Deriver[F]], schema: Expr[Schema[A]], stack: Stack, tpes: Chunk[TypeRepr])(using Quotes): Expr[F[A]] = {
+  def tupleN[F[_]: Type, A: Type](top: Boolean, selfRef: Ref, deriver: Expr[Deriver[F]], schema: Expr[Schema[A]], stack: Stack, tpes: Chunk[TypeRepr])(using Quotes): Expr[F[A]] = {
     val tschemaType = toTupleSchemaType(tpes)
     val tupleType = tpes.length match {
       case 1 => TypeRepr.of[scala.Tuple1]
@@ -445,7 +465,7 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
             nestedTupleType.asType match {
               case '[ntt] =>
                 val (schemaRef, schemaRefExpr) = createSchemaRef[ftt, Schema.Transform[ntt, ftt, _]](stack)
-                val summoned = summonOptional[F, ftt]
+                val summoned = summonOptionalIfNotTop[F, ftt](top)
 
                 val tschema = '{$schemaRefExpr.schema.asInstanceOf[Schema.Tuple2[a, b]]}
 
@@ -476,6 +496,8 @@ private case class DeriveInstance()(using val ctx: Quotes) extends ReflectionUti
             }
           }
     }
-
   }
+
+  def summonOptionalIfNotTop[F[_]: Type, A: Type](top: Boolean)(using Quotes): Expr[Option[F[A]]] =
+    if (top) '{None} else summonOptional[F, A]
 }

--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/VersionSpecificDeriver.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/VersionSpecificDeriver.scala
@@ -1,0 +1,5 @@
+package zio.schema
+
+trait VersionSpecificDeriver[F[_]] { self: Deriver[F] =>
+  inline def derive[A](implicit schema: Schema[A]): F[A] = Derive.derive[F, A](self)(schema)
+}

--- a/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
+++ b/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
@@ -1,9 +1,9 @@
 package zio.schema
 
+import scala.reflect.ClassTag
+
 import zio.Chunk
 import zio.schema.Deriver.{ WrappedF, wrap }
-
-import scala.reflect.ClassTag
 
 /** Deriver builds type class instances based on a Schema.
  *

--- a/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
+++ b/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
@@ -75,8 +75,7 @@ trait Deriver[F[_]] extends VersionSpecificDeriver[F] { self =>
     )
 
   def deriveTupleN[T](schemasAndInstances: => Chunk[(Schema[_], WrappedF[F, _])], summoned: => Option[F[T]]): F[T] = {
-    val arity        = schemasAndInstances.length
-    val recordSchema = tupleToRecordSchema[T](arity, schemasAndInstances)
+    val recordSchema = TupleRecordSchema.tupleToRecordSchema[T](schemasAndInstances.map(_._1))
     deriveRecord(
       recordSchema,
       schemasAndInstances.map(_._2),
@@ -178,88 +177,6 @@ trait Deriver[F[_]] extends VersionSpecificDeriver[F] { self =>
         }
     }
 
-  private def tupleToRecordSchema[T](
-    arity: Int,
-    schemasAndInstances: => Chunk[(Schema[_], WrappedF[F, _])]
-  ): Schema.Record[T] =
-    arity match {
-      case 2 =>
-        Schema
-          .CaseClass2[Any, Any, (Any, Any)](
-            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
-            Schema.Field(
-              "_1",
-              schemasAndInstances(0)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any)) => t._1,
-              set0 = (t: (Any, Any), v: Any) => t.copy(_1 = v)
-            ),
-            Schema.Field(
-              "_2",
-              schemasAndInstances(1)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any)) => t._2,
-              set0 = (t: (Any, Any), v: Any) => t.copy(_2 = v)
-            ),
-            (t1, t2) => (t1, t2)
-          )
-          .asInstanceOf[Schema.Record[T]]
-      case 3 =>
-        Schema
-          .CaseClass3[Any, Any, Any, (Any, Any, Any)](
-            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
-            Schema.Field(
-              "_1",
-              schemasAndInstances(0)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any, Any)) => t._1,
-              set0 = (t: (Any, Any, Any), v: Any) => t.copy(_1 = v)
-            ),
-            Schema.Field(
-              "_2",
-              schemasAndInstances(1)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any, Any)) => t._2,
-              set0 = (t: (Any, Any, Any), v: Any) => t.copy(_2 = v)
-            ),
-            Schema.Field(
-              "_3",
-              schemasAndInstances(2)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any, Any)) => t._3,
-              set0 = (t: (Any, Any, Any), v: Any) => t.copy(_3 = v)
-            ),
-            (t1, t2, t3) => (t1, t2, t3)
-          )
-          .asInstanceOf[Schema.Record[T]]
-      case 4 =>
-        Schema
-          .CaseClass4[Any, Any, Any, Any, (Any, Any, Any, Any)](
-            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
-            Schema.Field(
-              "_1",
-              schemasAndInstances(0)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any, Any, Any)) => t._1,
-              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
-            ),
-            Schema.Field(
-              "_2",
-              schemasAndInstances(1)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any, Any, Any)) => t._2,
-              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
-            ),
-            Schema.Field(
-              "_3",
-              schemasAndInstances(2)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any, Any, Any)) => t._3,
-              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
-            ),
-            Schema.Field(
-              "_4",
-              schemasAndInstances(3)._1.asInstanceOf[Schema[Any]],
-              get0 = (t: (Any, Any, Any, Any)) => t._4,
-              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
-            ),
-            (t1, t2, t3, t4) => (t1, t2, t3, t4)
-          )
-          .asInstanceOf[Schema.Record[T]]
-      case _ => throw new IllegalArgumentException(s"Unsupported tuple arity: $arity")
-    }
 }
 
 object Deriver {

--- a/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
+++ b/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
@@ -28,7 +28,7 @@ import zio.schema.Deriver.{ WrappedF, wrap }
  * which implements this automatically and only calls the trait's methods in case there is no available implicit for
  * the actual type.
  */
-trait Deriver[F[_]] { self =>
+trait Deriver[F[_]] extends VersionSpecificDeriver[F] { self =>
 
   lazy val cached: Deriver[F] = {
     val cache = CachedDeriver.createCache[F]

--- a/zio-schema-derivation/shared/src/main/scala/zio/schema/TupleRecordSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala/zio/schema/TupleRecordSchema.scala
@@ -1,0 +1,4796 @@
+package zio.schema
+
+import zio.Chunk
+
+private[schema] object TupleRecordSchema {
+
+  def tupleToRecordSchema[T](schemas: => Chunk[Schema[_]]): Schema.Record[T] = {
+    val arity = schemas.length
+    arity match {
+      case 2 =>
+        Schema
+          .CaseClass2[Any, Any, (Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any)) => t._1,
+              set0 = (t: (Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any)) => t._2,
+              set0 = (t: (Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            (t1, t2) => (t1, t2)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 3 =>
+        Schema
+          .CaseClass3[Any, Any, Any, (Any, Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            (t1, t2, t3) => (t1, t2, t3)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 4 =>
+        Schema
+          .CaseClass4[Any, Any, Any, Any, (Any, Any, Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            (t1, t2, t3, t4) => (t1, t2, t3, t4)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 5 =>
+        Schema
+          .CaseClass5[Any, Any, Any, Any, Any, (Any, Any, Any, Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            (t1, t2, t3, t4, t5) => (t1, t2, t3, t4, t5)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 6 =>
+        Schema
+          .CaseClass6[Any, Any, Any, Any, Any, Any, (Any, Any, Any, Any, Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6) => (t1, t2, t3, t4, t5, t6)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 7 =>
+        Schema
+          .CaseClass7[Any, Any, Any, Any, Any, Any, Any, (Any, Any, Any, Any, Any, Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7) => (t1, t2, t3, t4, t5, t6, t7)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 8 =>
+        Schema
+          .CaseClass8[Any, Any, Any, Any, Any, Any, Any, Any, (Any, Any, Any, Any, Any, Any, Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_8 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8) => (t1, t2, t3, t4, t5, t6, t7, t8)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 9 =>
+        Schema
+          .CaseClass9[Any, Any, Any, Any, Any, Any, Any, Any, Any, (Any, Any, Any, Any, Any, Any, Any, Any, Any)](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_9 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9) => (t1, t2, t3, t4, t5, t6, t7, t8, t9)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 10 =>
+        Schema
+          .CaseClass10[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_10 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) => (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 11 =>
+        Schema
+          .CaseClass11[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._11,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_11 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) => (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 12 =>
+        Schema
+          .CaseClass12[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._11,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._12,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_12 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) => (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 13 =>
+        Schema
+          .CaseClass13[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._11,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._12,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._13,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_13 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) =>
+              (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 14 =>
+        Schema
+          .CaseClass14[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._11,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._12,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._13,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._14,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) => t.copy(_14 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) =>
+              (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 15 =>
+        Schema
+          .CaseClass15[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._11,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._12,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._13,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._14,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._15,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_15 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) =>
+              (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 16 =>
+        Schema
+          .CaseClass16[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._11,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._12,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._13,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._14,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._15,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_15 = v)
+            ),
+            Schema.Field(
+              "_16",
+              schemas(15).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._16,
+              set0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                t.copy(_16 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16) =>
+              (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 17 =>
+        Schema
+          .CaseClass17[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._10,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._11,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._12,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._13,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._14,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._15,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_15 = v)
+            ),
+            Schema.Field(
+              "_16",
+              schemas(15).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._16,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_16 = v)
+            ),
+            Schema.Field(
+              "_17",
+              schemas(16).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._17,
+              set0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any), v: Any) =>
+                  t.copy(_17 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17) =>
+              (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 18 =>
+        Schema
+          .CaseClass18[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._1,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._2,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._3,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._4,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._5,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._6,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._7,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._8,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) => t._9,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._10,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._11,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._12,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._13,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._14,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._15,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_15 = v)
+            ),
+            Schema.Field(
+              "_16",
+              schemas(15).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._16,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_16 = v)
+            ),
+            Schema.Field(
+              "_17",
+              schemas(16).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._17,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_17 = v)
+            ),
+            Schema.Field(
+              "_18",
+              schemas(17).asInstanceOf[Schema[Any]],
+              get0 = (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                t._18,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_18 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18) =>
+              (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 19 =>
+        Schema
+          .CaseClass19[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._1,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._2,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._3,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._4,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._5,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._6,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._7,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._8,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._9,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._10,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._11,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._12,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._13,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._14,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._15,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_15 = v)
+            ),
+            Schema.Field(
+              "_16",
+              schemas(15).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._16,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_16 = v)
+            ),
+            Schema.Field(
+              "_17",
+              schemas(16).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._17,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_17 = v)
+            ),
+            Schema.Field(
+              "_18",
+              schemas(17).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._18,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_18 = v)
+            ),
+            Schema.Field(
+              "_19",
+              schemas(18).asInstanceOf[Schema[Any]],
+              get0 =
+                (t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)) =>
+                  t._19,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_19 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19) =>
+              (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 20 =>
+        Schema
+          .CaseClass20[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._1,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._2,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._3,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._4,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._5,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._6,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._7,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._8,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._9,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._10,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._11,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._12,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._13,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._14,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._15,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_15 = v)
+            ),
+            Schema.Field(
+              "_16",
+              schemas(15).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._16,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_16 = v)
+            ),
+            Schema.Field(
+              "_17",
+              schemas(16).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._17,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_17 = v)
+            ),
+            Schema.Field(
+              "_18",
+              schemas(17).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._18,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_18 = v)
+            ),
+            Schema.Field(
+              "_19",
+              schemas(18).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._19,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_19 = v)
+            ),
+            Schema.Field(
+              "_20",
+              schemas(19).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._20,
+              set0 = (
+                t: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any),
+                v: Any
+              ) => t.copy(_20 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20) =>
+              (
+                t1,
+                t2,
+                t3,
+                t4,
+                t5,
+                t6,
+                t7,
+                t8,
+                t9,
+                t10,
+                t11,
+                t12,
+                t13,
+                t14,
+                t15,
+                t16,
+                t17,
+                t18,
+                t19,
+                t20
+              )
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 21 =>
+        Schema
+          .CaseClass21[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any)
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._1,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._2,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._3,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._4,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._5,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._6,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._7,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._8,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._9,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._10,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._11,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._12,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._13,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._14,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._15,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_15 = v)
+            ),
+            Schema.Field(
+              "_16",
+              schemas(15).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._16,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_16 = v)
+            ),
+            Schema.Field(
+              "_17",
+              schemas(16).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._17,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_17 = v)
+            ),
+            Schema.Field(
+              "_18",
+              schemas(17).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._18,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_18 = v)
+            ),
+            Schema.Field(
+              "_19",
+              schemas(18).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._19,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_19 = v)
+            ),
+            Schema.Field(
+              "_20",
+              schemas(19).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._20,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_20 = v)
+            ),
+            Schema.Field(
+              "_21",
+              schemas(20).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._21,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_21 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21) =>
+              (
+                t1,
+                t2,
+                t3,
+                t4,
+                t5,
+                t6,
+                t7,
+                t8,
+                t9,
+                t10,
+                t11,
+                t12,
+                t13,
+                t14,
+                t15,
+                t16,
+                t17,
+                t18,
+                t19,
+                t20,
+                t21
+              )
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case 22 =>
+        Schema
+          .CaseClass22[
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            Any,
+            (
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any
+            )
+          ](
+            TypeId.parse(s"zio.schema.Tuple.Tuple$arity"),
+            Schema.Field(
+              "_1",
+              schemas(0).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._1,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_1 = v)
+            ),
+            Schema.Field(
+              "_2",
+              schemas(1).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._2,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_2 = v)
+            ),
+            Schema.Field(
+              "_3",
+              schemas(2).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._3,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_3 = v)
+            ),
+            Schema.Field(
+              "_4",
+              schemas(3).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._4,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_4 = v)
+            ),
+            Schema.Field(
+              "_5",
+              schemas(4).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._5,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_5 = v)
+            ),
+            Schema.Field(
+              "_6",
+              schemas(5).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._6,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_6 = v)
+            ),
+            Schema.Field(
+              "_7",
+              schemas(6).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._7,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_7 = v)
+            ),
+            Schema.Field(
+              "_8",
+              schemas(7).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._8,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_8 = v)
+            ),
+            Schema.Field(
+              "_9",
+              schemas(8).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._9,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_9 = v)
+            ),
+            Schema.Field(
+              "_10",
+              schemas(9).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._10,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_10 = v)
+            ),
+            Schema.Field(
+              "_11",
+              schemas(10).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._11,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_11 = v)
+            ),
+            Schema.Field(
+              "_12",
+              schemas(11).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._12,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_12 = v)
+            ),
+            Schema.Field(
+              "_13",
+              schemas(12).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._13,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_13 = v)
+            ),
+            Schema.Field(
+              "_14",
+              schemas(13).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._14,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_14 = v)
+            ),
+            Schema.Field(
+              "_15",
+              schemas(14).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._15,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_15 = v)
+            ),
+            Schema.Field(
+              "_16",
+              schemas(15).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._16,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_16 = v)
+            ),
+            Schema.Field(
+              "_17",
+              schemas(16).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._17,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_17 = v)
+            ),
+            Schema.Field(
+              "_18",
+              schemas(17).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._18,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_18 = v)
+            ),
+            Schema.Field(
+              "_19",
+              schemas(18).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._19,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_19 = v)
+            ),
+            Schema.Field(
+              "_20",
+              schemas(19).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._20,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_20 = v)
+            ),
+            Schema.Field(
+              "_21",
+              schemas(20).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._21,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_21 = v)
+            ),
+            Schema.Field(
+              "_22",
+              schemas(21).asInstanceOf[Schema[Any]],
+              get0 = (t: (
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any,
+                Any
+              )) => t._22,
+              set0 = (
+                t: (
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any,
+                  Any
+                ),
+                v: Any
+              ) => t.copy(_22 = v)
+            ),
+            (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, t22) =>
+              (
+                t1,
+                t2,
+                t3,
+                t4,
+                t5,
+                t6,
+                t7,
+                t8,
+                t9,
+                t10,
+                t11,
+                t12,
+                t13,
+                t14,
+                t15,
+                t16,
+                t17,
+                t18,
+                t19,
+                t20,
+                t21,
+                t22
+              )
+          )
+          .asInstanceOf[Schema.Record[T]]
+      case _ => throw new IllegalArgumentException(s"Unsupported tuple arity: $arity")
+    }
+  }
+}

--- a/zio-schema-derivation/shared/src/test/scala-2.12/zio/schema/VersionSpecificDeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-2.12/zio/schema/VersionSpecificDeriveSchemaSpec.scala
@@ -9,11 +9,9 @@ trait VersionSpecificDeriveSchemaSpec {
     implicit val schema = DeriveSchema.gen[ContainerFields]
   }
 
-
   def verifyFieldName[F]: FieldNameVerifier[F] = new FieldNameVerifier[F]
-    
-    
+
   class FieldNameVerifier[F] {
-     @nowarn def apply(name: String): Boolean = true // Cannot check as we don't have singleton types
-  }    
+    @nowarn def apply(name: String): Boolean = true // Cannot check as we don't have singleton types
+  }
 }

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -1,11 +1,11 @@
 package zio.schema
 
+import scala.reflect.ClassTag
+
 import zio.schema.Deriver.WrappedF
 import zio.schema.Schema.Field
 import zio.test.{ Spec, TestEnvironment, ZIOSpecDefault, assertTrue }
 import zio.{ Chunk, Scope }
-
-import scala.reflect.ClassTag
 
 object DeriveSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
@@ -312,6 +312,7 @@ object DeriveSpec extends ZIOSpecDefault {
 
   final case class UnsupportedField1(field: OpenTrait)
 
+  @SuppressWarnings(Array("all"))
   object UnsupportedField1 {
     implicit private val openTraitPlaceholderSchema: Schema[OpenTrait] = Schema.fail("OpenTrait")
 

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -67,6 +67,15 @@ object DeriveSpec extends ZIOSpecDefault {
           assertTrue(
             tc.isDerived == true
           )
+        },
+        test("new top level implicit value is not passed as summoned") {
+          assertTrue(
+            ImplicitDeriveCheck.tc1 ne null,
+            ImplicitDeriveCheck.tc1.isDerived == true,
+            ImplicitDeriveCheck.tc7 ne null,
+            ImplicitDeriveCheck.tc7.isDerived == true,
+            ImplicitDeriveCheck.tc7.inner.flatMap(_.inner).exists(_ ne null) == true
+          )
         }
       ),
       suite("enum")(
@@ -108,7 +117,7 @@ object DeriveSpec extends ZIOSpecDefault {
             tc8 ne null
           )
         }
-      },
+      }
     )
 
   trait TC[A] {
@@ -226,6 +235,17 @@ object DeriveSpec extends ZIOSpecDefault {
     case object Stop                    extends Enum2
 
     implicit val schema: Schema[Enum2] = DeriveSchema.gen[Enum2]
+  }
+
+  trait ImplicitDeriveCheckBase {
+    implicit val tc1: TC[Record1]
+    implicit val tc7: TC[Record7]
+  }
+
+  object ImplicitDeriveCheck extends ImplicitDeriveCheckBase {
+    val d: Deriver[TC]                     = deriver.autoAcceptSummoned
+    implicit override val tc1: TC[Record1] = Derive.derive[TC, Record1](d)
+    implicit override val tc7: TC[Record7] = Derive.derive[TC, Record7](d)
   }
 
   val deriver: Deriver[TC] = new Deriver[TC] {

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -1,11 +1,12 @@
 package zio.schema
 
 import scala.reflect.ClassTag
-
 import zio.schema.Deriver.WrappedF
 import zio.schema.Schema.Field
 import zio.test.{ Spec, TestEnvironment, ZIOSpecDefault, assertTrue }
 import zio.{ Chunk, Scope }
+
+import scala.annotation.nowarn
 
 object DeriveSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
@@ -314,7 +315,7 @@ object DeriveSpec extends ZIOSpecDefault {
 
   @SuppressWarnings(Array("all"))
   object UnsupportedField1 {
-    implicit private val openTraitPlaceholderSchema: Schema[OpenTrait] = Schema.fail("OpenTrait")
+    @nowarn implicit private val openTraitPlaceholderSchema: Schema[OpenTrait] = Schema.fail("OpenTrait")
 
     implicit val schema: Schema[UnsupportedField1] = DeriveSchema.gen[UnsupportedField1]
   }

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -108,7 +108,7 @@ object DeriveSpec extends ZIOSpecDefault {
             tc8 ne null
           )
         }
-      }
+      },
     )
 
   trait TC[A] {

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -14,9 +14,8 @@ object DeriveSpec extends ZIOSpecDefault {
           assertTrue(tc.isDerived == true)
         },
         test("can use existing instance for case object") {
-          implicit val schema: Schema[CaseObject2.type] = DeriveSchema.gen[CaseObject2.type]
-          val tc                                        = Derive.derive[TC, CaseObject2.type](deriver)
-          assertTrue(tc.isDerived == false)
+          val tc = Derive.derive[TC, CaseObject2Wrapper](deriver)
+          assertTrue(tc.isDerived == true, tc.inner.map(_.isDerived).contains(false))
         }
       ),
       suite("case class")(
@@ -25,8 +24,8 @@ object DeriveSpec extends ZIOSpecDefault {
           assertTrue(tc.isDerived == true)
         },
         test("can use existing instance for simple case class") {
-          val tc = Derive.derive[TC, Record2](deriver)
-          assertTrue(tc.isDerived == false)
+          val tc = Derive.derive[TC, Record2Wrapper](deriver)
+          assertTrue(tc.isDerived == true, tc.inner.map(_.isDerived).contains(false))
         },
         test("can derive new instance for case class referring another one using an existing instance") {
           val tc = Derive.derive[TC, Record3](deriver)
@@ -133,6 +132,12 @@ object DeriveSpec extends ZIOSpecDefault {
     override def inner: Option[TC[_]] = None
   }
 
+  case class CaseObject2Wrapper(obj: CaseObject2.type)
+
+  object CaseObject2Wrapper {
+    implicit val schema: Schema[CaseObject2Wrapper] = DeriveSchema.gen[CaseObject2Wrapper]
+  }
+
   case class Record1(a: String, b: Int)
 
   object Record1 {
@@ -147,6 +152,12 @@ object DeriveSpec extends ZIOSpecDefault {
       override def isDerived: Boolean   = false
       override def inner: Option[TC[_]] = None
     }
+  }
+
+  case class Record2Wrapper(obj: Record2)
+
+  object Record2Wrapper {
+    implicit val schema: Schema[Record2Wrapper] = DeriveSchema.gen[Record2Wrapper]
   }
 
   case class Record3(r: Option[Record2])

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -1,12 +1,12 @@
 package zio.schema
 
+import scala.annotation.nowarn
 import scala.reflect.ClassTag
+
 import zio.schema.Deriver.WrappedF
 import zio.schema.Schema.Field
 import zio.test.{ Spec, TestEnvironment, ZIOSpecDefault, assertTrue }
 import zio.{ Chunk, Scope }
-
-import scala.annotation.nowarn
 
 object DeriveSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =


### PR DESCRIPTION
Fixes for the new `Deriver`:
- Convenience method `Deriver#derive` (only for Scala 3 now)
- Not summoning implicit on top level to avoid capturing the value being derived
- Fix support for higher arity tuples
- Support for capturing implicit type classes for arbitrary types 
