### PR TITLE
Remove json default value field from fieldDefaultValue test

### DIFF
--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -235,7 +235,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
         assertDecodes(
           fieldDefaultValueSearchRequestSchema,
           FieldDefaultValueSearchRequest("test", 0, 10, "test"),
-          charSequenceToByteChunk("""{"query":"test","pageNumber":0,"resultPerPage":10,"nextPage":"test"}""")
+          charSequenceToByteChunk("""{"query":"test","pageNumber":0,"resultPerPage":10}""")
         )
       },
       test("field name with alias - id") {


### PR DESCRIPTION
The test is testing the fieldDefaultValue annotation but is providing a value for the field that would otherwise be defaulted.