### PR TITLE
Clean up and fix DynamicValue schema handling

### DIFF
--- a/tests/shared/src/test/scala-2/zio/schema/MetaSchemaSpec.scala
+++ b/tests/shared/src/test/scala-2/zio/schema/MetaSchemaSpec.scala
@@ -247,6 +247,11 @@ object MetaSchemaSpec extends ZIOSpecDefault {
         val schema       = Schema[Option[List[String]]]
         val materialized = MetaSchema.fromSchema(schema).toSchema
         assert(materialized)(hasSameSchemaStructure(schema))
+      },
+      test("dynamic") {
+        check(SchemaGen.anyDynamic) { schema =>
+          assert(MetaSchema.fromSchema(schema).toSchema)(hasSameSchemaStructure(schema))
+        }
       }
     )
   )

--- a/tests/shared/src/test/scala-2/zio/schema/SchemaGen.scala
+++ b/tests/shared/src/test/scala-2/zio/schema/SchemaGen.scala
@@ -589,7 +589,8 @@ object SchemaGen {
         anyStructure(anyTree(depth - 1))
           .zip(Gen.string(Gen.alphaChar).map(TypeId.parse))
           .map(z => Schema.record(z._2, z._1)),
-        Gen.const(Schema[Json])
+        Gen.const(Schema[Json]),
+        anyDynamic
 //        anyEnumeration(anyTree(depth - 1)).map(toCaseSet).map(Schema.enumeration[Any, CaseSet.Aux[Any]](_))
       )
 

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -258,7 +258,7 @@ object JsonCodec {
       case e @ Schema.Enum22(_, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, _) =>
         enumEncoder(e, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22)
       case e @ Schema.EnumN(_, cs, _) => enumEncoder(e, cs.toSeq: _*)
-      case Schema.Dynamic(_)          => dynamicEncoder(DynamicValueSchema.schema)
+      case Schema.Dynamic(_)          => dynamicEncoder(DynamicValue.schema)
       case _                          => throw new Exception(s"Missing a handler for encoding of schema ${schema.toString()}.")
     }
     //scalafmt: { maxColumn = 120, optIn.configStyleArguments = true }
@@ -451,7 +451,7 @@ object JsonCodec {
       case e @ Schema.Enum22(_, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, _) =>
         enumDecoder(e, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22)
       case e @ Schema.EnumN(_, cs, _) => enumDecoder(e, cs.toSeq: _*)
-      case Schema.Dynamic(_)          => dynamicDecoder(DynamicValueSchema.schema)
+      case Schema.Dynamic(_)          => dynamicDecoder(DynamicValue.schema)
       case _                          => throw new Exception(s"Missing a handler for decoding of schema ${schema.toString()}.")
     }
     //scalafmt: { maxColumn = 120, optIn.configStyleArguments = true }

--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -14,6 +14,7 @@ import zio.schema.annotation._
 import zio.schema.codec.DecodeError.ReadError
 import zio.schema.codec.JsonCodec.JsonEncoder.charSequenceToByteChunk
 import zio.schema.codec.JsonCodecSpec.PaymentMethod.{ CreditCard, PayPal, WireTransfer }
+import zio.schema.meta.MetaSchema
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect._
@@ -789,7 +790,27 @@ object JsonCodecSpec extends ZIOSpecDefault {
                 )
               }
         }
-      } @@ TestAspect.sized(1000) @@ TestAspect.samples(1000)
+      } @@ TestAspect.sized(1000) @@ TestAspect.samples(1000),
+      suite("meta schema")(
+        test("primitive string meta schema") {
+          assertEncodesThenDecodes(MetaSchema.schema, Schema[String].ast)
+        },
+        test("case class meta schema") {
+          assertEncodesThenDecodes(MetaSchema.schema, Schema[SchemaGen.Arity1].ast)
+        },
+        test("recursive class meta schema") {
+          assertEncodesThenDecodes(MetaSchema.schema, Schema[SchemaGen.Json].ast)
+        },
+        test("dynamic value meta schema") {
+          assertEncodesThenDecodes(MetaSchema.schema, Schema[DynamicValue].ast)
+        },
+        test("any meta schema") {
+          check(SchemaGen.anySchema) { schema =>
+            val metaSchema = schema.ast
+            assertEncodesThenDecodes(MetaSchema.schema, metaSchema)
+          }
+        }
+      )
     )
   )
 

--- a/zio-schema-msg-pack/shared/src/main/scala/zio/schema/codec/MessagePackDecoder.scala
+++ b/zio-schema-msg-pack/shared/src/main/scala/zio/schema/codec/MessagePackDecoder.scala
@@ -12,7 +12,7 @@ import org.msgpack.core.{ MessagePack, MessageUnpacker }
 
 import zio.schema.codec.DecodeError.MalformedFieldWithPath
 import zio.schema.codec.MessagePackDecoder._
-import zio.schema.{ DynamicValueSchema, Schema, StandardType }
+import zio.schema.{ DynamicValue, Schema, StandardType }
 import zio.{ Chunk, ChunkBuilder }
 
 private[codec] class MessagePackDecoder(bytes: Chunk[Byte]) {
@@ -101,7 +101,7 @@ private[codec] class MessagePackDecoder(bytes: Chunk[Byte]) {
       case Schema.Enum22(_, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, _) =>
         decodeEnum(path, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22)
       case Schema.EnumN(_, cs, _) => decodeEnum(path, cs.toSeq: _*)
-      case Schema.Dynamic(_)      => decodeValue(path, DynamicValueSchema.schema)
+      case Schema.Dynamic(_)      => decodeValue(path, DynamicValue.schema)
       case _                      => fail(path, s"Unknown schema ${schema.getClass.getName}")
     }
 

--- a/zio-schema-msg-pack/shared/src/main/scala/zio/schema/codec/MessagePackEncoder.scala
+++ b/zio-schema-msg-pack/shared/src/main/scala/zio/schema/codec/MessagePackEncoder.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable.ListMap
 import org.msgpack.core.MessagePack
 
 import zio.Chunk
-import zio.schema.{ DynamicValueSchema, Schema, StandardType }
+import zio.schema.{ DynamicValue, Schema, StandardType }
 
 private[codec] class MessagePackEncoder {
   private val packer = MessagePack.newDefaultBufferPacker()
@@ -115,7 +115,7 @@ private[codec] class MessagePackEncoder {
       case (Schema.Enum22(_, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, _), v) =>
         encodeEnum(v, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22)
       case (Schema.EnumN(_, cs, _), v) => encodeEnum(v, cs.toSeq: _*)
-      case (Schema.Dynamic(_), v)      => encodeValue(DynamicValueSchema.schema, v)
+      case (Schema.Dynamic(_), v)      => encodeValue(DynamicValue.schema, v)
       case (_, _)                      => ()
     }
 

--- a/zio-schema-protobuf/shared/src/test/scala-2/zio/schema/codec/ProtobufCodecSpec.scala
+++ b/zio-schema-protobuf/shared/src/test/scala-2/zio/schema/codec/ProtobufCodecSpec.scala
@@ -9,6 +9,7 @@ import scala.util.Try
 import zio.Console._
 import zio._
 import zio.schema.CaseSet._
+import zio.schema.meta.MetaSchema
 import zio.schema.{ CaseSet, DeriveSchema, DynamicValue, DynamicValueGen, Schema, SchemaGen, StandardType, TypeId }
 import zio.stream.{ ZSink, ZStream }
 import zio.test.Assertion._
@@ -728,6 +729,14 @@ object ProtobufCodecSpec extends ZIOSpecDefault {
         test("dynamic set") {
           check(SchemaGen.anyRecord.flatMap(DynamicValueGen.anyDynamicSet)) { dynamicValue =>
             assertZIO(encodeAndDecode(Schema.dynamicValue, dynamicValue))(equalTo(Chunk(dynamicValue)))
+          }
+        }
+      ),
+      suite("meta schema")(
+        test("any meta schema") {
+          check(SchemaGen.anySchema) { schema =>
+            val metaSchema = schema.ast
+            assertZIO(encodeAndDecode(MetaSchema.schema, metaSchema))(equalTo(Chunk(metaSchema)))
           }
         }
       )

--- a/zio-schema-zio-test/shared/src/main/scala/zio/schema/DeriveGen.scala
+++ b/zio-schema-zio-test/shared/src/main/scala/zio/schema/DeriveGen.scala
@@ -68,7 +68,7 @@ object DeriveGen {
       case tuple @ Schema.Tuple2(_, _, _)                                                                                           => genTuple(tuple)
       case either @ Schema.Either(_, _, _)                                                                                          => genEither(either)
       case lazzy @ Schema.Lazy(_)                                                                                                   => genLazy(lazzy)
-      case Schema.Dynamic(_)                                                                                                        => gen(DynamicValueSchema())
+      case Schema.Dynamic(_)                                                                                                        => gen(DynamicValue.schema)
       case _                                                                                                                        => throw new Exception(s"Missing handler for generating value of schema ${schema.toString()}")
     } // scalafmt: { maxColumn = 120 }
 
@@ -592,9 +592,8 @@ object DeriveGen {
 
   private def genSchemaAstDynamic(path: NodePath): Gen[Any, MetaSchema.Dynamic] =
     for {
-      withSchema <- Gen.boolean
-      optional   <- Gen.boolean
-    } yield MetaSchema.Dynamic(withSchema, path, optional)
+      optional <- Gen.boolean
+    } yield MetaSchema.Dynamic(path, optional)
 
   private def genAst(path: NodePath): Gen[Sized, MetaSchema] =
     Gen.weighted(

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -218,13 +218,6 @@ object DynamicValue {
 
   final case class Error(message: String) extends DynamicValue
 
-}
-
-private[schema] object DynamicValueSchema {
-  self =>
-
-  def apply(): Schema[DynamicValue] = schema
-
   lazy val schema: Schema[DynamicValue] =
     Schema.EnumN(
       TypeId.fromTypeName("zio.schema.DynamicValue"),
@@ -329,7 +322,7 @@ private[schema] object DynamicValueSchema {
         TypeId.parse("zio.schema.DynamicValue.RightValue"),
         Schema.Field(
           "value",
-          Schema.defer(DynamicValueSchema()),
+          Schema.defer(DynamicValue.schema),
           get0 = rightValue => rightValue.value,
           set0 = (rightValue, value) => rightValue.copy(value = value)
         ),
@@ -347,7 +340,7 @@ private[schema] object DynamicValueSchema {
         TypeId.parse("zio.schema.DynamicValue.LeftValue"),
         Schema.Field(
           "value",
-          Schema.defer(DynamicValueSchema()),
+          Schema.defer(DynamicValue.schema),
           get0 = leftValue => leftValue.value,
           set0 = (leftValue, value) => leftValue.copy(value = value)
         ),
@@ -365,13 +358,13 @@ private[schema] object DynamicValueSchema {
         TypeId.parse("zio.schema.DynamicValue.Tuple"),
         Schema.Field(
           "left",
-          Schema.defer(DynamicValueSchema()),
+          Schema.defer(DynamicValue.schema),
           get0 = tuple => tuple.left,
           set0 = (tuple, left) => tuple.copy(left = left)
         ),
         Schema.Field(
           "right",
-          Schema.defer(DynamicValueSchema()),
+          Schema.defer(DynamicValue.schema),
           get0 = tuple => tuple.right,
           set0 = (tuple, right) => tuple.copy(right = right)
         ),
@@ -390,7 +383,7 @@ private[schema] object DynamicValueSchema {
         Schema
           .Field(
             "value",
-            Schema.defer(DynamicValueSchema()),
+            Schema.defer(DynamicValue.schema),
             get0 = someValue => someValue.value,
             set0 = (someValue, value) => someValue.copy(value = value)
           ),
@@ -408,7 +401,7 @@ private[schema] object DynamicValueSchema {
         TypeId.parse("zio.schema.DynamicValue.Dictionary"),
         Schema.Field(
           "entries",
-          Schema.defer(Schema.chunk(Schema.tuple2(DynamicValueSchema(), DynamicValueSchema()))),
+          Schema.defer(Schema.chunk(Schema.tuple2(DynamicValue.schema, DynamicValue.schema))),
           get0 = dictionary => dictionary.entries,
           set0 = (dictionary, entries) => dictionary.copy(entries = entries)
         ),
@@ -426,7 +419,7 @@ private[schema] object DynamicValueSchema {
         TypeId.parse("zio.schema.DynamicValue.Sequence"),
         Schema.Field(
           "values",
-          Schema.defer(Schema.chunk(DynamicValueSchema())),
+          Schema.defer(Schema.chunk(DynamicValue.schema)),
           get0 = seq => seq.values,
           set0 = (seq, values) => seq.copy(values = values)
         ),
@@ -444,7 +437,7 @@ private[schema] object DynamicValueSchema {
         TypeId.parse("zio.schema.DynamicValue.SetValue"),
         Schema.Field(
           "values",
-          Schema.defer(Schema.set(DynamicValueSchema())),
+          Schema.defer(Schema.set(DynamicValue.schema)),
           get0 = seq => seq.values,
           set0 = (seq, values) => seq.copy(values = values)
         ),
@@ -468,7 +461,7 @@ private[schema] object DynamicValueSchema {
         ),
         Schema.Field(
           "value",
-          Schema.defer(Schema.tuple2(Schema.primitive[String], DynamicValueSchema())),
+          Schema.defer(Schema.tuple2(Schema.primitive[String], DynamicValue.schema)),
           get0 = enumeration => enumeration.value,
           set0 = (enumeration, value) => enumeration.copy(value = value)
         ),
@@ -488,7 +481,7 @@ private[schema] object DynamicValueSchema {
         Schema
           .Field(
             "values",
-            Schema.defer(Schema.chunk(Schema.tuple2(Schema.primitive[String], DynamicValueSchema()))),
+            Schema.defer(Schema.chunk(Schema.tuple2(Schema.primitive[String], DynamicValue.schema))),
             get0 = record => Chunk.fromIterable(record.values),
             set0 = (record, values) => record.copy(values = values.foldRight(ListMap.empty[String, DynamicValue])((a, b) => b + a))
           ),

--- a/zio-schema/shared/src/main/scala/zio/schema/MutableSchemaBasedValueBuilder.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/MutableSchemaBasedValueBuilder.scala
@@ -998,7 +998,7 @@ trait MutableSchemaBasedValueBuilder[Target, Context] {
               case Some(value) =>
                 finishWith(value)
               case None =>
-                currentSchema = Schema.dynamicValue
+                currentSchema = DynamicValue.schema
             }
           case _ => throw new Exception(s"Missing a handler for schema ${currentSchema.toString()}.")
         }

--- a/zio-schema/shared/src/main/scala/zio/schema/MutableSchemaBasedValueProcessor.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/MutableSchemaBasedValueProcessor.scala
@@ -1322,7 +1322,7 @@ trait MutableSchemaBasedValueProcessor[Target, Context] {
           processDynamic(currentContext, currentValue.asInstanceOf[DynamicValue]) match {
             case Some(target) => finishWith(target)
             case None =>
-              currentSchema = Schema.dynamicValue
+              currentSchema = DynamicValue.schema
           }
 
         case _ => throw new Exception(s"Missing a handler for schema ${currentSchema.toString()}.")

--- a/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
@@ -282,7 +282,7 @@ object Schema extends SchemaEquality {
     }
   )
 
-  implicit val dynamicValue: Schema[DynamicValue] = DynamicValueSchema()
+  implicit val dynamicValue: Schema[DynamicValue] = Schema.Dynamic()
 
   implicit def chunk[A](implicit schemaA: Schema[A]): Schema[Chunk[A]] =
     Schema.Sequence[Chunk[A], A, String](schemaA, identity, identity, Chunk.empty, "Chunk")

--- a/zio-schema/shared/src/main/scala/zio/schema/SchemaOrdering.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/SchemaOrdering.scala
@@ -54,7 +54,7 @@ object SchemaOrdering {
     case (r: Schema.Record[_], Record(_, lVals), Record(_, rVals)) =>
       compareRecords(r, lVals, rVals)
     case (Schema.Dynamic(_), left, right) =>
-      ordering(Schema[DynamicValue]).compare(left, right)
+      ordering(DynamicValue.schema).compare(left, right)
     case _ => 0
   }
 


### PR DESCRIPTION
- The implicit schema for `DynamicValue` is now `Schema.Dynamic` as it is a single placeholder when the schema is serialized instead of redundant inclusion of the whole real schema
- The real schema for `DynamicValue` is defined as `DynamicValue.schema` as with other types (#392) and it is made public for implementing codecs outside of `zio.schema`
- Added some new tests that include `DynamicValue` in generated schemas
- Fixed the issue that `MetaSchema` including a `Dynamic` node was not serializable and tests this with JSON and Protobuf