### PR TITLE
Fix json generic record decoding

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -515,6 +515,7 @@ object JsonCodec {
                   val value = schemaDecoder(schema).unsafeDecode(trace_, in)
                   builder += ((JsonFieldDecoder.string.unsafeDecodeField(trace_, label), value))
                 case None =>
+                  Lexer.char(trace, in, ':')
                   Lexer.skipValue(trace, in)
 
               }

--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -186,6 +186,15 @@ object JsonCodecSpec extends ZIOSpecDefault {
         }
       )
     ),
+    suite("generic record")(
+      test("with extra fields") {
+        assertDecodes(
+          recordSchema,
+          ListMap[String, Any]("foo" -> "s", "bar" -> 1),
+          charSequenceToByteChunk("""{"foo":"s","bar":1,"baz":2}""")
+        )
+      }
+    ),
     suite("transform")(
       test("string") {
         val stringSchema    = Schema.Primitive(StandardType.StringType)


### PR DESCRIPTION
I found this while playing around with zio-flow. If the record contains extra fields the `JsonDecoder` for `GenericRecord` doesn't properly skip values for extra fields.

This is actually fairly critical as it seems to prevent zio-flow from correctly handling response messages when the payload includes extra fields (as is the case with many third party apis)