### PR TITLE
Fallback to deriveUnknown if the schema is not the expected schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ _ZIO Schema_ is used by a growing number of ZIO libraries, including _ZIO Flow_,
 In order to use this library, we need to add the following lines in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-schema"          % "0.4.6"
-libraryDependencies += "dev.zio" %% "zio-schema-json"     % "0.4.6"
-libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "0.4.6"
+libraryDependencies += "dev.zio" %% "zio-schema"          % "0.4.7"
+libraryDependencies += "dev.zio" %% "zio-schema-json"     % "0.4.7"
+libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "0.4.7"
 
 // Required for automatic generic derivation of schemas
-libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "0.4.6",
+libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "0.4.7",
 libraryDependencies += "org.scala-lang" % "scala-reflect"  % scalaVersion.value % "provided"
 ```
 

--- a/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Derive.scala
+++ b/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Derive.scala
@@ -294,7 +294,7 @@ object Derive {
           } else if (tpe <:< tuple22Tpe) {
             tupleN()
           } else if (isCaseObject(tpe)) {
-            q"$deriver.deriveRecord[$tpe]($forcedSchema.asInstanceOf[_root_.zio.schema.Schema.Record[$tpe]], _root_.zio.Chunk.empty, $summoned)"
+            q"$deriver.tryDeriveRecord[$tpe]($forcedSchema.asInstanceOf[_root_.zio.schema.Schema[$tpe]], _root_.zio.Chunk.empty, $summoned)"
           } else if (isCaseClass(tpe)) {
             val fields = tpe.decls.sorted.collect {
               case p: TermSymbol if p.isCaseAccessor && !p.isMethod => p
@@ -334,7 +334,7 @@ object Derive {
 
               q"""{
                   lazy val $schemaRef = $forcedSchema.asInstanceOf[_root_.zio.schema.Schema.Record[$tpe]]
-                  lazy val $selfRefWithType = $deriver.deriveRecord[$tpe]($schemaRef, _root_.zio.Chunk(..$fieldInstances), $summoned)
+                  lazy val $selfRefWithType = $deriver.tryDeriveRecord[$tpe]($forcedSchema.asInstanceOf[_root_.zio.schema.Schema[$tpe]], _root_.zio.Chunk(..$fieldInstances), $summoned)
                   $selfRef
                 }"""
             }
@@ -350,7 +350,7 @@ object Derive {
             }
             q"""{
               lazy val $schemaRef = $forcedSchema.asInstanceOf[_root_.zio.schema.Schema.Enum[$tpe]]
-              lazy val $selfRefWithType = $deriver.deriveEnum[$tpe]($schemaRef, _root_.zio.Chunk(..$subtypeInstances), $summoned)
+              lazy val $selfRefWithType = $deriver.tryDeriveEnum[$tpe]($forcedSchema.asInstanceOf[_root_.zio.schema.Schema[$tpe]], _root_.zio.Chunk(..$subtypeInstances), $summoned)
               $selfRef
             }"""
           } else if (isMap(tpe)) {

--- a/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
+++ b/zio-schema-derivation/shared/src/main/scala/zio/schema/Deriver.scala
@@ -37,6 +37,26 @@ trait Deriver[F[_]] extends VersionSpecificDeriver[F] { self =>
     CachedDeriver.apply(this, cache)
   }
 
+  def tryDeriveRecord[A: ClassTag](
+    schema: Schema[A],
+    fields: => Chunk[WrappedF[F, _]],
+    summoned: => Option[F[A]]
+  ): F[A] =
+    schema match {
+      case record: Schema.Record[A] => deriveRecord(record, fields, summoned)
+      case _                        => deriveUnknown(summoned)
+    }
+
+  def tryDeriveEnum[A: ClassTag](
+    schema: Schema[A],
+    cases: => Chunk[WrappedF[F, _]],
+    summoned: => Option[F[A]]
+  ): F[A] =
+    schema match {
+      case e: Schema.Enum[A] => deriveEnum(e, cases, summoned)
+      case _                 => deriveUnknown(summoned)
+    }
+
   def deriveRecord[A](record: Schema.Record[A], fields: => Chunk[WrappedF[F, _]], summoned: => Option[F[A]]): F[A]
 
   def deriveEnum[A](`enum`: Schema.Enum[A], cases: => Chunk[WrappedF[F, _]], summoned: => Option[F[A]]): F[A]


### PR DESCRIPTION
A record or enum type may have a custom schema (even `Schema.fail`), but if we have a summoned implicit for the derived type class in scope, we can ignore this mismatch and use the summoned value.