### PR TITLE
add derived extension method on Schema.type.

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
@@ -8,6 +8,8 @@ import Schema._
 
 import zio.schema.annotation.fieldName
 
+extension (s: Schema.type) transparent inline def derived[A] = DeriveSchema.gen[A]
+
 object DeriveSchema {
 
   transparent inline def gen[T]: Schema[T] = ${ deriveSchema[T] }

--- a/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
@@ -10,12 +10,32 @@ trait VersionSpecificDeriveSchemaSpec extends ZIOSpecDefault {
   }
 
   inline def verifyFieldName[F]: FieldNameVerifier[F] = new FieldNameVerifier[F]
-    
-    
+
   class FieldNameVerifier[F] {
      inline def apply[S <: String & scala.Singleton](name: S): Boolean =
        VerifyFieldNameMacro.verifyFieldName[F, S]
   }
 
-  def versionSpecificSuite = Spec.labeled("Scala 3 specific tests", Spec.empty)
+  import SchemaAssertions._
+
+  final case class AutoDerives(i: Int) derives Schema
+
+  def versionSpecificSuite = Spec.labeled(
+    "Scala 3 specific tests", 
+    suite("Derivation")(
+      test("correctly derives case class with `derives` keyword") {
+        val expected: Schema[AutoDerives] = Schema.CaseClass1(
+          TypeId.parse("zio.schema.VersionSpecificDeriveSchemaSpec.AutoDerives"),
+          field0 = Schema.Field(
+            "i",
+            Schema.Primitive(StandardType.IntType),
+            get0 = _.i,
+            set0 = (a, b: Int) => a.copy(i = b)
+          ),
+          AutoDerives.apply
+        )
+        assert(Schema[AutoDerives])(hasSameSchema(expected))
+      }
+    )
+  )
 }


### PR DESCRIPTION
Resolves https://github.com/zio/zio-schema/issues/521

I added the extension method at the top-level of the `zio.schema` package, so a simple `import zio.schema.*` will bring it in scope.