### PR TITLE
feat: specific json encoder/decoder for Map[String, Any]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [ZIO Schema](https://github.com/zio/zio-schema) is a [ZIO](https://zio.dev)-based library for modeling the schema of data structures as first-class values.
 
-[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-schema/workflows/CI/badge.svg) [![Sonatype Releases](https://img.shields.io/nexus/r/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Release)](https://oss.sonatype.org/content/repositories/releases/dev/zio/zio-schema_2.13/) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-schema_2.13/) [![javadoc](https://javadoc.io/badge2/dev.zio/zio-schema-docs_2.13/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-schema-docs_2.13) [![ZIO Schema](https://img.shields.io/github/stars/zio/zio-schema?style=social)](https://github.com/zio/zio-schema)
+[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-schema/workflows/CI/badge.svg) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-schema_2.13/) [![ZIO Schema](https://img.shields.io/github/stars/zio/zio-schema?style=social)](https://github.com/zio/zio-schema)
 
 ## Introduction
 
@@ -30,12 +30,12 @@ _ZIO Schema_ is used by a growing number of ZIO libraries, including _ZIO Flow_,
 In order to use this library, we need to add the following lines in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-schema"          % "0.4.9"
-libraryDependencies += "dev.zio" %% "zio-schema-json"     % "0.4.9"
-libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "0.4.9"
+libraryDependencies += "dev.zio" %% "zio-schema"          % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-json"     % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "<version>"
 
 // Required for automatic generic derivation of schemas
-libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "0.4.9",
+libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "<version>",
 libraryDependencies += "org.scala-lang" % "scala-reflect"  % scalaVersion.value % "provided"
 ```
 


### PR DESCRIPTION
Fixes #447 

First step to implement Map Json Encoder/Decoder with Json objects `{}` instead of arrays of values `[{}]` (current implementation)
It only works if the key type is String.

This PR detects if the schema is a Map[String, V] and encode/decode like this:
```scala
  val emptyMap: Map[String, String] = Map.empty
  val expectedEmptyJson = """{}"""

  val extra: Map[String, String] = Map("extra" -> "config")
  val expectedJson = """{"extra":"config"}"""

  case class ServerVersion(
    server: String,
    details: Map[String, String] = Map.empty
  )

  val serverInfo = ServerVersion("server1", Map("extra" -> "config"))
  val expectedServerInfoJson = """{"server":"server1","details":{"extra":"config"}}"""

```

  