### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Learn more on the [ZIO Schema homepage](https://zio.dev/zio-schema)!
 
 ## Contributing
 
-For the general guidelines, see ZIO [contributor's guide](https://zio.dev/contributor-guidelines/).
+For the general guidelines, see ZIO [contributor's guide](https://zio.dev/contributor-guidelines).
 #### TL;DR
 
 Before you submit a PR, make sure your tests are passing, and that the code is properly formatted

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Learn more on the [ZIO Schema homepage](https://zio.dev/zio-schema)!
 
 ## Contributing
 
-For the general guidelines, see ZIO [contributor's guide](https://zio.dev/about/contributing).
+For the general guidelines, see ZIO [contributor's guide](https://zio.dev/contributor-guidelines/).
 #### TL;DR
 
 Before you submit a PR, make sure your tests are passing, and that the code is properly formatted
@@ -99,7 +99,7 @@ sbt test
 
 ## Code of Conduct
 
-See the [Code of Conduct](https://zio.dev/about/code-of-conduct)
+See the [Code of Conduct](https://zio.dev/code-of-conduct)
 
 ## Support
 


### PR DESCRIPTION
Following links were broken and led to 404:
- contributor's guide
- code of conduct