### PR TITLE
Scala 3: don't make the self ref vals private within

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
@@ -116,7 +116,7 @@ private case class DeriveSchema()(using val ctx: Quotes) extends ReflectionUtils
   }
 
   def deriveCaseObject[T: Type](stack: Stack, top: Boolean)(using Quotes) = {
-    val selfRefSymbol = Symbol.newVal(Symbol.spliceOwner, s"derivedSchema${stack.size}", TypeRepr.of[Schema[T]], Flags.Lazy, Symbol.spliceOwner)
+    val selfRefSymbol = Symbol.newVal(Symbol.spliceOwner, s"derivedSchema${stack.size}", TypeRepr.of[Schema[T]], Flags.Lazy, Symbol.noSymbol)
     val selfRef = Ref(selfRefSymbol)
 
     val typeInfo = '{TypeId.parse(${Expr(TypeRepr.of[T].show)})}
@@ -150,7 +150,7 @@ private case class DeriveSchema()(using val ctx: Quotes) extends ReflectionUtils
   }
 
   def deriveCaseClass[T: Type](mirror: Mirror, stack: Stack, top: Boolean)(using Quotes) = {
-    val selfRefSymbol = Symbol.newVal(Symbol.spliceOwner, s"derivedSchema${stack.size}", TypeRepr.of[Schema[T]], Flags.Lazy, Symbol.spliceOwner)
+    val selfRefSymbol = Symbol.newVal(Symbol.spliceOwner, s"derivedSchema${stack.size}", TypeRepr.of[Schema[T]], Flags.Lazy, Symbol.noSymbol)
     val selfRef = Ref(selfRefSymbol)
     val newStack = stack.push(selfRef, TypeRepr.of[T])
 
@@ -283,7 +283,7 @@ private case class DeriveSchema()(using val ctx: Quotes) extends ReflectionUtils
       }.toMap
   
   def deriveEnum[T: Type](mirror: Mirror, stack: Stack)(using Quotes) = {
-    val selfRefSymbol = Symbol.newVal(Symbol.spliceOwner, s"derivedSchema${stack.size}", TypeRepr.of[Schema[T]], Flags.Lazy, Symbol.spliceOwner)
+    val selfRefSymbol = Symbol.newVal(Symbol.spliceOwner, s"derivedSchema${stack.size}", TypeRepr.of[Schema[T]], Flags.Lazy, Symbol.noSymbol)
     val selfRef = Ref(selfRefSymbol)
     val newStack = stack.push(selfRef, TypeRepr.of[T])
 


### PR DESCRIPTION
When creating symbols, their `privateWithin` has to be a type.
When defining `zio-schema` derivation e.g.

```scala
given x: Schema[ArangoError] = DeriveSchema.gen[ArangoError]
```

`Symbol.spliceOwner` of the derivation macro was `x`. Which is not a correct value for `privateWithin`.

This property will now be enforced with https://github.com/lampepfl/dotty/pull/17352

EDIT: Also after this fix `-Xprint` should work for programs using `zio-schema` derivations.