### PR TITLE
Add `DecoderError` for unsupported schemas

### DIFF
--- a/zio-schema/shared/src/main/scala/zio/schema/codec/DecodeError.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/codec/DecodeError.scala
@@ -59,4 +59,8 @@ object DecodeError {
     def message: String = s"Value $values and $structure have incompatible shape"
   }
 
+  final case class UnsupportedSchema(schema: Schema[_], decoderName: String) extends DecodeError {
+    def message: String = s"Schema $schema is not supported by $decoderName"
+  }
+
 }


### PR DESCRIPTION
This is needed for zio-http, since we want to have a text codec, that should fail for non primitive schemas.