### PR TITLE
Fix DeriveSchema for parameterized enums

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
@@ -324,7 +324,8 @@ private case class DeriveSchema()(using val ctx: Quotes) extends ReflectionUtils
 
     val cases = typesAndLabels.map { case (tpe, label) => deriveCase[T](tpe, label, newStack) }
 
-    val isSimpleEnum: Boolean = !TypeRepr.of[T].typeSymbol.children.map(_.declaredFields.length).exists( _ > 0 )
+    val numParentFields: Int = TypeRepr.of[T].typeSymbol.declaredFields.length
+    val isSimpleEnum: Boolean = !TypeRepr.of[T].typeSymbol.children.map(_.declaredFields.length).exists( _ > numParentFields )
     val hasSimpleEnumAnn: Boolean = TypeRepr.of[T].typeSymbol.hasAnnotation(TypeRepr.of[_root_.zio.schema.annotation.simpleEnum].typeSymbol)
 
     val annotationExprs = (isSimpleEnum, hasSimpleEnumAnn) match {

--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
@@ -329,7 +329,7 @@ private case class DeriveSchema()(using val ctx: Quotes) extends ReflectionUtils
     val hasSimpleEnumAnn: Boolean = TypeRepr.of[T].typeSymbol.hasAnnotation(TypeRepr.of[_root_.zio.schema.annotation.simpleEnum].typeSymbol)
 
     val annotationExprs = (isSimpleEnum, hasSimpleEnumAnn) match {
-      case (true, false) => TypeRepr.of[T].typeSymbol.annotations.filter(filterAnnotation).map(_.asExpr).+:('{_root_.zio.schema.annotation.simpleEnum(true)})
+      case (true, false) => TypeRepr.of[T].typeSymbol.annotations.filter(filterAnnotation).map(_.asExpr).+:('{zio.schema.annotation.simpleEnum(true)})
       case (false, true) => throw new Exception(s"${TypeRepr.of[T].typeSymbol.name} must be a simple Enum")
       case _             => TypeRepr.of[T].typeSymbol.annotations.filter(filterAnnotation).map(_.asExpr)
     }

--- a/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
@@ -35,6 +35,16 @@ trait VersionSpecificDeriveSchemaSpec extends ZIOSpecDefault {
           AutoDerives.apply
         )
         assert(Schema[AutoDerives])(hasSameSchema(expected))
+      },
+      test("correctly assign simpleEnum to enum"){
+        enum Colour(val rgb: Int):
+          case Red extends Colour(0xff0000)
+          case Green extends Colour(0x00ff00)
+          case Blue extends Colour(0x0000ff)
+        
+
+        val derived = DeriveSchema.gen[Colour]
+        assertTrue(derived.annotations == Chunk(simpleEnum(true)))
       }
     )
   )

--- a/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
@@ -1,6 +1,8 @@
 package zio.schema
 
+import zio.Chunk
 import zio.test.*
+import zio.schema.annotation.simpleEnum
 
 trait VersionSpecificDeriveSchemaSpec extends ZIOSpecDefault {
   case class ContainerFields(field1: Option[String])
@@ -20,6 +22,12 @@ trait VersionSpecificDeriveSchemaSpec extends ZIOSpecDefault {
 
   final case class AutoDerives(i: Int) derives Schema
 
+  enum Colour(val rgb: Int) {
+    case Red extends Colour(0xff0000)
+    case Green extends Colour(0x00ff00)
+    case Blue extends Colour(0x0000ff)
+  }
+
   def versionSpecificSuite = Spec.labeled(
     "Scala 3 specific tests", 
     suite("Derivation")(
@@ -36,14 +44,8 @@ trait VersionSpecificDeriveSchemaSpec extends ZIOSpecDefault {
         )
         assert(Schema[AutoDerives])(hasSameSchema(expected))
       },
-      test("correctly assign simpleEnum to enum"){
-        enum Colour(val rgb: Int):
-          case Red extends Colour(0xff0000)
-          case Green extends Colour(0x00ff00)
-          case Blue extends Colour(0x0000ff)
-        
-
-        val derived = DeriveSchema.gen[Colour]
+      test("correctly assigns simpleEnum to enum") {
+        val derived: Schema[Colour] = DeriveSchema.gen[Colour]
         assertTrue(derived.annotations == Chunk(simpleEnum(true)))
       }
     )


### PR DESCRIPTION
Fixes #606. The problem was with Scala 3 parameterized "simple" enums.