### PR TITLE
Fixed decoder for enum with discriminator

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -517,7 +517,7 @@ object JsonCodec {
       case Schema.Either(left, right, _)         => ZJsonDecoder.either(schemaDecoder(left, hasDiscriminator), schemaDecoder(right, hasDiscriminator))
       case l @ Schema.Lazy(_)                    => schemaDecoder(l.schema, hasDiscriminator)
       //case Schema.Meta(_, _)                                                                           => astDecoder
-      case s @ Schema.CaseClass0(_, _, _)                                => caseClass0Decoder(s)
+      case s @ Schema.CaseClass0(_, _, _)                                => caseClass0Decoder(hasDiscriminator, s)
       case s @ Schema.CaseClass1(_, _, _, _)                             => caseClass1Decoder(hasDiscriminator, s)
       case s @ Schema.CaseClass2(_, _, _, _, _)                          => caseClass2Decoder(hasDiscriminator, s)
       case s @ Schema.CaseClass3(_, _, _, _, _, _)                       => caseClass3Decoder(hasDiscriminator, s)
@@ -833,8 +833,8 @@ object JsonCodec {
   private[codec] object ProductDecoder {
     import zio.schema.codec.JsonCodec.JsonDecoder.schemaDecoder
 
-    private[codec] def caseClass0Decoder[Z](schema: Schema.CaseClass0[Z]): ZJsonDecoder[Z] = { (trace: List[JsonError], in: RetractReader) =>
-      val _ = Codecs.unitDecoder.unsafeDecode(trace, in)
+    private[codec] def caseClass0Decoder[Z](hasDiscriminator: Boolean, schema: Schema.CaseClass0[Z]): ZJsonDecoder[Z] = { (trace: List[JsonError], in: RetractReader) =>
+      if (!hasDiscriminator) Codecs.unitDecoder.unsafeDecode(trace, in)
       schema.defaultConstruct()
     }
 

--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -243,7 +243,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
           charSequenceToByteChunk("""{"oneOf":{"_type":"StringValue2","value":"foo2"}}""")
         )
       },
-      test("case class ") {
+      test("case class") {
         assertEncodes(
           searchRequestWithTransientFieldSchema,
           SearchRequestWithTransientField("foo", 10, 20, "bar"),
@@ -1027,6 +1027,10 @@ object JsonCodecSpec extends ZIOSpecDefault {
           Enumeration2(BooleanValue2(false))
         )
       },
+      test("of case classes with discriminator") {
+        assertEncodesThenDecodes(Schema[Command], Command.Cash) &>
+          assertEncodesThenDecodes(Schema[Command], Command.Buy(100))
+      },
       suite("of case objects")(
         test("without annotation")(
           assertEncodesThenDecodes(Schema[Color], Color.Red)
@@ -1494,6 +1498,16 @@ object JsonCodecSpec extends ZIOSpecDefault {
     case object Blue extends Color
 
     implicit val schema: Schema[Color] = DeriveSchema.gen[Color]
+  }
+
+  @annotation.discriminatorName("type")
+  sealed trait Command
+
+  object Command {
+    case class Buy(credits: Int) extends Command
+    case object Cash             extends Command
+
+    implicit val schema: Schema[Command] = DeriveSchema.gen[Command]
   }
 
   case object Singleton


### PR DESCRIPTION
Fixes #609. I have checked and the problem was present in zio-schema since v0.4.0 at least. The reason is that `SchemaGen.anyEnumerationAndValue`, used to test enums, only generates enums with primitives as cases. I haven't changed that because I was unsure if there was some particular reason for it. It might be possible that other similar bugs exist and that it's better to make a more exhaustive `anyEnumerationAndValue`.