### PR TITLE
Find implicits first, before deriving any kind of schema in Scala 3

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
@@ -50,59 +50,64 @@ private case class DeriveSchema()(using val ctx: Quotes) extends ReflectionUtils
     val result = stack.find(typeRepr) match {
       case Some(ref) =>
         '{ Schema.defer(${ref.asExprOf[Schema[T]]}) }
-      case None => 
-        typeRepr.asType match {
-          case '[List[a]] =>
-            val schema = deriveSchema[a](stack)
-            '{ Schema.list(Schema.defer(${schema})) }.asExprOf[Schema[T]]
-          case '[scala.util.Either[a, b]] =>
-            val schemaA = deriveSchema[a](stack)
-            val schemaB = deriveSchema[b](stack)
-            '{ Schema.either(Schema.defer(${schemaA}), Schema.defer(${schemaB})) }.asExprOf[Schema[T]]
-          case '[Option[a]] =>
-            val schema = deriveSchema[a](stack)
-            // throw new Error(s"OPITOS ${schema.show}")
-            '{ Schema.option(Schema.defer($schema)) }.asExprOf[Schema[T]]
-          case '[scala.collection.Set[a]] =>
-            val schema = deriveSchema[a](stack)
-            '{ Schema.set(Schema.defer(${schema})) }.asExprOf[Schema[T]]
-          case '[Vector[a]] =>
-            val schema = deriveSchema[a](stack)
-            '{ Schema.vector(Schema.defer(${schema})) }.asExprOf[Schema[T]]
-          case '[scala.collection.Map[a, b]] =>
-            val schemaA = deriveSchema[a](stack)
-            val schemaB = deriveSchema[b](stack)
-            '{ Schema.map(Schema.defer(${schemaA}), Schema.defer(${schemaB})) }.asExprOf[Schema[T]]
-          case '[zio.Chunk[a]] =>
-            val schema = deriveSchema[a](stack)
-            '{ Schema.chunk(Schema.defer(${schema})) }.asExprOf[Schema[T]]
-          case _ => 
-            val summoned = if (!top) Expr.summon[Schema[T]] else None
-            summoned match {
-              case Some(schema) =>
-                // println(s"FOR TYPE ${typeRepr.show}")
-                // println(s"STACK ${stack.find(typeRepr)}")
-                // println(s"Found schema ${schema.show}")
-                schema
-              case _ =>
-                Mirror(typeRepr) match {
-                  case Some(mirror) =>
-                    mirror.mirrorType match {
-                      case MirrorType.Sum =>
-                        deriveEnum[T](mirror, stack)
-                      case MirrorType.Product =>
-                       deriveCaseClass[T](mirror, stack, top)
-                    }
-                  case None =>
-                    val sym = typeRepr.typeSymbol
-                    if (sym.isClassDef && sym.flags.is(Flags.Module)) {
-                      deriveCaseObject[T](stack, top)
-                    }
-                    else {
-                      report.errorAndAbort(s"Deriving schema for ${typeRepr.show} is not supported")
-                    }
+      case None =>
+        val summoned = Expr.summon[Schema[T]]
+        if (!top && summoned.isDefined) {
+          '{ Schema.defer(${summoned.get}) }.asExprOf[Schema[T]]
+        } else {
+          typeRepr.asType match {
+            case '[List[a]] =>
+              val schema = deriveSchema[a](stack)
+              '{ Schema.list(Schema.defer(${schema})) }.asExprOf[Schema[T]]
+            case '[scala.util.Either[a, b]] =>
+              val schemaA = deriveSchema[a](stack)
+              val schemaB = deriveSchema[b](stack)
+              '{ Schema.either(Schema.defer(${schemaA}), Schema.defer(${schemaB})) }.asExprOf[Schema[T]]
+            case '[Option[a]] =>
+              val schema = deriveSchema[a](stack)
+              // throw new Error(s"OPITOS ${schema.show}")
+              '{ Schema.option(Schema.defer($schema)) }.asExprOf[Schema[T]]
+            case '[scala.collection.Set[a]] =>
+              val schema = deriveSchema[a](stack)
+              '{ Schema.set(Schema.defer(${schema})) }.asExprOf[Schema[T]]
+            case '[Vector[a]] =>
+              val schema = deriveSchema[a](stack)
+              '{ Schema.vector(Schema.defer(${schema})) }.asExprOf[Schema[T]]
+            case '[scala.collection.Map[a, b]] =>
+              val schemaA = deriveSchema[a](stack)
+              val schemaB = deriveSchema[b](stack)
+              '{ Schema.map(Schema.defer(${schemaA}), Schema.defer(${schemaB})) }.asExprOf[Schema[T]]
+            case '[zio.Chunk[a]] =>
+              val schema = deriveSchema[a](stack)
+              '{ Schema.chunk(Schema.defer(${schema})) }.asExprOf[Schema[T]]
+            case _ =>
+              val summoned = if (!top) Expr.summon[Schema[T]] else None
+              summoned match {
+                case Some(schema) =>
+                  // println(s"FOR TYPE ${typeRepr.show}")
+                  // println(s"STACK ${stack.find(typeRepr)}")
+                  // println(s"Found schema ${schema.show}")
+                  schema
+                case _ =>
+                  Mirror(typeRepr) match {
+                    case Some(mirror) =>
+                      mirror.mirrorType match {
+                        case MirrorType.Sum =>
+                          deriveEnum[T](mirror, stack)
+                        case MirrorType.Product =>
+                          deriveCaseClass[T](mirror, stack, top)
+                      }
+                    case None =>
+                      val sym = typeRepr.typeSymbol
+                      if (sym.isClassDef && sym.flags.is(Flags.Module)) {
+                        deriveCaseObject[T](stack, top)
+                      }
+                      else {
+                        report.errorAndAbort(s"Deriving schema for ${typeRepr.show} is not supported")
+                      }
+                  }
               }
-            }
+          }
         }
     }
 

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -321,8 +321,8 @@ object DeriveSpec extends ZIOSpecDefault with VersionSpecificDeriveSpec {
 
   object GenericRecordWithDefaultValue {
     //explicitly Int, because generic implicit definition leads to "Schema derivation exceeded" error
-    implicit def schema: Schema[GenericRecordWithDefaultValue[Int]] =
-      DeriveSchema.gen[GenericRecordWithDefaultValue[Int]]
+    implicit def schema[T: Schema]: Schema[GenericRecordWithDefaultValue[T]] =
+      DeriveSchema.gen[GenericRecordWithDefaultValue[T]]
   }
 
   sealed trait Enum1

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -321,8 +321,8 @@ object DeriveSpec extends ZIOSpecDefault with VersionSpecificDeriveSpec {
 
   object GenericRecordWithDefaultValue {
     //explicitly Int, because generic implicit definition leads to "Schema derivation exceeded" error
-    implicit def schema[T: Schema]: Schema[GenericRecordWithDefaultValue[T]] =
-      DeriveSchema.gen[GenericRecordWithDefaultValue[T]]
+    implicit def schema: Schema[GenericRecordWithDefaultValue[Int]] =
+      DeriveSchema.gen[GenericRecordWithDefaultValue[Int]]
   }
 
   sealed trait Enum1


### PR DESCRIPTION
Currently, the macro for Scala 3 is ignoring self defined schemas for collections.
So if for example a `implicit val s: Schema[Map[X,Y]]` is in scope and you derive a schema for a case class that has a field of that type, the macro derives a map schema for derived X & Y schemas instead of using the implicit.
That is imho a bug, since user defined schemas should always be preferred.