### PR TITLE
feat: allow discriminator to not be the first field

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ _ZIO Schema_ is used by a growing number of ZIO libraries, including [ZIO Flow](
 In order to use this library, we need to add the following lines in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-schema"          % "0.4.15"
-libraryDependencies += "dev.zio" %% "zio-schema-avro"     % "0.4.15"
-libraryDependencies += "dev.zio" %% "zio-schema-bson"     % "0.4.15"
-libraryDependencies += "dev.zio" %% "zio-schema-json"     % "0.4.15"
-libraryDependencies += "dev.zio" %% "zio-schema-msg-pack" % "0.4.15"
-libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "0.4.15"
-libraryDependencies += "dev.zio" %% "zio-schema-thrift"   % "0.4.15"
-libraryDependencies += "dev.zio" %% "zio-schema-zio-test" % "0.4.15"
+libraryDependencies += "dev.zio" %% "zio-schema"          % "0.4.16"
+libraryDependencies += "dev.zio" %% "zio-schema-avro"     % "0.4.16"
+libraryDependencies += "dev.zio" %% "zio-schema-bson"     % "0.4.16"
+libraryDependencies += "dev.zio" %% "zio-schema-json"     % "0.4.16"
+libraryDependencies += "dev.zio" %% "zio-schema-msg-pack" % "0.4.16"
+libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "0.4.16"
+libraryDependencies += "dev.zio" %% "zio-schema-thrift"   % "0.4.16"
+libraryDependencies += "dev.zio" %% "zio-schema-zio-test" % "0.4.16"
 
 // Required for the automatic generic derivation of schemas
-libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "0.4.15"
+libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "0.4.16"
 libraryDependencies += "org.scala-lang" % "scala-reflect"  % scalaVersion.value % "provided"
 ```
 

--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -537,6 +537,20 @@ object JsonCodecSpec extends ZIOSpecDefault {
           charSequenceToByteChunk("""{"type":"onetime","amount":1000}""")
         )
       },
+      test("case name aliases - type in the middle") {
+        assertDecodes(
+          Subscription.schema,
+          Recurring("monthly", 100),
+          charSequenceToByteChunk("""{"period":"monthly","type":"recurring","amount":100}""")
+        )
+      },
+      test("case name aliases - type in the last place") {
+        assertDecodes(
+          Subscription.schema,
+          OneTime(1000),
+          charSequenceToByteChunk("""{"amount":1000, "type":"onetime"}""")
+        )
+      },
       test("case name - empty fields") {
         assertDecodes(
           Subscription.schema,


### PR DESCRIPTION
In the JSON decoder allow enum discriminators to appear in any position in an object, not just the first. 

If the discriminator comes first, the behavior is mostly unchanged: We use the discriminator to find the schema of the relevant enum case and continue parsing with this schema. In case the discriminator appears later, it is searched first, then the Lexer is rewound to the beginning of the object, and it is parsed with the schema of the relevant enum case. The discriminator is skipped over in case class parsing. 

/fixes #523