### PR TITLE
add support for transformed primitve map keys

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -10,7 +10,13 @@ import zio.json.JsonCodec._
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 import zio.json.ast.Json
 import zio.json.internal.{ Lexer, RecordingReader, RetractReader, StringMatrix, Write }
-import zio.json.{JsonCodec => ZJsonCodec, JsonDecoder => ZJsonDecoder, JsonEncoder => ZJsonEncoder, JsonFieldDecoder, JsonFieldEncoder}
+import zio.json.{
+  JsonCodec => ZJsonCodec,
+  JsonDecoder => ZJsonDecoder,
+  JsonEncoder => ZJsonEncoder,
+  JsonFieldDecoder,
+  JsonFieldEncoder
+}
 import zio.schema._
 import zio.schema.annotation._
 import zio.schema.codec.DecodeError.ReadError

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -289,12 +289,12 @@ object JsonCodec {
       schema: Schema[A],
       g: B => Either[String, A]
     ): Option[JsonFieldEncoder[B]] =
-      jsonFieldEncoder(schema).map { jsonFieldEncoder =>
+      jsonFieldEncoder(schema).map { fieldEncoder =>
         new JsonFieldEncoder[B] {
           override def unsafeEncodeField(b: B): String =
             g(b) match {
               case Left(_)  => throw new RuntimeException(s"Failed to encode field $b")
-              case Right(a) => jsonFieldEncoder.unsafeEncodeField(a)
+              case Right(a) => fieldEncoder.unsafeEncodeField(a)
             }
         }
       }


### PR DESCRIPTION
currently, defining a schema for maps with complex keys that represent simple keys is impossible. For example, consider a map defined as `Map[Key, Value]`, where `Key` is defined as `case class Key(key:String)`. When you try to define a schema like this:

```scala
schema = Schema.map(
   Schema[String].transform(Key.apply, _.key), 
   ...
)
```
to decode data that looks like this:

```json
{
     "some_key": { 
          "value": "some_value" 
     },
     "some_other_key": { 
          "value": "some_other_value"
     }
}
```

it will fail and produce an error: `"expected '[' got '{'"`. Currently, any non-primitive key (or lazy) defaults to an array representation of a key-value pair, causing the issue.

To address this issue, this PR proposes that `jsonFieldEncoder` and `jsonFieldDecoder` should also take into account the `Transform` schema type. This means it will recursively check if the internal schema is indeed a primitive codec, ensuring that the data is parsed correctly from a simple key, and applying the transformation from the key schema definition accordingly.