### PR TITLE
fix: contributor's guide broken link

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -29,8 +29,6 @@ jobs:
         check-latest: true
     - name: Check if the README file is up to date
       run: sbt  docs/checkReadme
-    - name: Check if the site workflow is up to date
-      run: sbt  docs/checkGithubWorkflow
     - name: Check artifacts build process
       run: sbt  +publishLocal
     - name: Check website build process

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [ZIO Schema](https://github.com/zio/zio-schema) is a [ZIO](https://zio.dev)-based library for modeling the schema of data structures as first-class values.
 
-[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-schema/workflows/CI/badge.svg) [![Sonatype Releases](https://img.shields.io/nexus/r/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Release)](https://oss.sonatype.org/content/repositories/releases/dev/zio/zio-schema_2.13/) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-schema_2.13/) [![javadoc](https://javadoc.io/badge2/dev.zio/zio-schema-docs_2.13/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-schema-docs_2.13) [![ZIO Schema](https://img.shields.io/github/stars/zio/zio-schema?style=social)](https://github.com/zio/zio-schema)
+[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-schema/workflows/CI/badge.svg) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-schema_2.13/) [![ZIO Schema](https://img.shields.io/github/stars/zio/zio-schema?style=social)](https://github.com/zio/zio-schema)
 
 ## Introduction
 
@@ -39,17 +39,17 @@ _ZIO Schema_ is used by a growing number of ZIO libraries, including [ZIO Flow](
 In order to use this library, we need to add the following lines in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-schema"          % "0.4.17"
-libraryDependencies += "dev.zio" %% "zio-schema-avro"     % "0.4.17"
-libraryDependencies += "dev.zio" %% "zio-schema-bson"     % "0.4.17"
-libraryDependencies += "dev.zio" %% "zio-schema-json"     % "0.4.17"
-libraryDependencies += "dev.zio" %% "zio-schema-msg-pack" % "0.4.17"
-libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "0.4.17"
-libraryDependencies += "dev.zio" %% "zio-schema-thrift"   % "0.4.17"
-libraryDependencies += "dev.zio" %% "zio-schema-zio-test" % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema"          % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-avro"     % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-bson"     % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-json"     % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-msg-pack" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-thrift"   % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-zio-test" % "<version>"
 
 // Required for the automatic generic derivation of schemas
-libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "<version>"
 libraryDependencies += "org.scala-lang" % "scala-reflect"  % scalaVersion.value % "provided"
 ```
 
@@ -106,7 +106,7 @@ Learn more on the [ZIO Schema homepage](https://zio.dev/zio-schema)!
 
 ## Contributing
 
-For the general guidelines, see ZIO [contributor's guide](https://zio.dev/about/contributing).
+For the general guidelines, see ZIO [contributor's guide](https://zio.dev/contributor-guidelines).
 #### TL;DR
 
 Before you submit a PR, make sure your tests are passing, and that the code is properly formatted
@@ -119,7 +119,7 @@ sbt test
 
 ## Code of Conduct
 
-See the [Code of Conduct](https://zio.dev/about/code-of-conduct)
+See the [Code of Conduct](https://zio.dev/code-of-conduct)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [ZIO Schema](https://github.com/zio/zio-schema) is a [ZIO](https://zio.dev)-based library for modeling the schema of data structures as first-class values.
 
-[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-schema/workflows/CI/badge.svg) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-schema_2.13/) [![ZIO Schema](https://img.shields.io/github/stars/zio/zio-schema?style=social)](https://github.com/zio/zio-schema)
+[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-schema/workflows/CI/badge.svg) [![Sonatype Releases](https://img.shields.io/nexus/r/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Release)](https://oss.sonatype.org/content/repositories/releases/dev/zio/zio-schema_2.13/) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-schema_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-schema_2.13/) [![javadoc](https://javadoc.io/badge2/dev.zio/zio-schema-docs_2.13/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-schema-docs_2.13) [![ZIO Schema](https://img.shields.io/github/stars/zio/zio-schema?style=social)](https://github.com/zio/zio-schema)
 
 ## Introduction
 
@@ -39,17 +39,17 @@ _ZIO Schema_ is used by a growing number of ZIO libraries, including [ZIO Flow](
 In order to use this library, we need to add the following lines in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-schema"          % "<version>"
-libraryDependencies += "dev.zio" %% "zio-schema-avro"     % "<version>"
-libraryDependencies += "dev.zio" %% "zio-schema-bson"     % "<version>"
-libraryDependencies += "dev.zio" %% "zio-schema-json"     % "<version>"
-libraryDependencies += "dev.zio" %% "zio-schema-msg-pack" % "<version>"
-libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "<version>"
-libraryDependencies += "dev.zio" %% "zio-schema-thrift"   % "<version>"
-libraryDependencies += "dev.zio" %% "zio-schema-zio-test" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema"          % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-avro"     % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-bson"     % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-json"     % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-msg-pack" % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-protobuf" % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-thrift"   % "0.4.17"
+libraryDependencies += "dev.zio" %% "zio-schema-zio-test" % "0.4.17"
 
 // Required for the automatic generic derivation of schemas
-libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-schema-derivation" % "0.4.17"
 libraryDependencies += "org.scala-lang" % "scala-reflect"  % scalaVersion.value % "provided"
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -442,7 +442,6 @@ lazy val docs = project
     mainModuleName := (zioSchemaJVM / moduleName).value,
     projectStage := ProjectStage.Development,
     ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(),
-    docsPublishBranch := "main",
     readmeContribution +=
       """|
          |#### TL;DR

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ addSbtPlugin("com.github.sbt"     % "sbt-ci-release"                % "1.5.12")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                       % "0.4.6")
-addSbtPlugin("dev.zio"            % "zio-sbt-website"               % "0.3.10")
+addSbtPlugin("dev.zio"            % "zio-sbt-website"               % "0.4.0")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.7"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ addSbtPlugin("com.github.sbt"     % "sbt-ci-release"                % "1.5.12")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                       % "0.4.6")
-addSbtPlugin("dev.zio"            % "zio-sbt-website"               % "0.4.0")
+addSbtPlugin("dev.zio"            % "zio-sbt-website"               % "0.4.0-alpha.22")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.7"


### PR DESCRIPTION
## Description
- Last part of `README.md` is auto generated using `zio-sbt-website` not using `index.md`
- This is common on most of the `zio` repos 
- This fix is already done in [https://github.com/zio/zio-sbt/pull/223/](https://github.com/zio/zio-sbt/pull/223/)
- Bumped `zio-sbt-website` version to `0.4.0-alpha.22` which fixes the issue
- This fixes the issue #630 and broken links in all other repos of `zio`
- If required I can raise a PR for version bump on other repos of `zio`

/claim #630

Raised a similar PR on [https://github.com/zio/zio-http/pull/2618](https://github.com/zio/zio-http/pull/2618)