### PR TITLE
Adding Fallback Schema

### DIFF
--- a/tests/shared/src/test/scala-2/zio/schema/DynamicValueGen.scala
+++ b/tests/shared/src/test/scala-2/zio/schema/DynamicValueGen.scala
@@ -79,6 +79,8 @@ object DynamicValueGen {
       case Schema.Tuple2(left, right, _)                                                                                                                                                              => anyDynamicTupleValue(left, right)
       case Schema.Either(left, right, _) =>
         Gen.oneOf(anyDynamicLeftValueOfSchema(left), anyDynamicRightValueOfSchema(right))
+      case Schema.Fallback(left, right, _, _) =>
+        Gen.oneOf(anyDynamicLeftValueOfSchema(left), anyDynamicRightValueOfSchema(right), anyDynamicBothValueOfSchema(left, right))
       case Schema.Transform(schema, _, _, _, _) => anyDynamicValueOfSchema(schema)
       case Schema.Fail(message, _)              => Gen.const(DynamicValue.Error(message))
       case l @ Schema.Lazy(_)                   => anyDynamicValueOfSchema(l.schema)
@@ -91,6 +93,11 @@ object DynamicValueGen {
 
   def anyDynamicRightValueOfSchema[A](schema: Schema[A]): Gen[Sized, DynamicValue.RightValue] =
     anyDynamicValueOfSchema(schema).map(DynamicValue.RightValue(_))
+
+  def anyDynamicBothValueOfSchema[A, B](left: Schema[A], right: Schema[A]): Gen[Sized, DynamicValue.BothValue] =
+    anyDynamicValueOfSchema(left).zip(anyDynamicValueOfSchema(right)).map {
+      case (l, r) => DynamicValue.BothValue(l, r)
+    }
 
   def anyDynamicSomeValueOfSchema[A](schema: Schema[A]): Gen[Sized, DynamicValue.SomeValue] =
     anyDynamicValueOfSchema(schema).map(DynamicValue.SomeValue(_))

--- a/zio-schema-avro/src/main/scala/zio/schema/codec/AvroSchemaCodec.scala
+++ b/zio-schema-avro/src/main/scala/zio/schema/codec/AvroSchemaCodec.scala
@@ -415,6 +415,9 @@ object AvroSchemaCodec extends AvroSchemaCodec {
           name  <- getName(e)
         } yield wrapAvro(union, name, EitherWrapper)
 
+      case Schema.Fallback(left, right, _, _) =>
+        toAvroSchema(Schema.Tuple2(Schema.Optional(left), Schema.Optional(right)))
+
       case Lazy(schema0) => toAvroSchema(schema0())
       case Dynamic(_)    => toAvroSchema(Schema[MetaSchema])
     }
@@ -784,6 +787,7 @@ object AvroSchemaCodec extends AvroSchemaCodec {
                 case _                      => Left("ZIO schema wrapped either must have exactly two cases")
               }
             case e: Schema.Either[_, _]                                                              => Right(e)
+            case f: Schema.Fallback[_, _]                                                            => Right(f)
             case c: CaseClass0[_]                                                                    => Right(c)
             case c: CaseClass1[_, _]                                                                 => Right(c)
             case c: CaseClass2[_, _, _]                                                              => Right(c)

--- a/zio-schema-derivation/shared/src/main/scala/zio/schema/CachedDeriver.scala
+++ b/zio-schema-derivation/shared/src/main/scala/zio/schema/CachedDeriver.scala
@@ -122,6 +122,7 @@ private[schema] object CachedDeriver {
     final case class WithIdentityObject[A](inner: CacheKey[_], id: Any)                         extends CacheKey[A]
     final case class Optional[A](key: CacheKey[A])                                              extends CacheKey[A]
     final case class Either[A, B](leftKey: CacheKey[A], rightKey: CacheKey[B])                  extends CacheKey[Either[A, B]]
+    final case class Fallback[A, B](leftKey: CacheKey[A], rightKey: CacheKey[B])                extends CacheKey[Fallback[A, B]]
     final case class Tuple2[A, B](leftKey: CacheKey[A], rightKey: CacheKey[B])                  extends CacheKey[(A, B)]
     final case class Set[A](element: CacheKey[A])                                               extends CacheKey[Set[A]]
     final case class Map[K, V](key: CacheKey[K], valuew: CacheKey[V])                           extends CacheKey[Map[K, V]]
@@ -144,6 +145,8 @@ private[schema] object CachedDeriver {
           Tuple2(fromSchema(tuple.left), fromSchema(tuple.right)).asInstanceOf[CacheKey[A]]
         case either: Schema.Either[_, _] =>
           Either(fromSchema(either.leftSchema), fromSchema(either.rightSchema)).asInstanceOf[CacheKey[A]]
+        case fallback: Schema.Fallback[_, _] =>
+          Fallback(fromSchema(fallback.left), fromSchema(fallback.right)).asInstanceOf[CacheKey[A]]
         case Schema.Lazy(schema0) => fromSchema(schema0())
         case Schema.Dynamic(_)    => Misc(schema)
         case Schema.Fail(_, _)    => Misc(schema)

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/package.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/package.scala
@@ -65,6 +65,7 @@ package object json {
       case DynamicValue.Tuple(left, right) => Json.Arr(Chunk(toJson(left), toJson(right)))
       case DynamicValue.LeftValue(value)   => Json.Obj("Left" -> toJson(value))
       case DynamicValue.RightValue(value)  => Json.Obj("Right" -> toJson(value))
+      case DynamicValue.BothValue(_, _)    => throw new Exception("DynamicValue.BothValue is unsupported")
       case DynamicValue.DynamicAst(_)      => throw new Exception("DynamicValue.DynamicAst is unsupported")
       case DynamicValue.Error(_)           => throw new Exception("DynamicValue.Error is unsupported")
     }

--- a/zio-schema-msg-pack/src/test/scala-2/zio/schema/codec/MessagePackCodecSpec.scala
+++ b/zio-schema-msg-pack/src/test/scala-2/zio/schema/codec/MessagePackCodecSpec.scala
@@ -25,7 +25,7 @@ object MessagePackCodecSpec extends ZIOSpecDefault {
   val objectMapper = new ObjectMapper(new MessagePackFactory())
   objectMapper.registerModule(DefaultScalaModule)
 
-  def spec: Spec[TestEnvironment with Scope, Any] = suite("ThriftCodec Spec")(
+  def spec: Spec[TestEnvironment with Scope, Any] = suite("MessagePackCodec Spec")(
     suite("Should correctly encode")(
       test("integers") {
         for {
@@ -433,6 +433,63 @@ object MessagePackCodecSpec extends ZIOSpecDefault {
           ed  <- encodeAndDecode(complexEitherSchema, eitherRight2)
           ed2 <- encodeAndDecodeNS(complexEitherSchema, eitherRight)
         } yield assert(ed)(equalTo(Chunk(eitherRight2))) && assert(ed2)(equalTo(eitherRight))
+      },
+      test("fallback left full decode") {
+        val fallback = zio.schema.Fallback.Left(9)
+        for {
+          ed  <- encodeAndDecode(fallbackSchema1, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback left non full decode") {
+        val fallback = zio.schema.Fallback.Left(9)
+        for {
+          ed  <- encodeAndDecode(fallbackSchema2, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback right full decode") {
+        val fallback = zio.schema.Fallback.Right("hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema1, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback right non full decode") {
+        val fallback = zio.schema.Fallback.Right("hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema2, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback both full decode") {
+        val fallback = zio.schema.Fallback.Both(2, "hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema1, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback both non full decode") {
+        val fallback = zio.schema.Fallback.Both(2, "hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema2, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback.simplify))) && assert(ed2)(equalTo(fallback.simplify))
+      },
+      test("fallback with product type") {
+        val fallbackLeft = zio.schema.Fallback.Left(MyRecord(150))
+        for {
+          ed  <- encodeAndDecode(complexFallbackSchema2, fallbackLeft)
+          ed2 <- encodeAndDecodeNS(complexFallbackSchema2, fallbackLeft)
+        } yield assert(ed)(equalTo(Chunk(fallbackLeft))) && assert(ed2)(equalTo(fallbackLeft))
+      },
+      test("fallback with sum type") {
+        val fallbackRight  = zio.schema.Fallback.Right(BooleanValue(true))
+        val fallbackRight2 = zio.schema.Fallback.Right(StringValue("hello"))
+        for {
+          ed  <- encodeAndDecode(complexFallbackSchema, fallbackRight2)
+          ed2 <- encodeAndDecodeNS(complexFallbackSchema, fallbackRight)
+        } yield assert(ed)(equalTo(Chunk(fallbackRight2))) && assert(ed2)(equalTo(fallbackRight))
       },
       test("optionals") {
         val value = Some(123)
@@ -901,6 +958,16 @@ object MessagePackCodecSpec extends ZIOSpecDefault {
 
   val complexEitherSchema2: Schema.Either[MyRecord, MyRecord] =
     Schema.Either(myRecord, myRecord)
+
+  val fallbackSchema1: Schema.Fallback[Int, String] = Schema.Fallback(Schema[Int], Schema[String], true)
+
+  val fallbackSchema2: Schema.Fallback[Int, String] = Schema.Fallback(Schema[Int], Schema[String], false)
+
+  val complexFallbackSchema: Schema.Fallback[Record, OneOf] =
+    Schema.Fallback(Record.schemaRecord, schemaOneOf)
+
+  val complexFallbackSchema2: Schema.Fallback[MyRecord, MyRecord] =
+    Schema.Fallback(myRecord, myRecord)
 
   case class RichProduct(stringOneOf: OneOf, basicString: BasicString, record: Record)
 

--- a/zio-schema-protobuf/shared/src/test/scala-2/zio/schema/codec/ProtobufCodecSpec.scala
+++ b/zio-schema-protobuf/shared/src/test/scala-2/zio/schema/codec/ProtobufCodecSpec.scala
@@ -496,6 +496,63 @@ object ProtobufCodecSpec extends ZIOSpecDefault {
             ed2 <- encodeAndDecodeNS(complexEitherSchema, eitherRight)
           } yield assert(ed)(equalTo(Chunk(eitherRight2))) && assert(ed2)(equalTo(eitherRight))
         },
+        test("fallback left full decode") {
+          val fallback = zio.schema.Fallback.Left(9)
+          for {
+            ed  <- encodeAndDecode(fallbackSchema1, fallback)
+            ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+          } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+        },
+        test("fallback left non full decode") {
+          val fallback = zio.schema.Fallback.Left(9)
+          for {
+            ed  <- encodeAndDecode(fallbackSchema2, fallback)
+            ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+          } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+        },
+        test("fallback right full decode") {
+          val fallback = zio.schema.Fallback.Right("hello")
+          for {
+            ed  <- encodeAndDecode(fallbackSchema1, fallback)
+            ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+          } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+        },
+        test("fallback right non full decode") {
+          val fallback = zio.schema.Fallback.Right("hello")
+          for {
+            ed  <- encodeAndDecode(fallbackSchema2, fallback)
+            ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+          } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+        },
+        test("fallback both full decode") {
+          val fallback = zio.schema.Fallback.Both(2, "hello")
+          for {
+            ed  <- encodeAndDecode(fallbackSchema1, fallback)
+            ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+          } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+        },
+        test("fallback both non full decode") {
+          val fallback = zio.schema.Fallback.Both(2, "hello")
+          for {
+            ed  <- encodeAndDecode(fallbackSchema2, fallback)
+            ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+          } yield assert(ed)(equalTo(Chunk(fallback.simplify))) && assert(ed2)(equalTo(fallback.simplify))
+        },
+        test("fallback with product type") {
+          val fallbackLeft = zio.schema.Fallback.Left(MyRecord(150))
+          for {
+            ed  <- encodeAndDecode(complexFallbackSchema2, fallbackLeft)
+            ed2 <- encodeAndDecodeNS(complexFallbackSchema2, fallbackLeft)
+          } yield assert(ed)(equalTo(Chunk(fallbackLeft))) && assert(ed2)(equalTo(fallbackLeft))
+        },
+        test("fallback with sum type") {
+          val fallbackRight  = zio.schema.Fallback.Right(BooleanValue(true))
+          val fallbackRight2 = zio.schema.Fallback.Right(StringValue("hello"))
+          for {
+            ed  <- encodeAndDecode(complexFallbackSchema, fallbackRight2)
+            ed2 <- encodeAndDecodeNS(complexFallbackSchema, fallbackRight)
+          } yield assert(ed)(equalTo(Chunk(fallbackRight2))) && assert(ed2)(equalTo(fallbackRight))
+        },
         test("optionals") {
           check(Gen.option(Gen.int(Int.MinValue, Int.MaxValue))) { value =>
             for {
@@ -998,6 +1055,16 @@ object ProtobufCodecSpec extends ZIOSpecDefault {
 
   val complexEitherSchema2: Schema.Either[MyRecord, MyRecord] =
     Schema.Either(myRecord, myRecord)
+
+  val fallbackSchema1: Schema.Fallback[Int, String] = Schema.Fallback(Schema[Int], Schema[String], true)
+
+  val fallbackSchema2: Schema.Fallback[Int, String] = Schema.Fallback(Schema[Int], Schema[String], false)
+
+  val complexFallbackSchema: Schema.Fallback[Record, OneOf] =
+    Schema.Fallback(Record.schemaRecord, schemaOneOf)
+
+  val complexFallbackSchema2: Schema.Fallback[MyRecord, MyRecord] =
+    Schema.Fallback(myRecord, myRecord)
 
   case class RichProduct(stringOneOf: OneOf, basicString: BasicString, record: Record)
 

--- a/zio-schema-thrift/src/test/scala-2/zio/schema/codec/ThriftCodecSpec.scala
+++ b/zio-schema-thrift/src/test/scala-2/zio/schema/codec/ThriftCodecSpec.scala
@@ -486,6 +486,63 @@ object ThriftCodecSpec extends ZIOSpecDefault {
           ed2 <- encodeAndDecodeNS(complexEitherSchema, eitherRight)
         } yield assert(ed)(equalTo(Chunk(eitherRight2))) && assert(ed2)(equalTo(eitherRight))
       },
+      test("fallback left full decode") {
+        val fallback = zio.schema.Fallback.Left(9)
+        for {
+          ed  <- encodeAndDecode(fallbackSchema1, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback left non full decode") {
+        val fallback = zio.schema.Fallback.Left(9)
+        for {
+          ed  <- encodeAndDecode(fallbackSchema2, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback right full decode") {
+        val fallback = zio.schema.Fallback.Right("hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema1, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback right non full decode") {
+        val fallback = zio.schema.Fallback.Right("hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema2, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback both full decode") {
+        val fallback = zio.schema.Fallback.Both(2, "hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema1, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema1, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback))) && assert(ed2)(equalTo(fallback))
+      },
+      test("fallback both non full decode") {
+        val fallback = zio.schema.Fallback.Both(2, "hello")
+        for {
+          ed  <- encodeAndDecode(fallbackSchema2, fallback)
+          ed2 <- encodeAndDecodeNS(fallbackSchema2, fallback)
+        } yield assert(ed)(equalTo(Chunk(fallback.simplify))) && assert(ed2)(equalTo(fallback.simplify))
+      },
+      test("fallback with product type") {
+        val fallbackLeft = zio.schema.Fallback.Left(MyRecord(150))
+        for {
+          ed  <- encodeAndDecode(complexFallbackSchema2, fallbackLeft)
+          ed2 <- encodeAndDecodeNS(complexFallbackSchema2, fallbackLeft)
+        } yield assert(ed)(equalTo(Chunk(fallbackLeft))) && assert(ed2)(equalTo(fallbackLeft))
+      },
+      test("fallback with sum type") {
+        val fallbackRight  = zio.schema.Fallback.Right(BooleanValue(true))
+        val fallbackRight2 = zio.schema.Fallback.Right(StringValue("hello"))
+        for {
+          ed  <- encodeAndDecode(complexFallbackSchema, fallbackRight2)
+          ed2 <- encodeAndDecodeNS(complexFallbackSchema, fallbackRight)
+        } yield assert(ed)(equalTo(Chunk(fallbackRight2))) && assert(ed2)(equalTo(fallbackRight))
+      },
       test("optionals") {
         val value = Some(123)
         for {
@@ -1027,6 +1084,16 @@ object ThriftCodecSpec extends ZIOSpecDefault {
 
   val complexEitherSchema2: Schema.Either[MyRecord, MyRecord] =
     Schema.Either(myRecord, myRecord)
+
+  val fallbackSchema1: Schema.Fallback[Int, String] = Schema.Fallback(Schema[Int], Schema[String], true)
+
+  val fallbackSchema2: Schema.Fallback[Int, String] = Schema.Fallback(Schema[Int], Schema[String], false)
+
+  val complexFallbackSchema: Schema.Fallback[Record, OneOf] =
+    Schema.Fallback(Record.schemaRecord, schemaOneOf)
+
+  val complexFallbackSchema2: Schema.Fallback[MyRecord, MyRecord] =
+    Schema.Fallback(myRecord, myRecord)
 
   case class RichProduct(stringOneOf: OneOf, basicString: BasicString, record: Record)
 

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -154,6 +154,16 @@ object DynamicValue {
         case Right(value) => DynamicValue.RightValue(value)
       }
 
+    override protected def processFallback(
+      schema: Schema.Fallback[_, _],
+      value: Fallback[DynamicValue, DynamicValue]
+    ): DynamicValue =
+      value match {
+        case Fallback.Left(value)       => DynamicValue.LeftValue(value)
+        case Fallback.Right(value)      => DynamicValue.RightValue(value)
+        case Fallback.Both(left, right) => DynamicValue.BothValue(left, right)
+      }
+
     override protected def processOption(schema: Schema.Optional[_], value: Option[DynamicValue]): DynamicValue =
       value match {
         case Some(value) => DynamicValue.SomeValue(value)
@@ -220,6 +230,8 @@ object DynamicValue {
   final case class LeftValue(value: DynamicValue) extends DynamicValue
 
   final case class RightValue(value: DynamicValue) extends DynamicValue
+
+  final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue
 
   final case class DynamicAst(ast: MetaSchema) extends DynamicValue
 

--- a/zio-schema/shared/src/main/scala/zio/schema/Fallback.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Fallback.scala
@@ -1,0 +1,63 @@
+package zio.schema
+
+/**
+ * `Fallback` represents an enriched `Either` type that can contain both a left and a right value. The left value represents the default value, that fallbacks to the right value when it is not found.
+ */
+sealed trait Fallback[+A, +B] { self =>
+
+  /**
+   * Tranform a `Fallback` into an `Either`, using the left value for `Fallback.Both`.
+   */
+  def toEither: Either[A, B] = self match {
+    case Fallback.Left(l)    => Left(l)
+    case Fallback.Right(r)   => Right(r)
+    case Fallback.Both(l, _) => Left(l)
+  }
+
+  /**
+   * Deletes the right part of `Fallback.Both` instances.
+   */
+  def simplify: Fallback[A, B] = self match {
+    case Fallback.Both(left, _) => Fallback.Left(left)
+    case other                  => other
+  }
+
+  def fold[C](fa: A => C, fb: B => C): C = self match {
+    case Fallback.Left(left)    => fa(left)
+    case Fallback.Right(right)  => fb(right)
+    case Fallback.Both(left, _) => fa(left)
+  }
+
+  def map[C](f: A => C): Fallback[C, B] = mapLeft(f)
+
+  def mapLeft[C](f: A => C): Fallback[C, B] = self match {
+    case Fallback.Left(left)        => Fallback.Left(f(left))
+    case Fallback.Right(right)      => Fallback.Right(right)
+    case Fallback.Both(left, right) => Fallback.Both(f(left), right)
+  }
+
+  def mapRight[C](f: B => C): Fallback[A, C] = self match {
+    case Fallback.Left(left)        => Fallback.Left(left)
+    case Fallback.Right(right)      => Fallback.Right(f(right))
+    case Fallback.Both(left, right) => Fallback.Both(left, f(right))
+  }
+
+  def swap: Fallback[B, A] = self match {
+    case Fallback.Left(left)        => Fallback.Right(left)
+    case Fallback.Right(right)      => Fallback.Left(right)
+    case Fallback.Both(left, right) => Fallback.Both(right, left)
+  }
+}
+
+object Fallback {
+
+  def fromEither[A, B](either: Either[A, B]): Fallback[A, B] = either match {
+    case scala.util.Left(value)  => Left(value)
+    case scala.util.Right(value) => Right(value)
+  }
+
+  final case class Left[+A, +B](left: A)           extends Fallback[A, B]
+  final case class Right[+A, +B](right: B)         extends Fallback[A, B]
+  final case class Both[+A, +B](left: A, right: B) extends Fallback[A, B]
+
+}

--- a/zio-schema/shared/src/main/scala/zio/schema/SchemaEquality.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/SchemaEquality.scala
@@ -70,6 +70,10 @@ trait SchemaEquality {
             lEither.annotations == rEither.annotations &&
               lEither.left === rEither.left &&
               lEither.right === rEither.right
+          case (lEither: Schema.Fallback[_, _], rEither: Schema.Fallback[_, _]) =>
+            lEither.annotations == rEither.annotations &&
+              lEither.left === rEither.left &&
+              lEither.right === rEither.right
           case (lLazy: Schema.Lazy[_], rLazy: Schema.Lazy[_]) =>
             if (lLazy.schema eq rLazy.schema)
               true

--- a/zio-schema/shared/src/main/scala/zio/schema/meta/AstRenderer.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/meta/AstRenderer.scala
@@ -36,6 +36,14 @@ private[schema] object AstRenderer {
         .append("\n")
         .append(Chunk(Labelled("left", left), Labelled("right", right)).map(renderField(_, INDENT_STEP)).mkString("\n"))
         .toString
+    case ExtensibleMetaSchema.Fallback(_, left, right, optional) =>
+      val buffer = new StringBuffer()
+      buffer.append(s"fallback")
+      if (optional) buffer.append("?")
+      buffer
+        .append("\n")
+        .append(Chunk(Labelled("left", left), Labelled("right", right)).map(renderField(_, INDENT_STEP)).mkString("\n"))
+        .toString
     case ExtensibleMetaSchema.ListNode(items, _, optional) =>
       val buffer = new StringBuffer()
       buffer.append(s"list")
@@ -98,6 +106,18 @@ private[schema] object AstRenderer {
       case ExtensibleMetaSchema.Either(_, left, right, optional) =>
         pad(buffer, indent)
         buffer.append(s"${labelled.label}: either")
+        if (optional) buffer.append("?")
+        buffer
+          .append("\n")
+          .append(
+            Chunk(Labelled("left", left), Labelled("right", right))
+              .map(renderField(_, indent + INDENT_STEP))
+              .mkString("\n")
+          )
+          .toString
+      case ExtensibleMetaSchema.Fallback(_, left, right, optional) =>
+        pad(buffer, indent)
+        buffer.append(s"${labelled.label}: fallback")
         if (optional) buffer.append("?")
         buffer
           .append("\n")


### PR DESCRIPTION
/claim #584

Added a new `Schema.Fallback[A, B]` for a new sealed trait `Fallback[A, B]` with subclasses `Left`, `Right` and `Both`. The idea is to allow not only to decode from fallback semantics but to encode to them using just one schema.

The property `fullDecode: Boolean` in `Schema.Fallback` allows to completely retrieve a `Fallback` or to retrieve only the `Left` part from a `Fallback.Both`. So:

```
// with fullDecode = true
"""[3, "hello"]""" // decodes Fallback.Both(3, "hello")

// with fullDecode = false
"""[3, "hello"]""" // decodes Fallback.Left(3)
```

If it's not possible to decode the left member, it reads the right one:
```
// with a Schema.Fallback[Int, String]
"""["wrong", "right"]""" // decodes Fallback.Right("right")
```

(P.D. It seems like #588 is not possible to claim anymore)