### PR TITLE
Correctly encode and decode wrapper for Avro Union

### DIFF
--- a/zio-schema-avro/src/main/scala/zio/schema/codec/AvroCodec.scala
+++ b/zio-schema-avro/src/main/scala/zio/schema/codec/AvroCodec.scala
@@ -472,9 +472,10 @@ object AvroCodec {
 
   private def decodeEitherValue[A, B](value: Any, schemaLeft: Schema[A], schemaRight: Schema[B]) = {
     val record = value.asInstanceOf[GenericRecord]
-    val result = decodeValue(record.get("value"), schemaLeft)
+    val v      = record.get("value")
+    val result = decodeInWrapper(schemaLeft, v)
     if (result.isRight) result.map(Left(_))
-    else decodeValue(record.get("value"), schemaRight).map(Right(_))
+    else decodeInWrapper(schemaRight, v).map(Right(_))
   }
 
   private def decodeFallbackValue[A, B](value: Any, schema: Schema.Fallback[A, B]) = {
@@ -505,9 +506,14 @@ object AvroCodec {
     }
   }
 
+  private def decodeInWrapper[A](schema: Schema[A], value: Any) =
+    if (isUnion(schema)) {
+      decodeValue(value.asInstanceOf[GenericData.Record].get("value"), schema)
+    } else decodeValue(value, schema)
+
   private def decodeOptionalValue[A](value: Any, schema: Schema[A]) =
     if (value == null) Right(None)
-    else decodeValue(value, schema).map(Some(_))
+    else decodeInWrapper(schema, value).map(Some(_))
 
   private def encodeValue[A](a: A, schema: Schema[A]): Any = schema match {
     case Schema.Enum1(_, c1, _)                     => encodeEnum(schema, a, c1)
@@ -956,8 +962,28 @@ object AvroCodec {
 
   }
 
+  private def encodeUnionWrapper[A](schema: Schema[A], value: Any): Any =
+    if (isUnion(schema)) {
+      val s = AvroSchemaCodec
+        .encodeToApacheAvro(schema)
+        .getOrElse(throw new Exception("Avro schema could not be generated for Optional."))
+      val name = AvroSchemaCodec
+        .getName(schema)
+        .getOrElse(throw new Exception("Avro schema could not be generated for Optional."))
+      val record = new GenericRecordBuilder(
+        AvroSchemaCodec.wrapAvro(s, name, AvroPropMarker.UnionWrapper)
+      )
+      record.set("value", value)
+      record.build()
+    } else value
+
   private def encodeOption[A](schema: Schema[A], v: Option[A]): Any =
-    v.map(encodeValue(_, schema)).orNull
+    v.map { value =>
+      val a = encodeValue(value, schema)
+
+      // if `schema` is converted to an Avro Union, then it is wrapped.
+      encodeUnionWrapper(schema, a)
+    }.orNull
 
   private def encodeEither[A, B](left: Schema[A], right: Schema[B], either: scala.util.Either[A, B]): Any = {
     val schema = AvroSchemaCodec
@@ -966,8 +992,8 @@ object AvroCodec {
 
     val record = new GenericRecordBuilder(schema)
     val result = either match {
-      case Left(a)  => record.set("value", encodeValue(a, left))
-      case Right(b) => record.set("value", encodeValue(b, right))
+      case Left(a)  => record.set("value", encodeUnionWrapper(left, encodeValue(a, left)))
+      case Right(b) => record.set("value", encodeUnionWrapper(right, encodeValue(b, right)))
     }
 
     result.build()
@@ -1040,12 +1066,36 @@ object AvroCodec {
         GenericData.get.createEnum(schema.getEnumSymbols.get(fieldIndex), schema)
       } else {
 
-        encodeValue(subtypeCase.deconstruct(value), subtypeCase.schema.asInstanceOf[Schema[Any]])
+        // must check if it's wrapped
+        val caseSchema = subtypeCase.schema.asInstanceOf[Schema[Any]]
+        val v          = encodeValue(subtypeCase.deconstruct(value), caseSchema)
+        encodeUnionWrapper(caseSchema, v)
 
       }
     } else {
       throw new Exception("Could not find matching case for enum value.")
     }
   }
+
+  /**
+   * Returns `true` if the corresponding AvroSchema is an union.
+   */
+  private def isUnion[A](schema: Schema[A]): Boolean =
+    schema match {
+      case _: Schema.Optional[_] => true
+      case enu: Schema.Enum[_] => {
+        val avroEnumAnnotationExists = AvroSchemaCodec.hasAvroEnumAnnotation(enu.annotations)
+        val isAvroEnumEquivalent = enu.cases.map(_.schema).forall {
+          case (Schema.Transform(Schema.Primitive(standardType, _), _, _, _, _))
+              if standardType == StandardType.UnitType && avroEnumAnnotationExists =>
+            true
+          case (Schema.Primitive(standardType, _)) if standardType == StandardType.StringType => true
+          case (Schema.CaseClass0(_, _, _)) if avroEnumAnnotationExists                       => true
+          case _                                                                              => false
+        }
+        !isAvroEnumEquivalent
+      }
+      case _ => false
+    }
 
 }

--- a/zio-schema-avro/src/test/scala-2/zio/schema/codec/AvroCodecSpec.scala
+++ b/zio-schema-avro/src/test/scala-2/zio/schema/codec/AvroCodecSpec.scala
@@ -289,6 +289,11 @@ object AvroCodecSpec extends ZIOSpecDefault {
       val codec = AvroCodec.schemaBasedBinaryCodec[Chunk[Option[Int]]]
       val bytes = codec.encode(Chunk(Some(42), Some(53), None, Some(64)))
       assertTrue(bytes.length == 10)
+    },
+    test("Encode Option[Option[Int]]") {
+      val codec = AvroCodec.schemaBasedBinaryCodec[Option[Option[Int]]]
+      val bytes = codec.encode(Some(Some(42)))
+      assertTrue(bytes.length == 3)
     }
   )
 
@@ -307,6 +312,11 @@ object AvroCodecSpec extends ZIOSpecDefault {
       val codec = AvroCodec.schemaBasedBinaryCodec[Either[List[String], Int]]
       val bytes = codec.encode(Left(List("John", "Adam", "Daniel")))
       assertTrue(bytes.length == 20)
+    },
+    test("Encode Either[String, Option[Int]]") {
+      val codec = AvroCodec.schemaBasedBinaryCodec[Either[String, Option[Int]]]
+      val bytes = codec.encode(Right(Some(42)))
+      assertTrue(bytes.length == 3)
     }
   )
 
@@ -592,6 +602,26 @@ object AvroCodecSpec extends ZIOSpecDefault {
       val bytes  = codec.encode(Some(42))
       val result = codec.decode(bytes)
       assertTrue(result == Right(Some(42)))
+    },
+    test("Decode Option[Option[_]]") {
+      val codec  = AvroCodec.schemaBasedBinaryCodec[Option[Option[Int]]]
+      val bytes  = codec.encode(Some(Some(42)))
+      val result = codec.decode(bytes)
+      assertTrue(result == Right(Some(Some(42))))
+    },
+    test("Decode Option[Enum]") {
+      sealed trait Enum
+
+      object Enum {
+        case class Case1() extends Enum
+        case class Case2() extends Enum
+        implicit val schemaEnum: Schema[Enum] = DeriveSchema.gen[Enum]
+      }
+
+      val codec  = AvroCodec.schemaBasedBinaryCodec[Option[Enum]]
+      val bytes  = codec.encode(Some(Enum.Case1()))
+      val result = codec.decode(bytes)
+      assertTrue(result == Right(Some(Enum.Case1())))
     }
   )
 
@@ -607,6 +637,12 @@ object AvroCodecSpec extends ZIOSpecDefault {
       val bytes  = codec.encode(Left(List("John", "Adam", "Daniel")))
       val result = codec.decode(bytes)
       assertTrue(result == Right(Left(List("John", "Adam", "Daniel"))))
+    },
+    test("Decode Either[String, Option[Int]]") {
+      val codec  = AvroCodec.schemaBasedBinaryCodec[Either[String, Option[Int]]]
+      val bytes  = codec.encode(Right(Some(42)))
+      val result = codec.decode(bytes)
+      assertTrue(result == Right(Right(Some(42))))
     }
   )
 


### PR DESCRIPTION
/claim #608

The problem was that a `Schema` corresponding to an Avro Union will get wrapped in an Avro Record to avoid two nested Avro Unions. So this should fix the problem for the cases when `Optional`, `Either` or `Enum` is wrapping one another (and further nesting).

Also, I think that the test suite for the Avro codec need further work. Changing the current test suite to cover all cases using generators, like in the other codecs, might uncover some bugs.