### PR TITLE
Make possible to create factory methods for Deriver API

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Derive.scala
+++ b/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Derive.scala
@@ -372,9 +372,8 @@ object Derive {
             q"""$deriver.deriveUnknown[$tpe]($summoned)"""
       }
 
-    val tree = recurse(weakTypeOf[A], schema.tree, List.empty[Frame[c.type]], top = true)
-    //println(tree)
-    tree
+    recurse(weakTypeOf[A], schema.tree, List.empty[Frame[c.type]], top = true)
+
   }
 
   final case class Frame[C <: whitebox.Context](ctx: C, ref: String, tpe: C#Type)

--- a/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Factory.scala
+++ b/zio-schema-derivation/shared/src/main/scala-2/zio/schema/Factory.scala
@@ -1,0 +1,37 @@
+package zio.schema
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+/**
+ * Useful to create factory methods.
+ *
+ * import Factory._
+ * def createSomeTrait[A: Factory](deriver: Deriver[SomeTrait])(implicit schema: Schema[A]): SomeTrait[A] =
+ *    implicitly[Factory[A]].derive[SomeTrait](deriver)
+ *
+ */
+trait Factory[A] {
+  def derive[F[_]](deriver: Deriver[F])(implicit schema: Schema[A]): F[A]
+}
+
+object Factory {
+
+  implicit def factory[A]: Factory[A] = macro factoryImpl[A]
+
+  def factoryImpl[A: c.WeakTypeTag](
+    c: whitebox.Context
+  ): c.Tree = {
+    import c.universe._
+
+    val tpeA = weakTypeOf[A]
+
+    q"""
+        new Factory[$tpeA] {
+            override def derive[F[_]](deriver: Deriver[F])(implicit schema: Schema[$tpeA]): F[$tpeA] = Derive.derive[F, $tpeA](deriver)
+                
+        }
+    
+    """
+  }
+}

--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/Derive.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/Derive.scala
@@ -8,6 +8,7 @@ import zio.Chunk
 import Schema._
 
 object Derive {
+
   inline def derive[F[_], A](deriver: Deriver[F])(implicit schema: Schema[A]): F[A] = ${ deriveInstance[F, A]('deriver, 'schema) }
 
   private def deriveInstance[F[_]: Type, A: Type](deriver: Expr[Deriver[F]], schema: Expr[Schema[A]])(using ctx: Quotes): Expr[F[A]] =

--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/Factory.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/Factory.scala
@@ -1,0 +1,20 @@
+package zio.schema
+
+/**
+ * Useful to create factory methods.
+ * 
+ * import Factory._
+ * def createSomeTrait[A: Factory](deriver: Deriver[SomeTrait])(implicit schema: Schema[A]): SomeTrait[A] = 
+ *    implicitly[Factory[A]].derive[SomeTrait](deriver)
+ * 
+ */
+trait Factory[A] {
+  def derive[F[_]](deriver: Deriver[F])(implicit schema: Schema[A]): F[A]
+}
+
+object Factory {
+
+  inline implicit def factory[A]: Factory[A] = new Factory[A] {
+    override def derive[F[_]](deriver: Deriver[F])(implicit schema: Schema[A]): F[A] = Derive.derive[F, A](deriver)(schema)
+  }
+}

--- a/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala/zio/schema/DeriveSpec.scala
@@ -204,6 +204,19 @@ import zio.{ Chunk, Scope }
           )
         }
       ),
+      suite("support factory")(
+        test("factory") {
+          import zio.schema.Factory
+          import zio.schema.Factory._
+          def createSomeTrait[A: Factory](deriver: Deriver[TC])(implicit schema: Schema[A]): TC[A] =
+            implicitly[Factory[A]].derive[TC](deriver)
+
+          implicit val im: Factory[Enum1] = factory[Enum1]
+
+          val tc = createSomeTrait[Enum1](deriver)
+          assertTrue(tc.isDerived == true)
+        }
+      ),
       versionSpecificSuite
     )
 


### PR DESCRIPTION
When calling a macro with a generic type parameter from a method with another generic type parameter, the macro is evaluated with the generic type instead of waiting until a concrete type is used.  This raises a compile error in Scala 2:
```
def factory[A](deriver: Deriver[TC])(implicit schema: Schema[A]): TC[A] =
  Derive.derive[TC](deriver)
```
In Scala 3 this can be avoided using `inline`.

Adding a typeclass `Factory` allows to implement a factory method without having to create a macro calling `deriveImpl` in Scala 2.