### PR TITLE
Fix the json decoder for case classes that only have `None` fields.

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1341,7 +1341,7 @@ object JsonCodec {
 
       if (discriminator == -1) {
         Lexer.char(trace, in, '{')
-        loop(0, in)
+        if (Lexer.firstField(trace, in)) loop(0, in)
       } else if (discriminator == -2) {
         if (Lexer.nextField(trace, in)) loop(0, in)
       } else {

--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -1096,6 +1096,9 @@ object JsonCodecSpec extends ZIOSpecDefault {
       },
       test("object") {
         assertEncodesThenDecodes(schemaObject, Singleton)
+      },
+      test("all optional fields empty") {
+        assertEncodesThenDecodes(AllOptionalFields.schema, AllOptionalFields(None, None, None))
       }
     ),
     suite("record")(
@@ -1802,5 +1805,15 @@ object JsonCodecSpec extends ZIOSpecDefault {
   object MapOfComplexKeysAndValues {
     implicit lazy val mapSchema: Schema[Map[KeyWrapper, ValueWrapper]] = Schema.map[KeyWrapper, ValueWrapper]
     implicit lazy val schema: Schema[MapOfComplexKeysAndValues]        = DeriveSchema.gen[MapOfComplexKeysAndValues]
+  }
+
+  final case class AllOptionalFields(
+    name: Option[String],
+    mode: Option[Int],
+    active: Option[Boolean]
+  )
+
+  object AllOptionalFields {
+    implicit lazy val schema: Schema[AllOptionalFields] = DeriveSchema.gen[AllOptionalFields]
   }
 }


### PR DESCRIPTION
Fixes #661 