### PR TITLE
Deprecation of Checking the Updated Readme

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,8 +27,6 @@ jobs:
         distribution: temurin
         java-version: 17
         check-latest: true
-    - name: Check if the README file is up to date
-      run: sbt  docs/checkReadme
     - name: Check artifacts build process
       run: sbt  +publishLocal
     - name: Check website build process


### PR DESCRIPTION
Checking the readme on a pull request is deprecated a long time ago. Instead, we have to update ci to have autogenerated ci
This PR is the first step to fix [this](https://github.com/zio/zio-schema/issues/679) issue.