### PR TITLE
update the codec for big decimal (#663)

### DIFF
--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -412,7 +412,7 @@ object BsonSchemaCodec {
         case StandardType.BinaryType     => BsonCodec.byteIterable[Chunk].asInstanceOf[BsonCodec[A]]
         case StandardType.CharType       => BsonCodec.char.asInstanceOf[BsonCodec[A]]
         case StandardType.BigIntegerType => BsonCodec.bigInteger.asInstanceOf[BsonCodec[A]]
-        case StandardType.BigDecimalType => BsonCodec.bigDecimal.asInstanceOf[BsonCodec[A]]
+        case StandardType.BigDecimalType => BsonCodec.javaBigDecimal.asInstanceOf[BsonCodec[A]]
         case StandardType.UUIDType       => BsonCodec.uuid.asInstanceOf[BsonCodec[A]]
         case StandardType.DayOfWeekType =>
           BsonCodec.dayOfWeek.asInstanceOf[BsonCodec[A]] // BsonCodec[java.time.DayOfWeek]


### PR DESCRIPTION
Refer:
 ```
import java.math.{BigDecimal => JBigDecimal, BigInteger
  
implicit val javaBigDecimal: BsonCodec[JBigDecimal] =
    BsonCodec(BsonEncoder.javaBigDecimal, BsonDecoder.java
```
[Code Link](https://github.com/zio/zio-bson/blob/41281e46f801e89acb353949e2d0bacd26e1e2ef/zio-bson/src/main/scala/zio/bson/BsonCodec.scala#L80)

/claim #663 
Closes #663 