### PR TITLE
Add implementation of hashCode method for Dynamic Value along with the corresponding test

### DIFF
--- a/tests/shared/src/test/scala-2/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala-2/zio/schema/DynamicValueSpec.scala
@@ -100,6 +100,14 @@ object DynamicValueSpec extends ZIOSpecDefault {
             assertTrue(json2 == Right(json))
           }
         } @@ TestAspect.size(250) @@ TestAspect.ignore
+      ),
+      suite("hashCode consistency")(
+        test("hashCode does not change across runs") {
+          val primitive1 = DynamicValue.Primitive(123, StandardType.IntType)
+          val hash1      = primitive1.hashCode()
+          val hash2      = primitive1.hashCode()
+          assert(hash1)(equalTo(hash2))
+        }
       )
     )
 

--- a/tests/shared/src/test/scala-2/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala-2/zio/schema/DynamicValueSpec.scala
@@ -102,7 +102,7 @@ object DynamicValueSpec extends ZIOSpecDefault {
         } @@ TestAspect.size(250) @@ TestAspect.ignore
       ),
       suite("hashCode consistency")(
-        test("hashCode does not change across runs") {
+        test("hashCode does not change") {
           val primitive1 = DynamicValue.Primitive(123, StandardType.IntType)
           val hash1      = primitive1.hashCode()
           val hash2      = primitive1.hashCode()

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -118,6 +118,22 @@ sealed trait DynamicValue {
       case _ =>
         Left(DecodeError.CastError(self, schema))
     }
+  override def hashCode(): Int = this match {
+    case DynamicValue.Primitive(value, standardType) => 31 * value.hashCode() + standardType.hashCode()
+    case DynamicValue.Record(id, values)             => 31 * id.hashCode() + values.hashCode()
+    case DynamicValue.Enumeration(id, value)         => 31 * id.hashCode() + value.hashCode()
+    case DynamicValue.Sequence(values)               => values.hashCode()
+    case DynamicValue.Dictionary(entries)            => entries.hashCode()
+    case DynamicValue.SetValue(values)               => values.hashCode()
+    case DynamicValue.SomeValue(value)               => value.hashCode()
+    case DynamicValue.NoneValue                      => 0
+    case DynamicValue.Tuple(left, right)             => 31 * left.hashCode() + right.hashCode()
+    case DynamicValue.LeftValue(value)               => value.hashCode()
+    case DynamicValue.RightValue(value)              => value.hashCode()
+    case DynamicValue.BothValue(left, right)         => 31 * left.hashCode() + right.hashCode()
+    case DynamicValue.DynamicAst(ast)                => ast.hashCode()
+    case DynamicValue.Error(message)                 => message.hashCode()
+  }
 
 }
 


### PR DESCRIPTION
/claim #655
In order to resolve the issue of incosistent `hashCode` values for DynamicValue objects, I have added an implementation of the `hashCode` method for the `DynamicValue` class. I have also added a test to ensure that the `hashCode` values are consistent. Thanks!
