### PR TITLE
Not adding `simpleEnum` annotation when it's implemented as a case class

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
@@ -360,7 +360,9 @@ private case class DeriveSchema()(using val ctx: Quotes) {
     val cases = typesAndLabels.map { case (tpe, label) => deriveCase[T](tpe, label, newStack) }
 
     val numParentFields: Int = TypeRepr.of[T].typeSymbol.declaredFields.length
-    val isSimpleEnum: Boolean = !TypeRepr.of[T].typeSymbol.children.map(_.declaredFields.length).exists( _ > numParentFields )
+    val childrenFields = TypeRepr.of[T].typeSymbol.children.map(_.declaredFields.length)
+    val childrenFieldsConstructor = TypeRepr.of[T].typeSymbol.children.map(_.caseFields.length)
+    val isSimpleEnum: Boolean = childrenFieldsConstructor.forall( _ == 0) && childrenFields.forall( _ <= numParentFields)
     val hasSimpleEnumAnn: Boolean = TypeRepr.of[T].typeSymbol.hasAnnotation(TypeRepr.of[_root_.zio.schema.annotation.simpleEnum].typeSymbol)
 
     val docAnnotationExpr = TypeRepr.of[T].typeSymbol.docstring.map { docstring =>

--- a/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
+++ b/zio-schema-derivation/shared/src/test/scala-3/zio/schema/VersionSpecificDeriveSchemaSpec.scala
@@ -48,6 +48,23 @@ trait VersionSpecificDeriveSchemaSpec extends ZIOSpecDefault {
     @description("Red")
     case Red
 
+  enum NonSimpleEnum1:
+    case A(a: Int)
+
+  enum NonSimpleEnum2(a: Int):
+    case A(b: Int) extends NonSimpleEnum2(0)
+
+
+  enum NonSimpleEnum3(a: Int):
+    case A(b: Int) extends NonSimpleEnum3(b)
+
+  enum NonSimpleEnum4(val a: Int):
+    case A(override val a: Int) extends NonSimpleEnum4(a)
+
+  enum NonSimpleEnum5(a: Int, b: String):
+    case A extends NonSimpleEnum5(0, "")
+    case B(n: Int) extends NonSimpleEnum5(n, "")
+
   def versionSpecificSuite = Spec.labeled(
     "Scala 3 specific tests",
     suite("Derivation")(
@@ -67,6 +84,18 @@ trait VersionSpecificDeriveSchemaSpec extends ZIOSpecDefault {
       test("correctly assigns simpleEnum to enum") {
         val derived: Schema[Colour] = DeriveSchema.gen[Colour]
         assertTrue(derived.annotations == Chunk(simpleEnum(true)))
+      },
+      test("doesn't assigns simpleEnum to non-simple enum") {
+        val derived1: Schema[NonSimpleEnum1] = DeriveSchema.gen[NonSimpleEnum1]
+        val derived2: Schema[NonSimpleEnum2] = DeriveSchema.gen[NonSimpleEnum2]
+        val derived3: Schema[NonSimpleEnum3] = DeriveSchema.gen[NonSimpleEnum3]
+        val derived4: Schema[NonSimpleEnum4] = DeriveSchema.gen[NonSimpleEnum4]
+        val derived5: Schema[NonSimpleEnum5] = DeriveSchema.gen[NonSimpleEnum5]
+        assertTrue(derived1.annotations.isEmpty) &&
+        assertTrue(derived2.annotations.isEmpty) &&
+        assertTrue(derived3.annotations.isEmpty) &&
+        assertTrue(derived4.annotations.isEmpty) &&
+        assertTrue(derived5.annotations.isEmpty)
       },
       test("derive different annotations for parent and child in enum") {
         val parent = DeriveSchema.gen[ColourAnnotations]


### PR DESCRIPTION
The schemas created by @anqit had a `simpleEnum` annotation added automatically when they were not simple enumerations. This is because the cases of `enums` that have a constructor with parameters are implemented differently 
(as case classes) so they need to be treated separately. The example should work now. 
fixes #697 
/claim #697