### PR TITLE
Fix JSON decoding of empty objects

### DIFF
--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -1607,6 +1607,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
   }
 
   @rejectExtraFields final case class CaseClass0WithRejectExtraFields()
+
   object CaseClass0WithRejectExtraFields {
     val schema: Schema[CaseClass0WithRejectExtraFields] = DeriveSchema.gen[CaseClass0WithRejectExtraFields]
   }

--- a/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-2/zio/schema/codec/JsonCodecSpec.scala
@@ -526,7 +526,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
           JsonError.Message("extra field") :: Nil
         ) &>
           assertDecodesToError(
-            CaseClass0WithRejectExtraFields.schema,
+            schemaObject.annotate(rejectExtraFields()),
             """{"extraField":10}""",
             JsonError.Message("extra field") :: Nil
           )
@@ -1604,12 +1604,6 @@ object JsonCodecSpec extends ZIOSpecDefault {
       DeriveJsonEncoder.gen[PersonWithRejectExtraFields]
 
     val schema: Schema[PersonWithRejectExtraFields] = DeriveSchema.gen[PersonWithRejectExtraFields]
-  }
-
-  @rejectExtraFields final case class CaseClass0WithRejectExtraFields()
-
-  object CaseClass0WithRejectExtraFields {
-    val schema: Schema[CaseClass0WithRejectExtraFields] = DeriveSchema.gen[CaseClass0WithRejectExtraFields]
   }
 
   case class FieldDefaultValueSearchRequest(

--- a/zio-schema-json/shared/src/test/scala-3/zio/schema/codec/DefaultValueSpec.scala
+++ b/zio-schema-json/shared/src/test/scala-3/zio/schema/codec/DefaultValueSpec.scala
@@ -12,7 +12,7 @@ object DefaultValueSpec extends ZIOSpecDefault {
 
   def spec: Spec[TestEnvironment, Any] =
     suite("Custom Spec")(
-      customSuite,
+      customSuite
     ) @@ timeout(90.seconds)
 
   private val customSuite = suite("custom")(
@@ -24,7 +24,7 @@ object DefaultValueSpec extends ZIOSpecDefault {
     )
   )
 
-  case class WithDefaultValue(orderId:Int, description: String = "desc")
+  case class WithDefaultValue(orderId: Int, description: String = "desc")
 
   object WithDefaultValue {
     implicit lazy val schema: Schema[WithDefaultValue] = DeriveSchema.gen[WithDefaultValue]


### PR DESCRIPTION
This PR fixes the decoding failure of discriminated case objects.

### Example

```scala
@discriminatorName("type")
enum Foo derives Schema:
  case Bar(b: Int)
  case Baz

JsonCodec.jsonDecoder(Schema[Foo]).decodeJson("""{ "type": "Baz" }""")
```

It also makes case object decoding respect `@rejectExtraFields`. 

However, currently `@rejectExtraFields` can be applied only to the leaf nodes of ADTs, not the sealed trait/enum itself. To fix this, we need to propagate the parent schema to every caseClassN decoder, but it's out of the scope of this PR. (#700)