### PR TITLE
Update zio and reactivate native multi threading (#720)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
         jvm: ${{ matrix.java }}
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
-    - name: Install libuv
+    - name: Install Bohem GC
       if: matrix.platform == 'Native'
-      run: sudo apt-get update && sudo apt-get install -y libuv1-dev
+      run: sudo apt-get update && sudo apt-get install -y libgc-dev
     - name: Run tests
       run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -6,6 +6,7 @@ import BuildInfoKeys.*
 import scalafix.sbt.ScalafixPlugin.autoImport.*
 import scalanativecrossproject.NativePlatform
 
+import scala.scalanative.build.{ GC, Mode }
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.nativeConfig
 
 object BuildHelper {
@@ -27,7 +28,7 @@ object BuildHelper {
   val Scala213: String = versions("2.13")
   val Scala3: String   = versions("3.3")
 
-  val zioVersion                   = "2.1.7"
+  val zioVersion                   = "2.1.9"
   val zioJsonVersion               = "0.7.2"
   val zioPreludeVersion            = "1.0.0-RC28"
   val zioOpticsVersion             = "0.2.2"
@@ -188,7 +189,18 @@ object BuildHelper {
         baseDirectory.value
       )
     },
-    nativeConfig ~= { _.withMultithreading(false) }
+    nativeConfig ~= { cfg =>
+      val os = System.getProperty("os.name").toLowerCase
+      // For some unknown reason, we can't run the test suites in debug mode on MacOS
+      if (os.contains("mac")) cfg.withMode(Mode.releaseFast)
+      else cfg.withGC(GC.boehm) // See https://github.com/scala-native/scala-native/issues/4032
+    },
+    scalacOptions += {
+      if (crossProjectPlatform.value == NativePlatform)
+        "-P:scalanative:genStaticForwardersForNonTopLevelObjects"
+      else ""
+    },
+    Test / fork := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
   )
 
   def buildInfoSettings(packageName: String) = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"                 % "0.11.0")
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"                % "1.5.12")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.3")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                       % "0.4.6")
 addSbtPlugin("dev.zio"            % "zio-sbt-website"               % "0.4.0-alpha.22")
 


### PR DESCRIPTION
The issue with the native pipeline was zio. After updating to 0.5.x multithreading made problems and was deactivated in zio. But it had to be deactivated in schema too. Which I did [here](https://github.com/zio/zio-schema/pull/726/files#diff-dd3701b993fcc974a9a6d017159aac00d4b41bcd05ad319815c6001311c669d5).

This PR updates to the newest zio version and reenables multithreading, since latest zio supports it.

fixes #720
/claim #720