### PR TITLE
Schema.Primitive respects default annotation for defaultValue (#715)

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DefaultValueSpec.scala
@@ -300,6 +300,11 @@ object DefaultValueSpec extends ZIOSpecDefault {
         val rightSchema = Schema.either(Schema.fail("Nothing"), Schema.primitive(StandardType.StringType))
         assert(rightSchema.defaultValue)(isRight(isRight(equalTo(""))))
       }
-    )
+    ),
+    suite("default from annotation") {
+      test("default value from annotation") {
+        assert(Schema[String].default("default").defaultValue)(isRight(equalTo("default")))
+      }
+    }
   )
 }


### PR DESCRIPTION
Add Schema.defaultValue to set default of a schema

fixes #715
/claim #715