### PR TITLE
feat: upgrade scala native to latest and enable multithreading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
         jvm: ${{ matrix.java }}
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
-    - name: Install libuv
+    - name: Install Bohem GC
       if: matrix.platform == 'Native'
-      run: sudo apt-get update && sudo apt-get install -y libuv1-dev
+      run: sudo apt-get update && sudo apt-get install -y libgc-dev
     - name: Run tests
       run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
 

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,6 @@ lazy val zioSchemaMacros = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(macroDefinitionSettings)
   .nativeSettings(Test / fork := false)
   .nativeSettings(
-    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -158,7 +157,6 @@ lazy val zioSchema = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
-    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -214,7 +212,6 @@ lazy val zioSchemaDerivation = crossProject(JSPlatform, JVMPlatform, NativePlatf
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
-    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -244,7 +241,6 @@ lazy val zioSchemaJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
-    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -272,7 +268,6 @@ lazy val zioSchemaProtobuf = crossProject(JSPlatform, JVMPlatform, NativePlatfor
   .settings(buildInfoSettings("zio.schema.protobuf"))
   .nativeSettings(Test / fork := false)
   .nativeSettings(
-    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -364,7 +359,6 @@ lazy val zioSchemaOptics = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
-    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -395,7 +389,6 @@ lazy val zioSchemaExamples = crossProject(JSPlatform, JVMPlatform, NativePlatfor
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
-    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import sbtcrossproject.CrossPlugin.autoImport._
-import BuildHelper.{ crossProjectSettings, _ }
+import BuildHelper.*
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
@@ -113,6 +113,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.schema"))
   .settings(testDeps)
+  .nativeSettings(nativeSettings)
 
 lazy val testsJS = tests.js
   .settings(scalaJSUseMainModuleInitializer := true)
@@ -126,6 +127,7 @@ lazy val zioSchemaMacros = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(buildInfoSettings("zio.schema"))
   .settings(macroDefinitionSettings)
   .nativeSettings(Test / fork := false)
+  .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
@@ -156,6 +158,7 @@ lazy val zioSchema = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     )
   )
   .nativeSettings(Test / fork := false)
+  .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
@@ -211,6 +214,7 @@ lazy val zioSchemaDerivation = crossProject(JSPlatform, JVMPlatform, NativePlatf
     }
   )
   .nativeSettings(Test / fork := false)
+  .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
@@ -240,6 +244,7 @@ lazy val zioSchemaJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     )
   )
   .nativeSettings(Test / fork := false)
+  .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
@@ -267,6 +272,7 @@ lazy val zioSchemaProtobuf = crossProject(JSPlatform, JVMPlatform, NativePlatfor
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.schema.protobuf"))
   .nativeSettings(Test / fork := false)
+  .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
@@ -358,6 +364,7 @@ lazy val zioSchemaOptics = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     )
   )
   .nativeSettings(Test / fork := false)
+  .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
@@ -388,6 +395,7 @@ lazy val zioSchemaExamples = crossProject(JSPlatform, JVMPlatform, NativePlatfor
     scalacOptions -= "-Xfatal-warnings"
   )
   .nativeSettings(Test / fork := false)
+  .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
@@ -412,6 +420,7 @@ lazy val zioSchemaZioTest = crossProject(JSPlatform, JVMPlatform, NativePlatform
   .settings(stdSettings("zio-schema-zio-test"))
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.schema.test"))
+  .nativeSettings(nativeSettings)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio" %%% "zio-test" % zioVersion

--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,7 @@ lazy val zioSchemaMacros = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(macroDefinitionSettings)
   .nativeSettings(Test / fork := false)
   .nativeSettings(
+    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -157,6 +158,7 @@ lazy val zioSchema = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
+    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -212,6 +214,7 @@ lazy val zioSchemaDerivation = crossProject(JSPlatform, JVMPlatform, NativePlatf
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
+    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -241,6 +244,7 @@ lazy val zioSchemaJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
+    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -268,6 +272,7 @@ lazy val zioSchemaProtobuf = crossProject(JSPlatform, JVMPlatform, NativePlatfor
   .settings(buildInfoSettings("zio.schema.protobuf"))
   .nativeSettings(Test / fork := false)
   .nativeSettings(
+    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -359,6 +364,7 @@ lazy val zioSchemaOptics = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
+    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )
@@ -389,6 +395,7 @@ lazy val zioSchemaExamples = crossProject(JSPlatform, JVMPlatform, NativePlatfor
   )
   .nativeSettings(Test / fork := false)
   .nativeSettings(
+    nativeSettings,
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"                 % "0.11.0")
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"                % "1.5.12")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.3")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                       % "0.4.6")
 addSbtPlugin("dev.zio"            % "zio-sbt-website"               % "0.4.0-alpha.22")
 


### PR DESCRIPTION
Upgraded ZIO and Scala-Native to their latest versions and while enabling `multithreading=true`, it resulted in the Out of heap space which is an issue with scala-native and an active discussion is going here in the upstream:

- https://github.com/scala-native/scala-native/issues/4032

Note that the GC change is only needed for few tests which are memory intensive. Once that's upstream is fixed I think we can remove that config safely

fixes #720
/claim #720