### PR TITLE
Fixes #737

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -137,7 +137,7 @@ object JsonCodec {
 
           if (valueEnded && depth == 0) {
             val str = stringBuilder.result()
-            if (!str.isBlank) chunkBuilder += str
+            if (!str.forall(_.isWhitespace)) chunkBuilder += str
             stringBuilder.clear()
           }
         }

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -2,25 +2,27 @@ package zio.schema.codec
 
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
+
 import scala.annotation.{ switch, tailrec }
 import scala.collection.immutable.ListMap
+
 import zio.json.JsonCodec._
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 import zio.json.ast.Json
 import zio.json.internal.{ Lexer, RecordingReader, RetractReader, StringMatrix, WithRecordingReader, Write }
 import zio.json.{
-  JsonFieldDecoder,
-  JsonFieldEncoder,
   JsonCodec => ZJsonCodec,
   JsonDecoder => ZJsonDecoder,
-  JsonEncoder => ZJsonEncoder
+  JsonEncoder => ZJsonEncoder,
+  JsonFieldDecoder,
+  JsonFieldEncoder
 }
 import zio.prelude.NonEmptyMap
 import zio.schema._
 import zio.schema.annotation._
 import zio.schema.codec.DecodeError.ReadError
 import zio.stream.{ ZChannel, ZPipeline }
-import zio.{ Cause, Chunk, ChunkBuilder, NonEmptyChunk, ZIO, ZNothing }
+import zio.{ Cause, Chunk, ChunkBuilder, ZIO, ZNothing }
 
 object JsonCodec {
 

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -152,10 +152,10 @@ object JsonCodec {
           },
           err =>
             if (stringBuilder.isEmpty) ZChannel.refailCause(err)
-            else ZChannel.write(Chunk.single(stringBuilder.result)) *> ZChannel.refailCause(err),
+            else ZChannel.write(Chunk.single(stringBuilder.result())) *> ZChannel.refailCause(err),
           done =>
             if (stringBuilder.isEmpty) ZChannel.succeed(done)
-            else ZChannel.write(Chunk.single(stringBuilder.result)) *> ZChannel.succeed(done)
+            else ZChannel.write(Chunk.single(stringBuilder.result())) *> ZChannel.succeed(done)
         )
 
       ZPipeline.fromChannel(loop)

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -1,9 +1,7 @@
 package zio.schema.codec
 
 import java.time.{ ZoneId, ZoneOffset }
-
 import scala.collection.immutable.ListMap
-
 import zio.Console._
 import zio._
 import zio.json.JsonDecoder.JsonError
@@ -22,7 +20,12 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
+import java.io.IOException
+
 object JsonCodecSpec extends ZIOSpecDefault {
+
+  case class Person(name: String, age: Int)
+  val personSchema: Schema[Person] = DeriveSchema.gen[Person]
 
   def spec: Spec[TestEnvironment, Any] =
     suite("JsonCodec Spec")(
@@ -434,6 +437,71 @@ object JsonCodecSpec extends ZIOSpecDefault {
           Enum23Cases.schema,
           Enum23Cases.Case1("foo"),
           """{"NumberOne":{"value":"foo"}}"""
+        )
+      }
+    ),
+    suite("Streams")(
+      test("Encodes a stream with multiple integers") {
+        assertEncodesMore(Schema[Int], 1 to 5, charSequenceToByteChunk("1\n2\n3\n4\n5"))
+      },
+      test("Decodes a stream with multiple integers") {
+        assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1\n2\n3\n4\n5")) &>
+        assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1 2 3 4 5")) &>
+        assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1 2, 3;;; 4x5"))
+      },
+      test("Decodes a stream with multiple booleans") {
+        assertDecodesMore(Schema[Boolean], Chunk(true, true, false), charSequenceToByteChunk("true true false")) &>
+        assertDecodesMore(Schema[Boolean], Chunk(true, true, false), charSequenceToByteChunk("truetruefalse"))
+      },
+      test("Encodes a stream with multiple strings") {
+        assertEncodesMore(Schema[String], List("a", "b", "c"), charSequenceToByteChunk("\"a\"\n\"b\"\n\"c\""))
+      },
+      test("Decodes a stream with multiple strings") {
+        assertDecodesMore(Schema[String], Chunk("a", "b", "c"), charSequenceToByteChunk("\"a\"\n\"b\"\n\"c\"")) &>
+        assertDecodesMore(Schema[String], Chunk("a", "b", "c"), charSequenceToByteChunk(""""a" "b""c""""))
+      },
+      test("Encodes a stream with multiple records") {
+        assertEncodesMore(
+          personSchema,
+          List(
+            Person("Alice", 1),
+            Person("Bob", 2),
+            Person("Charlie", 3)
+          ),
+          charSequenceToByteChunk(
+            """{"name":"Alice","age":1}
+              |{"name":"Bob","age":2}
+              |{"name":"Charlie","age":3}""".stripMargin
+          )
+        )
+      },
+      test("Decodes a stream with multiple records") {
+        assertDecodesMore(
+          personSchema,
+          Chunk(
+            Person("Alice", 1),
+            Person("Bob", 2),
+            Person("Charlie", 3)
+          ),
+          charSequenceToByteChunk(
+            """{"name":"Alice","age":1}
+              |{"name":"Bob","age":2}
+              |{"name":"Charlie","age":3}""".stripMargin
+          )
+        )
+      },
+      test("Encodes a stream with no records") {
+        assertEncodesMore(
+          personSchema,
+          List.empty[Person],
+          charSequenceToByteChunk("")
+        )
+      },
+      test("Decodes a stream with no records") {
+        assertDecodesMore(
+          personSchema,
+          Chunk.empty,
+          charSequenceToByteChunk("")
         )
       }
     )
@@ -1307,7 +1375,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
       ),
       test("decode discriminated case objects with extra fields")(
         assertDecodes(Schema[Command], Command.Cash, charSequenceToByteChunk("""{"type":"Cash","extraField":1}""")) &>
-          assertDecodes(Schema[Command], Command.Cash, charSequenceToByteChunk("""{"extraField":1,"type":"Cash"}""""))
+          assertDecodes(Schema[Command], Command.Cash, charSequenceToByteChunk("""{"extraField":1,"type":"Cash"}"""))
       ),
       suite("of case objects")(
         test("without annotation")(
@@ -1505,6 +1573,23 @@ object JsonCodecSpec extends ZIOSpecDefault {
     assertZIO(stream)(equalTo(chunk))
   }
 
+  private def assertEncodesMore[A](
+    schema: Schema[A],
+    values: Seq[A],
+    chunk: Chunk[Byte],
+    cfg: JsonCodec.Config = JsonCodec.Config.default,
+    print: Boolean = false
+  ) = {
+    val stream = ZStream
+      .fromIterable(values)
+      .via(JsonCodec.schemaBasedBinaryCodec(cfg)(schema).streamEncoder)
+      .runCollect
+      .tap { chunk =>
+        printLine(s"${new String(chunk.toArray)}").when(print).ignore
+      }
+    assertZIO(stream)(equalTo(chunk))
+  }
+
   private def assertEncodesJson[A](
     schema: Schema[A],
     value: A,
@@ -1549,6 +1634,16 @@ object JsonCodecSpec extends ZIOSpecDefault {
   ) = {
     val result = ZStream.fromChunk(chunk).via(JsonCodec.schemaBasedBinaryCodec[A](cfg)(schema).streamDecoder).runCollect
     assertZIO(result)(equalTo(Chunk(value)))
+  }
+
+  private def assertDecodesMore[A](
+    schema: Schema[A],
+    values: Chunk[A],
+    chunk: Chunk[Byte],
+    cfg: JsonCodec.Config = JsonCodec.Config.default
+  ) = {
+    val result = ZStream.fromChunk(chunk).via(JsonCodec.schemaBasedBinaryCodec[A](cfg)(schema).streamDecoder).runCollect
+    assertZIO(result)(equalTo(values))
   }
 
   private def assertEncodesThenDecodesFallback[A, B](

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -20,8 +20,6 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
-import java.io.IOException
-
 object JsonCodecSpec extends ZIOSpecDefault {
 
   case class Person(name: String, age: Int)

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -1,7 +1,9 @@
 package zio.schema.codec
 
 import java.time.{ ZoneId, ZoneOffset }
+
 import scala.collection.immutable.ListMap
+
 import zio.Console._
 import zio._
 import zio.json.JsonDecoder.JsonError

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -446,19 +446,19 @@ object JsonCodecSpec extends ZIOSpecDefault {
       },
       test("Decodes a stream with multiple integers") {
         assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1\n2\n3\n4\n5")) &>
-        assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1 2 3 4 5")) &>
-        assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1 2, 3;;; 4x5"))
+          assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1 2 3 4 5")) &>
+          assertDecodesMore(Schema[Int], Chunk.fromIterable(1 to 5), charSequenceToByteChunk("1 2, 3;;; 4x5"))
       },
       test("Decodes a stream with multiple booleans") {
         assertDecodesMore(Schema[Boolean], Chunk(true, true, false), charSequenceToByteChunk("true true false")) &>
-        assertDecodesMore(Schema[Boolean], Chunk(true, true, false), charSequenceToByteChunk("truetruefalse"))
+          assertDecodesMore(Schema[Boolean], Chunk(true, true, false), charSequenceToByteChunk("truetruefalse"))
       },
       test("Encodes a stream with multiple strings") {
         assertEncodesMore(Schema[String], List("a", "b", "c"), charSequenceToByteChunk("\"a\"\n\"b\"\n\"c\""))
       },
       test("Decodes a stream with multiple strings") {
         assertDecodesMore(Schema[String], Chunk("a", "b", "c"), charSequenceToByteChunk("\"a\"\n\"b\"\n\"c\"")) &>
-        assertDecodesMore(Schema[String], Chunk("a", "b", "c"), charSequenceToByteChunk(""""a" "b""c""""))
+          assertDecodesMore(Schema[String], Chunk("a", "b", "c"), charSequenceToByteChunk(""""a" "b""c""""))
       },
       test("Encodes a stream with multiple records") {
         assertEncodesMore(


### PR DESCRIPTION
Fix for the issue #737:

* separates encoded elements with new lines (so that numbers can be decoded separated)
* when decoding, looks for boundaries between elements. Needs separators only for numbers. Recognizes automatically the ends of objects, arrays, strings, boolean values and nulls.
