### PR TITLE
Avro UNION schema-decode to Option

### DIFF
--- a/zio-schema-avro/src/main/scala/zio/schema/codec/AvroSchemaCodec.scala
+++ b/zio-schema-avro/src/main/scala/zio/schema/codec/AvroSchemaCodec.scala
@@ -933,22 +933,9 @@ object AvroSchemaCodec extends AvroSchemaCodec {
 
     def unapply(schema: SchemaAvro): Option[SchemaAvro] =
       if (schema.getType == SchemaAvro.Type.UNION) {
-        val types = schema.getTypes
-        if (types.size == 2) {
-          if (types.get(0).getType == SchemaAvro.Type.NULL ||
-              types.get(1).getType == SchemaAvro.Type.NULL) {
-            if (types.get(1).getType != SchemaAvro.Type.NULL) {
-              Some(types.get(1))
-            } else if (types.get(0).getType != SchemaAvro.Type.NULL) {
-              Some(types.get(0))
-            } else {
-              None
-            }
-          } else {
-            None
-          }
-        } else {
-          None
+        schema.getTypes.asScala.toList match {
+          case List(t1, t2) if t1.getType == SchemaAvro.Type.NULL => Some(t2)
+          case _ => None
         }
       } else {
         None

--- a/zio-schema-avro/src/test/scala/zio/schema/codec/AvroSchemaCodecSpec.scala
+++ b/zio-schema-avro/src/test/scala/zio/schema/codec/AvroSchemaCodecSpec.scala
@@ -1284,7 +1284,7 @@ object AvroSchemaCodecSpec extends ZIOSpecDefault {
             val s      = """[{"type":"int"}, {"type":"null"}]"""
             val schema = AvroSchemaCodec.decode(Chunk.fromArray(s.getBytes()))
 
-            assert(schema)(isRight(isOption(hasOptionElementSchema(isStandardType(StandardType.IntType)))))
+            assert(schema)(isRight(isOption(anything).negate))
           },
           test("not an option union with more than one element type") {
             val s      = """[{"type":"null"}, {"type":"int"}, {"type":"string"}]"""


### PR DESCRIPTION
only schema-decode avro union into an option field if the null comes first, because the index if actual type is encoded into the binary message, and the avro schema-encoder will encode an option with the null first