### PR TITLE
More efficient JSON decoders and encoders for records

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1579,12 +1579,13 @@ object JsonCodec {
             buffer(idx) = field.defaultValue.get
           } else {
             val schema = field.schema match {
-              case l @ Schema.Lazy(_) => l.schema
+              case l: Schema.Lazy[_] => l.schema
               case s                  => s
             }
             buffer(idx) = schema match {
+              case _: Schema.Optional[_]               => None
               case collection: Schema.Collection[_, _] => collection.empty
-              case _                                   => schemaDecoder(schema).unsafeDecodeMissing(spans(idx) :: trace)
+              case _                                   => error(spans(idx) :: trace, "missing")
             }
           }
         }

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1022,7 +1022,11 @@ object JsonCodec {
           continue = Lexer.nextField(trace, in)
         }
         // add fields with default values if they are not present in the JSON
-        remainingDefaults.forEach((fieldName, value) => map = map.updated(fieldName, value))
+        val it = remainingDefaults.entrySet.iterator
+        while (it.hasNext) {
+          val entry = it.next()
+          map = map.updated(entry.getKey, entry.getValue)
+        }
         map
       }
     }

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -2,6 +2,7 @@ package zio.schema.codec
 
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
+import java.util
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.annotation.{ switch, tailrec }
@@ -19,6 +20,7 @@ import zio.json.{
   JsonFieldEncoder
 }
 import zio.prelude.NonEmptyMap
+import zio.schema.Schema.GenericRecord
 import zio.schema._
 import zio.schema.annotation.{ rejectExtraFields, _ }
 import zio.schema.codec.DecodeError.ReadError
@@ -338,7 +340,7 @@ object JsonCodec {
         case Schema.Tuple2(l, r, _)                                     => ZJsonEncoder.tuple2(schemaEncoder(l, cfg, discriminatorTuple), schemaEncoder(r, cfg, discriminatorTuple))
         case Schema.Optional(schema, _)                                 => ZJsonEncoder.option(schemaEncoder(schema, cfg, discriminatorTuple))
         case Schema.Fail(_, _)                                          => unitEncoder.contramap(_ => ())
-        case Schema.GenericRecord(_, structure, _)                      => recordEncoder(structure.toChunk, cfg)
+        case s @ Schema.GenericRecord(_, _, _)                          => recordEncoder(s, cfg)
         case Schema.Either(left, right, _)                              => ZJsonEncoder.either(schemaEncoder(left, cfg, discriminatorTuple), schemaEncoder(right, cfg, discriminatorTuple))
         case Schema.Fallback(left, right, _, _)                         => fallbackEncoder(schemaEncoder(left, cfg, discriminatorTuple), schemaEncoder(right, cfg, discriminatorTuple))
         case l @ Schema.Lazy(_)                                         => ZJsonEncoder.suspend(schemaEncoder(l.schema, cfg, discriminatorTuple))
@@ -448,14 +450,12 @@ object JsonCodec {
                   var first = true
                   values.foreach {
                     case (key, value) =>
-                      if (first)
-                        first = false
+                      if (first) first = false
                       else {
                         out.write(',')
-                        if (indent.isDefined)
-                          ZJsonEncoder.pad(indent_, out)
+                        if (indent.isDefined) pad(indent_, out)
                       }
-                      string.encoder.unsafeEncode(JsonFieldEncoder.string.unsafeEncodeField(key), indent_, out)
+                      string.encoder.unsafeEncode(key, indent_, out)
                       if (indent.isEmpty) out.write(':')
                       else out.write(" : ")
                       directEncoder.unsafeEncode(value, indent_, out)
@@ -561,7 +561,7 @@ object JsonCodec {
               pad(indent_, out)
 
               if (discriminatorChunk.isEmpty && !noDiscriminators) {
-                string.encoder.unsafeEncode(JsonFieldEncoder.string.unsafeEncodeField(caseName), indent_, out)
+                string.encoder.unsafeEncode(caseName, indent_, out)
                 if (indent.isEmpty) out.write(':')
                 else out.write(" : ")
               }
@@ -598,36 +598,44 @@ object JsonCodec {
           }
       }
 
-    private def recordEncoder[Z](structure: Seq[Schema.Field[Z, _]], cfg: Config): ZJsonEncoder[ListMap[String, _]] = {
-      (value: ListMap[String, _], indent: Option[Int], out: Write) =>
+    private def recordEncoder(schema: Schema.GenericRecord, cfg: Config): ZJsonEncoder[ListMap[String, _]] = {
+      val nonTransientFields = schema.nonTransientFields.toArray
+      val encoders           = nonTransientFields.map(field => schemaEncoder(field.schema.asInstanceOf[Schema[Any]], cfg))
+      if (nonTransientFields.isEmpty) { (_: ListMap[String, _], _: Option[Int], out: Write) =>
+        out.write("{}")
+      } else { (value: ListMap[String, _], indent: Option[Int], out: Write) =>
         {
-          if (structure.isEmpty) {
-            out.write("{}")
-          } else {
-            out.write('{')
-            val indent_ = bump(indent)
+          out.write('{')
+          val doPrettyPrint = indent ne None
+          var indent_       = indent
+          if (doPrettyPrint) {
+            indent_ = bump(indent)
             pad(indent_, out)
-            var first = true
-            structure.foreach {
-              case field if field.transient || isEmptyOptionalValue(field, value(field.fieldName), cfg) => ()
-              case f @ Schema.Field(_, a, _, _, _, _) =>
-                val enc = schemaEncoder(a.asInstanceOf[Schema[Any]], cfg)
-                if (first)
-                  first = false
-                else {
-                  out.write(',')
-                  if (indent.isDefined)
-                    ZJsonEncoder.pad(indent_, out)
-                }
-                string.encoder.unsafeEncode(JsonFieldEncoder.string.unsafeEncodeField(f.fieldName), indent_, out)
-                if (indent.isEmpty) out.write(':')
-                else out.write(" : ")
-                enc.unsafeEncode(value(f.fieldName), indent_, out)
-            }
-            pad(indent, out)
-            out.write('}')
           }
+          val strEnc = string.encoder
+          var first  = true
+          var i      = 0
+          while (i < nonTransientFields.length) {
+            val field      = nonTransientFields(i)
+            val fieldName  = field.fieldName
+            val fieldValue = value(fieldName)
+            if (!isEmptyOptionalValue(field, fieldValue, cfg)) {
+              if (first) first = false
+              else {
+                out.write(',')
+                if (doPrettyPrint) pad(indent_, out)
+              }
+              strEnc.unsafeEncode(fieldName, indent_, out)
+              if (doPrettyPrint) out.write(" : ")
+              else out.write(':')
+              encoders(i).unsafeEncode(fieldValue, indent_, out)
+            }
+            i += 1
+          }
+          if (doPrettyPrint) pad(indent, out)
+          out.write('}')
         }
+      }
     }
   }
 
@@ -722,7 +730,7 @@ object JsonCodec {
       case Schema.NonEmptyMap(ks, vs, _)                  => mapDecoder(ks, vs).mapOrFail(m => NonEmptyMap.fromMapOption(m).toRight("NonEmptyMap expected"))
       case Schema.Set(s, _)                               => ZJsonDecoder.chunk(schemaDecoder(s, -1)).map(entries => entries.toSet)
       case Schema.Fail(message, _)                        => failDecoder(message)
-      case Schema.GenericRecord(_, structure, _)          => recordDecoder(structure.toChunk, schema.annotations.contains(rejectExtraFields()))
+      case s @ Schema.GenericRecord(_, _, _)              => recordDecoder(s)
       case Schema.Either(left, right, _)                  => ZJsonDecoder.either(schemaDecoder(left, -1), schemaDecoder(right, -1))
       case s @ Schema.Fallback(_, _, _, _)                => fallbackDecoder(s)
       case l @ Schema.Lazy(_)                             => ZJsonDecoder.suspend(schemaDecoder(l.schema, discriminator))
@@ -977,47 +985,45 @@ object JsonCodec {
     private def deAliasCaseName(alias: String, caseNameAliases: Map[String, String]): String =
       caseNameAliases.getOrElse(alias, alias)
 
-    private def recordDecoder[Z](
-      structure: Seq[Schema.Field[Z, _]],
-      rejectAdditionalFields: Boolean
-    ): ZJsonDecoder[ListMap[String, Any]] = { (trace: List[JsonError], in: RetractReader) =>
-      {
-        val builder: ChunkBuilder[(String, Any)] = zio.ChunkBuilder.make[(String, Any)](structure.size)
+    private def recordDecoder(schema: GenericRecord): ZJsonDecoder[ListMap[String, Any]] = {
+      val spansWithDecoders =
+        new util.HashMap[String, (JsonError.ObjectAccess, ZJsonDecoder[Any])](schema.fields.size * 2)
+      val defaults = new util.HashMap[String, Any]
+      schema.fields.foreach { field =>
+        val fieldName = field.fieldName
+        val spanWithDecoder =
+          (JsonError.ObjectAccess(fieldName), schemaDecoder(field.schema).asInstanceOf[ZJsonDecoder[Any]])
+        field.nameAndAliases.foreach(x => spansWithDecoders.put(x, spanWithDecoder))
+        if (field.optional && field.defaultValue.isDefined) defaults.put(fieldName, field.defaultValue.get)
+      }
+      val rejectAdditionalFields = schema.annotations.exists(_.isInstanceOf[rejectExtraFields])
+      (trace: List[JsonError], in: RetractReader) => {
         Lexer.char(trace, in, '{')
-        if (Lexer.firstField(trace, in)) {
-          while ({
-            val field = Lexer.string(trace, in).toString
-            structure.find(f => f.nameAndAliases.contains(field)) match {
-              case Some(s @ Schema.Field(_, schema, _, _, _, _)) =>
-                val fieldName = s.fieldName
-                val trace_    = JsonError.ObjectAccess(fieldName) :: trace
-                Lexer.char(trace_, in, ':')
-                val value = schemaDecoder(schema).unsafeDecode(trace_, in)
-                builder += ((JsonFieldDecoder.string.unsafeDecodeField(trace_, fieldName), value))
-              case None if rejectAdditionalFields =>
-                throw UnsafeJson(JsonError.Message(s"unexpected field: $field") :: trace)
-              case None =>
-                Lexer.char(trace, in, ':')
-                Lexer.skipValue(trace, in)
-
-            }
-            Lexer.nextField(trace, in)
-          }) {
-            ()
+        val remainingDefaults = defaults.clone().asInstanceOf[util.HashMap[String, Any]]
+        var map               = ListMap.empty[String, Any]
+        var continue          = Lexer.firstField(trace, in)
+        while (continue) {
+          val fieldNameOrAlias = Lexer.string(trace, in).toString
+          val spanWithDecoder  = spansWithDecoders.get(fieldNameOrAlias)
+          if (spanWithDecoder ne null) {
+            val span   = spanWithDecoder._1
+            val dec    = spanWithDecoder._2
+            val trace_ = span :: trace
+            Lexer.char(trace_, in, ':')
+            val fieldName = span.field
+            remainingDefaults.remove(fieldName)
+            map = map.updated(fieldName, dec.unsafeDecode(trace_, in))
+          } else if (rejectAdditionalFields) {
+            throw UnsafeJson(JsonError.Message(s"unexpected field: $fieldNameOrAlias") :: trace)
+          } else {
+            Lexer.char(trace, in, ':')
+            Lexer.skipValue(trace, in)
           }
+          continue = Lexer.nextField(trace, in)
         }
-        val tuples                       = builder.result()
-        val collectedFields: Set[String] = tuples.map { case (fieldName, _) => fieldName }.toSet
-        val resultBuilder                = ListMap.newBuilder[String, Any]
-
         // add fields with default values if they are not present in the JSON
-        structure.foreach { field =>
-          if (!collectedFields.contains(field.fieldName) && field.optional && field.defaultValue.isDefined) {
-            val value = field.fieldName -> field.defaultValue.get
-            resultBuilder += value
-          }
-        }
-        (resultBuilder ++= tuples).result()
+        remainingDefaults.forEach((fieldName, value) => map = map.updated(fieldName, value))
+        map
       }
     }
 
@@ -1116,16 +1122,20 @@ object JsonCodec {
       val caseTpeNames       = discriminatorTuple.map(_._2).toArray
       (a: Z, indent: Option[Int], out: Write) => {
         out.write('{')
-        val indent_ = bump(indent)
-        pad(indent_, out)
+        val doPrettyPrint = indent ne None
+        var indent_       = indent
+        if (doPrettyPrint) {
+          indent_ = bump(indent)
+          pad(indent_, out)
+        }
         val strEnc = string.encoder
         var first  = true
         var i      = 0
         while (i < tags.length) {
           first = false
           strEnc.unsafeEncode(tags(i), indent_, out)
-          if (indent.isEmpty) out.write(':')
-          else out.write(" : ")
+          if (doPrettyPrint) out.write(" : ")
+          else out.write(':')
           strEnc.unsafeEncode(caseTpeNames(i), indent_, out)
           i += 1
         }
@@ -1139,15 +1149,15 @@ object JsonCodec {
             if (first) first = false
             else {
               out.write(',')
-              if (indent.isDefined) pad(indent_, out)
+              if (doPrettyPrint) pad(indent_, out)
             }
             strEnc.unsafeEncode(schema.name, indent_, out)
-            if (indent.isEmpty) out.write(':')
-            else out.write(" : ")
+            if (doPrettyPrint) out.write(" : ")
+            else out.write(':')
             enc.unsafeEncode(value, indent_, out)
           }
         }
-        pad(indent, out)
+        if (doPrettyPrint) pad(indent, out)
         out.write('}')
       }
     }
@@ -1156,31 +1166,27 @@ object JsonCodec {
   //scalafmt: { maxColumn = 400, optIn.configStyleArguments = false }
   private[codec] object ProductDecoder {
 
-    private[codec] def caseClass0Decoder[Z](discriminator: Int, schema: Schema.CaseClass0[Z]): ZJsonDecoder[Z] = { (trace: List[JsonError], in: RetractReader) =>
-      def skipField(): Unit = {
-        val rejectExtraFields = schema.annotations.collectFirst({ case _: rejectExtraFields => () }).isDefined
-        if (rejectExtraFields) {
-          throw UnsafeJson(JsonError.Message("extra field") :: trace)
+    private[codec] def caseClass0Decoder[Z](discriminator: Int, schema: Schema.CaseClass0[Z]): ZJsonDecoder[Z] = {
+      val rejectExtraFields = schema.annotations.exists(_.isInstanceOf[rejectExtraFields])
+      (trace: List[JsonError], in: RetractReader) => {
+        var continue =
+          if (discriminator == -2) Lexer.nextField(trace, in)
+          else {
+            if (discriminator == -1) Lexer.char(trace, in, '{')
+            Lexer.firstField(trace, in)
+          }
+        while (continue) {
+          if (rejectExtraFields) {
+            throw UnsafeJson(JsonError.Message("extra field") :: trace)
+          }
+          Lexer.char(trace, in, '"')
+          Lexer.skipString(trace, in)
+          Lexer.char(trace, in, ':')
+          Lexer.skipValue(trace, in)
+          continue = Lexer.nextField(trace, in)
         }
-        Lexer.char(trace, in, '"')
-        Lexer.skipString(trace, in)
-        Lexer.char(trace, in, ':')
-        Lexer.skipValue(trace, in)
+        schema.defaultConstruct()
       }
-
-      if (discriminator == -2) {
-        while (Lexer.nextField(trace, in)) { skipField() }
-      } else {
-        if (discriminator == -1) {
-          Lexer.char(trace, in, '{')
-        }
-        if (Lexer.firstField(trace, in)) {
-          skipField()
-          while (Lexer.nextField(trace, in)) { skipField() }
-        }
-      }
-
-      schema.defaultConstruct()
     }
 
     private[codec] def caseClass1Decoder[A, Z](discriminator: Int, schema: Schema.CaseClass1[A, Z]): ZJsonDecoder[Z] = {
@@ -1592,26 +1598,23 @@ object JsonCodec {
 
   private object CaseClassJsonDecoder {
 
-    def apply[Z](caseClassSchema: Schema.Record[Z], discriminator: Int): CaseClassJsonDecoder[Z] = {
-      val len      = caseClassSchema.fields.length
+    def apply[Z](schema: Schema.Record[Z], discriminator: Int): CaseClassJsonDecoder[Z] = {
+      val len      = schema.fields.length
       val fields   = new Array[Schema.Field[Z, _]](len)
       val decoders = new Array[ZJsonDecoder[_]](len)
       val spans    = new Array[JsonError.ObjectAccess](len)
       val names    = new Array[String](len)
-      var aliases  = Map.empty[String, Int]
+      val aliases  = Array.newBuilder[(String, Int)]
       var i        = 0
-      caseClassSchema.fields.foreach { field =>
+      schema.fields.foreach { field =>
         val name = field.name.asInstanceOf[String]
         fields(i) = field
         names(i) = name
         spans(i) = JsonError.ObjectAccess(name)
         decoders(i) = schemaDecoder(field.schema)
         field.annotations.foreach {
-          case annotation: fieldNameAliases =>
-            annotation.aliases.foreach { alias =>
-              aliases = aliases.updated(alias, i)
-            }
-          case _ =>
+          case annotation: fieldNameAliases => annotation.aliases.foreach(a => aliases += ((a, i)))
+          case _                            =>
         }
         i += 1
       }
@@ -1619,9 +1622,9 @@ object JsonCodec {
         fields,
         decoders,
         spans,
-        new StringMatrix(names, aliases.toArray),
+        new StringMatrix(names, aliases.result()),
         discriminator,
-        caseClassSchema.annotations.collectFirst({ case _: rejectExtraFields => () }).isDefined
+        schema.annotations.exists(_.isInstanceOf[rejectExtraFields])
       )
     }
   }

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1578,9 +1578,10 @@ object JsonCodec {
           if ((field.optional || field.transient) && field.defaultValue.isDefined) {
             buffer(idx) = field.defaultValue.get
           } else {
-            val schema = field.schema match {
-              case l: Schema.Lazy[_] => l.schema
-              case s                  => s
+            var schema = field.schema
+            schema match {
+              case l: Schema.Lazy[_] => schema = l.schema
+              case _                 =>
             }
             buffer(idx) = schema match {
               case _: Schema.Optional[_]               => None


### PR DESCRIPTION
BEWARE: Case classes with more than 22 fields  for parsing and serialization use `Schema.GenericRecord` that under the hood uses transformation from/to `ListMap` (the most inefficient Scala collection that has `O(n)` complexity for lookups and inserts).

Below are results of [benchmarks](https://github.com/plokhotnyuk/jsoniter-scala/pull/1232) for real-world message samples using JDK-21 on Intel® Core™ i7-11800H CPU @ 2.3GHz (max 4.6GHz) 

### Scala 2.13

Before:

```txt
Benchmark                                   Mode  Cnt        Score        Error  Units
GeoJSONWriting.zioJson                     thrpt    5    11509.636 ±    426.210  ops/s
GeoJSONWriting.zioSchemaJson               thrpt    5    16104.759 ±    209.080  ops/s
GitHubActionsAPIReading.zioJson            thrpt    5   238538.723 ±   8177.055  ops/s
GitHubActionsAPIReading.zioSchemaJson      thrpt    5   222514.430 ±   5547.097  ops/s
GitHubActionsAPIWriting.zioJson            thrpt    5   342839.086 ±   7157.601  ops/s
GitHubActionsAPIWriting.zioSchemaJson      thrpt    5   323509.502 ±   4936.931  ops/s
GoogleMapsAPIPrettyPrinting.zioJson        thrpt    5    17059.393 ±    581.105  ops/s
GoogleMapsAPIPrettyPrinting.zioSchemaJson  thrpt    5    16573.563 ±    337.655  ops/s
GoogleMapsAPIReading.zioJson               thrpt    5    13982.431 ±    341.561  ops/s
GoogleMapsAPIReading.zioSchemaJson         thrpt    5    13842.595 ±    578.194  ops/s
GoogleMapsAPIWriting.zioJson               thrpt    5    24972.722 ±    468.115  ops/s
GoogleMapsAPIWriting.zioSchemaJson         thrpt    5    25915.911 ±    295.172  ops/s
OpenRTBReading.zioJson                     thrpt    5   114007.985 ±   1431.479  ops/s
OpenRTBReading.zioSchemaJson               thrpt    5    79211.901 ±    822.182  ops/s
TwitterAPIReading.zioJson                  thrpt    5    10678.123 ±    148.329  ops/s
TwitterAPIReading.zioSchemaJson            thrpt    5     7268.961 ±    216.017  ops/s
TwitterAPIWriting.zioSchemaJson            thrpt    5    14045.225 ±    230.728  ops/s
```

After:
```txt
Benchmark                                   Mode  Cnt        Score        Error  Units
GeoJSONWriting.zioJson                     thrpt    5    11555.041 ±    508.988  ops/s
GeoJSONWriting.zioSchemaJson               thrpt    5    15670.732 ±    280.056  ops/s
GitHubActionsAPIReading.zioJson            thrpt    5   226589.943 ±   6620.085  ops/s
GitHubActionsAPIReading.zioSchemaJson      thrpt    5   225792.266 ±   2472.357  ops/s
GitHubActionsAPIWriting.zioJson            thrpt    5   342785.015 ±   8113.470  ops/s
GitHubActionsAPIWriting.zioSchemaJson      thrpt    5   322699.803 ±  11433.594  ops/s
GoogleMapsAPIPrettyPrinting.zioJson        thrpt    5    17699.092 ±    257.323  ops/s
GoogleMapsAPIPrettyPrinting.zioSchemaJson  thrpt    5    18509.454 ±    246.413  ops/s
GoogleMapsAPIReading.zioJson               thrpt    5    13736.513 ±    512.711  ops/s
GoogleMapsAPIReading.zioSchemaJson         thrpt    5    14022.238 ±    361.512  ops/s
GoogleMapsAPIWriting.zioJson               thrpt    5    25187.089 ±    466.850  ops/s
GoogleMapsAPIWriting.zioSchemaJson         thrpt    5    26927.483 ±    303.798  ops/s
OpenRTBReading.zioJson                     thrpt    5   114339.425 ±   1126.331  ops/s
OpenRTBReading.zioSchemaJson               thrpt    5    94564.696 ±   2510.726  ops/s
TwitterAPIReading.zioJson                  thrpt    5     9604.793 ±    247.095  ops/s
TwitterAPIReading.zioSchemaJson            thrpt    5    13850.582 ±    174.689  ops/s
TwitterAPIWriting.zioSchemaJson            thrpt    5    16088.669 ±    927.031  ops/s
```

### Scala 3.6.2

Before:

```txt
Benchmark                                   Mode  Cnt        Score       Error  Units
GeoJSONWriting.zioJson                     thrpt    5    12221.286 ±   522.041  ops/s
GeoJSONWriting.zioSchemaJson               thrpt    5    15297.340 ±   641.081  ops/s
GitHubActionsAPIReading.zioJson            thrpt    5   271564.817 ± 18327.367  ops/s
GitHubActionsAPIReading.zioSchemaJson      thrpt    5   268534.801 ±  5660.602  ops/s
GitHubActionsAPIWriting.zioJson            thrpt    5   368410.078 ±  4260.637  ops/s
GitHubActionsAPIWriting.zioSchemaJson      thrpt    5   338656.400 ±  1350.642  ops/s
GoogleMapsAPIPrettyPrinting.zioJson        thrpt    5    18925.725 ±   568.680  ops/s
GoogleMapsAPIPrettyPrinting.zioSchemaJson  thrpt    5    18316.578 ±   686.262  ops/s
GoogleMapsAPIReading.zioJson               thrpt    5    17410.773 ±   499.557  ops/s
GoogleMapsAPIReading.zioSchemaJson         thrpt    5    20159.010 ±   452.471  ops/s
GoogleMapsAPIWriting.zioJson               thrpt    5    27655.787 ±  1071.832  ops/s
GoogleMapsAPIWriting.zioSchemaJson         thrpt    5    24778.901 ±   888.373  ops/s
OpenRTBReading.zioJson                     thrpt    5   140866.407 ±  1125.914  ops/s
OpenRTBReading.zioSchemaJson               thrpt    5    73574.917 ±   943.538  ops/s
TwitterAPIReading.zioJson                  thrpt    5    15041.247 ±   284.596  ops/s
TwitterAPIReading.zioSchemaJson            thrpt    5     7441.366 ±    91.045  ops/s
TwitterAPIWriting.zioSchemaJson            thrpt    5    12892.386 ±   830.567  ops/s
```

After:
```txt
Benchmark                                   Mode  Cnt        Score        Error  Units
GeoJSONWriting.zioJson                     thrpt    5    11031.272 ±     60.439  ops/s
GeoJSONWriting.zioSchemaJson               thrpt    5    14985.481 ±    186.642  ops/s
GitHubActionsAPIReading.zioJson            thrpt    5   272805.697 ±   2739.527  ops/s
GitHubActionsAPIReading.zioSchemaJson      thrpt    5   274473.034 ±   6134.873  ops/s
GitHubActionsAPIWriting.zioJson            thrpt    5   370507.931 ±   5288.682  ops/s
GitHubActionsAPIWriting.zioSchemaJson      thrpt    5   337849.886 ±   9830.916  ops/s
GoogleMapsAPIPrettyPrinting.zioJson        thrpt    5    19294.778 ±    651.552  ops/s
GoogleMapsAPIPrettyPrinting.zioSchemaJson  thrpt    5    17828.131 ±    694.554  ops/s
GoogleMapsAPIReading.zioJson               thrpt    5    16806.799 ±    562.611  ops/s
GoogleMapsAPIReading.zioSchemaJson         thrpt    5    19931.393 ±   1104.529  ops/s
GoogleMapsAPIWriting.zioJson               thrpt    5    27761.813 ±   1087.806  ops/s
GoogleMapsAPIWriting.zioSchemaJson         thrpt    5    26460.697 ±    694.238  ops/s
OpenRTBReading.zioJson                     thrpt    5   143912.206 ±   2833.240  ops/s
OpenRTBReading.zioSchemaJson               thrpt    5    91562.192 ±    829.948  ops/s
TwitterAPIReading.zioJson                  thrpt    5    14458.395 ±    116.581  ops/s
TwitterAPIReading.zioSchemaJson            thrpt    5    10843.616 ±     66.909  ops/s
TwitterAPIWriting.zioSchemaJson            thrpt    5    14920.064 ±    702.144  ops/s
```
