### PR TITLE
More efficient handling of different discriminator types

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -863,13 +863,13 @@ object JsonCodec {
                 case Some(discriminatorName) =>
                   @tailrec
                   def findDiscriminator(index: Int, rr: RecordingReader): (String, List[JsonError], Int) = {
-                    val subtypeOrDiscriminator = deAliasCaseName(Lexer.string(trace, rr).toString, caseNameAliases)
-                    val trace_                 = JsonError.ObjectAccess(subtypeOrDiscriminator) :: trace
-                    if (subtypeOrDiscriminator == discriminatorName) {
+                    val discriminatorFieldName = Lexer.string(trace, rr).toString
+                    val trace_                 = JsonError.ObjectAccess(discriminatorFieldName) :: trace
+                    if (discriminatorFieldName == discriminatorName) {
                       Lexer.char(trace_, rr, ':')
-                      val discriminator = Lexer.string(trace, rr).toString
+                      val discriminatorFieldValue = Lexer.string(trace, rr).toString
                       // Perform a second de-aliasing because the first one would resolve the discriminator key instead.
-                      val innerSubtype = deAliasCaseName(discriminator, caseNameAliases)
+                      val innerSubtype = deAliasCaseName(discriminatorFieldValue, caseNameAliases)
                       (innerSubtype, JsonError.ObjectAccess(innerSubtype) :: trace_, {
                         if (index > 0) {
                           rr.rewind()

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1576,18 +1576,18 @@ object JsonCodec {
       val spans    = Array.newBuilder[JsonError.ObjectAccess]
       val names    = Array.newBuilder[String]
       val aliases  = Array.newBuilder[(String, Int)]
-      var i        = 0
+      var idx      = 0
       schema.fields.foreach { field =>
-        fields(i) = field
-        decoders(i) = schemaDecoder(field.schema)
+        fields(idx) = field
+        decoders(idx) = schemaDecoder(field.schema)
         val name = field.name.asInstanceOf[String]
         names += name
         spans += JsonError.ObjectAccess(name)
         field.annotations.foreach {
-          case annotation: fieldNameAliases => annotation.aliases.foreach(a => aliases += ((a, i)))
-          case _                            =>
+          case fna: fieldNameAliases => fna.aliases.foreach(a => aliases += ((a, idx)))
+          case _                     =>
         }
-        i += 1
+        idx += 1
       }
       val hasDiscriminator = discriminator.isDefined
       if (hasDiscriminator) {

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -865,8 +865,8 @@ object JsonCodec {
                   def findDiscriminator(index: Int, rr: RecordingReader): (String, List[JsonError], Int) = {
                     val discriminatorFieldName = Lexer.string(trace, rr).toString
                     val trace_                 = JsonError.ObjectAccess(discriminatorFieldName) :: trace
+                    Lexer.char(trace_, rr, ':')
                     if (discriminatorFieldName == discriminatorName) {
-                      Lexer.char(trace_, rr, ':')
                       val discriminatorFieldValue = Lexer.string(trace, rr).toString
                       // Perform a second de-aliasing because the first one would resolve the discriminator key instead.
                       val innerSubtype = deAliasCaseName(discriminatorFieldValue, caseNameAliases)
@@ -877,7 +877,6 @@ object JsonCodec {
                         } else -2
                       })
                     } else {
-                      Lexer.char(trace_, rr, ':')
                       Lexer.skipValue(trace_, rr)
                       if (Lexer.nextField(trace, rr)) findDiscriminator(index + 1, rr)
                       else throw UnsafeJson(JsonError.Message("missing subtype") :: trace)

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1468,23 +1468,21 @@ object JsonCodec {
   ) {
 
     def unsafeDecodeFields(trace: List[JsonError], in: RetractReader): Array[Any] = {
-      val len    = fields.length
-      val buffer = new Array[Any](len)
-      var reader = in
-      if (discriminator == -1) Lexer.char(trace, reader, '{')
-      else reader = RecordingReader(reader)
-      var continue = Lexer.firstField(trace, reader)
-      var pos = 0
+      if (discriminator == -1) Lexer.char(trace, in, '{')
+      var continue = Lexer.firstField(trace, in)
+      val len      = fields.length
+      val buffer   = new Array[Any](len)
+      var pos      = 0
       while (continue) {
-        val idx = Lexer.field(trace, reader, stringMatrix)
-        if (pos == discriminator) Lexer.skipValue(trace, reader)
+        val idx = Lexer.field(trace, in, stringMatrix)
+        if (pos == discriminator) Lexer.skipValue(trace, in)
         else if (idx >= 0) {
           val trace_ = spans(idx) :: trace
           if (buffer(idx) != null) error(trace_, "duplicate")
-          else buffer(idx) = fieldDecoders(idx).unsafeDecode(trace_, reader)
-        } else if (!rejectExtraFields) Lexer.skipValue(trace, reader)
+          else buffer(idx) = fieldDecoders(idx).unsafeDecode(trace_, in)
+        } else if (!rejectExtraFields) Lexer.skipValue(trace, in)
         else error(trace, "extra field")
-        continue = Lexer.nextField(trace, reader)
+        continue = Lexer.nextField(trace, in)
         pos += 1
       }
       var idx = 0

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1516,8 +1516,11 @@ object JsonCodec {
   ) {
 
     def unsafeDecodeFields(trace: List[JsonError], in: RetractReader): Array[Any] = {
-      if (noDiscriminator) Lexer.char(trace, in, '{')
-      var continue = Lexer.firstField(trace, in)
+      var continue = true
+      if (noDiscriminator) {
+        Lexer.char(trace, in, '{')
+        continue = Lexer.firstField(trace, in)
+      }
       val len      = fields.length
       val buffer   = new Array[Any](len)
       while (continue) {

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1525,8 +1525,8 @@ object JsonCodec {
         if (idx >= 0) {
           val trace_ = spans(idx) :: trace
           if (idx == len && hasDiscriminator) Lexer.skipValue(trace_, in)
-          else if (buffer(idx) != null) error("duplicate", trace_)
-          else buffer(idx) = fieldDecoders(idx).unsafeDecode(trace_, in)
+          else if (buffer(idx) == null) buffer(idx) = fieldDecoders(idx).unsafeDecode(trace_, in)
+          else error("duplicate", trace_)
         } else if (skipExtraFields) Lexer.skipValue(trace, in)
         else error("extra field", trace)
         continue = Lexer.nextField(trace, in)

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -867,7 +867,7 @@ object JsonCodec {
                     val trace_                 = JsonError.ObjectAccess(discriminatorFieldName) :: trace
                     Lexer.char(trace_, rr, ':')
                     if (discriminatorFieldName == discriminatorName) {
-                      val discriminatorFieldValue = Lexer.string(trace, rr).toString
+                      val discriminatorFieldValue = Lexer.string(trace_, rr).toString
                       rr.rewind()
                       val subtype = deAliasCaseName(discriminatorFieldValue, caseNameAliases)
                       (subtype, JsonError.ObjectAccess(subtype) :: trace_, index)

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -1035,6 +1035,13 @@ object JsonCodecSpec extends ZIOSpecDefault {
           charSequenceToByteChunk("""{"amount":1000, "type":"onetime"}""")
         )
       },
+      test("case name - illegal discriminator value") {
+        assertDecodesToError(
+          Subscription.schema,
+          """{"amount":1000, "type":123}""",
+          JsonError.Message("expected '\"' got '1'") :: JsonError.ObjectAccess("type") :: Nil
+        )
+      },
       test("case name - empty fields") {
         assertDecodes(
           Subscription.schema,


### PR DESCRIPTION
An intermediate PR before fixing inconsistency of handling of different discriminator types that was reported in this issue: https://github.com/zio/zio-schema/issues/763

It contains a bunch of yak shaving commits to avoid copying all those redundant stuff for `Schema.GenericRecord` codecs

It would be better to review it on per commit basis