### PR TITLE
Fix support of fieldName annotations

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-3/zio/schema/DeriveSchema.scala
@@ -256,7 +256,7 @@ private case class DeriveSchema()(using val ctx: Quotes) {
                tpe.asType
            }
            val annotations = paramAnns.getOrElse(label, List.empty)
-           val nameExpr = annotations.collectFirst {
+           val nameExpr = annotations.reverse.collectFirst {
              case ann if ann.isExprOf[fieldName] =>
                val fieldNameAnn = ann.asExprOf[fieldName]
                  '{${fieldNameAnn}.name}
@@ -291,7 +291,7 @@ private case class DeriveSchema()(using val ctx: Quotes) {
                 tpe.asType
             }
            val annotations = paramAnns.getOrElse(label, List.empty)
-           val nameExpr = annotations.collectFirst {
+           val nameExpr = annotations.reverse.collectFirst {
              case ann if ann.isExprOf[fieldName] =>
                val fieldNameAnn = ann.asExprOf[fieldName]
                '{${fieldNameAnn}.name}
@@ -478,7 +478,7 @@ private case class DeriveSchema()(using val ctx: Quotes) {
       val chunk = '{ zio.Chunk.fromIterable(${ Expr.ofSeq(anns.reverse) }) }
 
       if (anns.nonEmpty) {
-        val (newName, newNameValue) = anns.collectFirst {
+        val (newName, newNameValue) = anns.reverse.collectFirst {
           case ann if ann.isExprOf[fieldName] =>
             val fieldNameAnn = ann.asExprOf[fieldName]
             ('{${fieldNameAnn}.name}, extractFieldNameValue(fieldNameAnn))
@@ -529,7 +529,7 @@ private case class DeriveSchema()(using val ctx: Quotes) {
       val chunk = '{ zio.Chunk.fromIterable(${ Expr.ofSeq(anns.reverse) }) }
 
       if (anns.nonEmpty) {
-        val newName = anns.collectFirst {
+        val newName = anns.reverse.collectFirst {
           case ann if ann.isExprOf[fieldName] => '{${ann.asExprOf[fieldName]}.name}
         }.getOrElse(Expr(name))
 

--- a/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
@@ -432,15 +432,17 @@ object Schema extends SchemaPlatformSpecific with SchemaEquality {
     val transient: Boolean =
       annotations.exists(_.isInstanceOf[transientField])
 
-    val nameAndAliases: scala.collection.immutable.Set[String] =
-      annotations.collect {
-        case aliases: fieldNameAliases => aliases.aliases
-        case f: fieldName              => Seq(f.name)
-      }.flatten.toSet + name
-
     val fieldName: String = annotations.collectFirst {
       case f: fieldName => f.name
     }.getOrElse(name)
+
+    val nameAndAliases: scala.collection.immutable.Set[String] =
+      annotations.foldLeft(scala.collection.immutable.Set(fieldName)) { (acc, annotation) =>
+        annotation match {
+          case aliases: fieldNameAliases => acc ++ aliases.aliases
+          case _                         => acc
+        }
+      }
 
     override def toString: String = s"Field($name,$schema)"
   }


### PR DESCRIPTION
* Fix using of fieldName annotations to rename fields (not aliasing)

* Fix ignoring non-first fieldName annotations at the field declarations
