### PR TITLE
Fix unexpected `ClassCastException` in `Schema.serializable`

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/SchemaSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/SchemaSpec.scala
@@ -40,7 +40,13 @@ object SchemaSpec extends ZIOSpecDefault {
         assert(schemaEnum("key"))(hasSameSchema(schemaEnum("key"))) &&
         assert(schemaEnum("key1"))(not(hasSameSchema(schemaEnum("key2"))))
 
-      } @@ TestAspect.scala2Only
+      } @@ TestAspect.scala2Only,
+      test("schema of schema") {
+        assert(schemaInt.serializable)(hasSameSchema(schemaInt.serializable))
+      },
+      test("schema of schema of schema") {
+        assert(schemaInt.serializable.serializable)(hasSameSchema(schemaInt.serializable.serializable))
+      }
     ),
     test("Tuple.toRecord should preserve annotations") {
       val left        = Schema.primitive(StandardType.StringType)

--- a/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/Schema.scala
@@ -129,6 +129,7 @@ sealed trait Schema[A] {
   def serializable: Schema[Schema[A]] =
     MetaSchema
       .fromSchema(self)
+      .toSchema
       .asInstanceOf[Schema[Schema[_]]]
       .transformOrFail(
         s => s.coerce(self),
@@ -559,6 +560,7 @@ object Schema extends SchemaPlatformSpecific with SchemaEquality {
     override def serializable: Schema[Schema[B]] =
       MetaSchema
         .fromSchema(schema)
+        .toSchema
         .asInstanceOf[Schema[Schema[_]]]
         .transformOrFail(
           s => s.coerce(schema).flatMap(s1 => Right(s1.transformOrFail(f, g))),


### PR DESCRIPTION
Fix #799