### PR TITLE
Add config to zio-schema-bson

### DIFF
--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -114,7 +114,7 @@ object BsonSchemaCodec {
     def withClassNameMapping(classNameMapping: TermMapping): Config =
       copy(classNameMapping = classNameMapping)
 
-    def copy(
+    private[this] def copy(
       sumTypeHandling: SumTypeHandling = sumTypeHandling,
       classNameMapping: TermMapping = classNameMapping
     ): Config =

--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -3,6 +3,7 @@ package zio.schema.codec
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 
+import scala.collection.compat._
 import scala.collection.immutable.{ HashMap, ListMap }
 import scala.jdk.CollectionConverters._
 
@@ -42,6 +43,11 @@ import zio.schema.{ DynamicValue, Fallback, Schema, StandardType, TypeId }
 import zio.{ Chunk, ChunkBuilder, Unsafe }
 
 object BsonSchemaCodec {
+
+  {
+    // TODO: better way to prevent scalafix from removing the import
+    val _ = IterableOnce
+  }
 
   case class Config(
     sumTypeHandling: SumTypeHandling = WrapperWithClassNameField,

--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -2,12 +2,13 @@ package zio.schema.codec
 
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+
 import scala.collection.immutable.{ HashMap, ListMap }
 import scala.jdk.CollectionConverters._
-import scala.collection.compat._
 
 import org.bson.types.ObjectId
 import org.bson.{ BsonDocument, BsonNull, BsonReader, BsonType, BsonValue, BsonWriter }
+
 import zio.bson.BsonBuilder._
 import zio.bson.DecoderUtils._
 import zio.bson.{
@@ -35,10 +36,10 @@ import zio.schema.annotation.{
   transientCase,
   transientField
 }
+import zio.schema.codec.BsonSchemaCodec.Config.SumTypeHandling.WrapperWithClassNameField
+import zio.schema.codec.BsonSchemaCodec.Config.{ SumTypeHandling, TermMapping }
 import zio.schema.{ DynamicValue, Fallback, Schema, StandardType, TypeId }
 import zio.{ Chunk, ChunkBuilder, Unsafe }
-import zio.schema.codec.BsonSchemaCodec.Config.{ SumTypeHandling, TermMapping }
-import zio.schema.codec.BsonSchemaCodec.Config.SumTypeHandling.WrapperWithClassNameField
 
 object BsonSchemaCodec {
 

--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -2,12 +2,14 @@ package zio.schema.codec
 
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+
 import scala.collection.compat._
 import scala.collection.immutable.{ HashMap, ListMap }
 import scala.jdk.CollectionConverters._
 
 import org.bson.types.ObjectId
 import org.bson.{ BsonDocument, BsonNull, BsonReader, BsonType, BsonValue, BsonWriter }
+
 import zio.bson.BsonBuilder._
 import zio.bson.DecoderUtils._
 import zio.bson.{
@@ -35,9 +37,9 @@ import zio.schema.annotation.{
   transientCase,
   transientField
 }
+import zio.schema.codec.BsonSchemaCodec.SumTypeHandling.WrapperWithClassNameField
 import zio.schema.{ DynamicValue, Fallback, Schema, StandardType, TypeId }
 import zio.{ Chunk, ChunkBuilder, Unsafe }
-import zio.schema.codec.BsonSchemaCodec.SumTypeHandling.WrapperWithClassNameField
 
 object BsonSchemaCodec {
 

--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -110,14 +110,23 @@ object BsonSchemaCodec {
 
   }
 
-  def bsonEncoder[A](schema: Schema[A], config: Config = Config()): BsonEncoder[A] =
+  def bsonEncoder[A](schema: Schema[A], config: Config): BsonEncoder[A] =
     BsonSchemaEncoder.schemaEncoder(config)(schema)
 
-  def bsonDecoder[A](schema: Schema[A], config: Config = Config()): BsonDecoder[A] =
+  def bsonEncoder[A](schema: Schema[A]): BsonEncoder[A] =
+    bsonEncoder(schema, Config())
+
+  def bsonDecoder[A](schema: Schema[A], config: Config): BsonDecoder[A] =
     BsonSchemaDecoder.schemaDecoder(config)(schema)
 
-  def bsonCodec[A](schema: Schema[A], config: Config = Config()): BsonCodec[A] =
+  def bsonDecoder[A](schema: Schema[A]): BsonDecoder[A] =
+    bsonDecoder(schema, Config())
+
+  def bsonCodec[A](schema: Schema[A], config: Config): BsonCodec[A] =
     BsonCodec(bsonEncoder(schema, config), bsonDecoder(schema, config))
+
+  def bsonCodec[A](schema: Schema[A]): BsonCodec[A] =
+    bsonCodec(schema, Config())
 
   object Codecs {
     protected[codec] val unitEncoder: BsonEncoder[Unit] = new BsonEncoder[Unit] {

--- a/zio-schema-bson/src/test/scala/zio/schema/codec/BsonConfig.scala
+++ b/zio-schema-bson/src/test/scala/zio/schema/codec/BsonConfig.scala
@@ -15,6 +15,51 @@ object BsonConfig {
     implicit lazy val codec: BsonCodec[WithoutDiscriminator] = BsonSchemaCodec.bsonCodec(schema)
   }
 
+  sealed trait WithClassNameTransformOptions
+
+  object WithClassNameTransformOptions {
+    case class A(s: String) extends WithClassNameTransformOptions
+    case class B(s: String) extends WithClassNameTransformOptions
+
+    implicit lazy val schema: Schema[WithClassNameTransformOptions] = DeriveSchema.gen
+    implicit lazy val codec: BsonCodec[WithClassNameTransformOptions] = BsonSchemaCodec.bsonCodec(
+      schema,
+      BsonSchemaCodec.Config(
+        classNameMapping = _.toLowerCase
+      )
+    )
+  }
+
+  sealed trait WithDiscriminatorOptions
+
+  object WithDiscriminatorOptions {
+    case class A(s: String) extends WithDiscriminatorOptions
+    case class B(s: String) extends WithDiscriminatorOptions
+
+    implicit lazy val schema: Schema[WithDiscriminatorOptions] = DeriveSchema.gen
+    implicit lazy val codec: BsonCodec[WithDiscriminatorOptions] = BsonSchemaCodec.bsonCodec(
+      schema,
+      BsonSchemaCodec.Config(
+        sumTypeHandling = BsonSchemaCodec.Config.SumTypeHandling.DiscriminatorField("type")
+      )
+    )
+  }
+
+  sealed trait WithoutDiscriminatorOptions
+
+  object WithoutDiscriminatorOptions {
+    case class A(s: String) extends WithoutDiscriminatorOptions
+    case class B(s: String) extends WithoutDiscriminatorOptions
+
+    implicit lazy val schema: Schema[WithoutDiscriminatorOptions] = DeriveSchema.gen
+    implicit lazy val codec: BsonCodec[WithoutDiscriminatorOptions] = BsonSchemaCodec.bsonCodec(
+      schema,
+      BsonSchemaCodec.Config(
+        sumTypeHandling = BsonSchemaCodec.Config.SumTypeHandling.WrapperWithClassNameField
+      )
+    )
+  }
+
   @bsonDiscriminator("$type")
   sealed trait WithDiscriminator
 

--- a/zio-schema-bson/src/test/scala/zio/schema/codec/BsonConfig.scala
+++ b/zio-schema-bson/src/test/scala/zio/schema/codec/BsonConfig.scala
@@ -24,7 +24,7 @@ object BsonConfig {
     implicit lazy val schema: Schema[WithClassNameTransformOptions] = DeriveSchema.gen
     implicit lazy val codec: BsonCodec[WithClassNameTransformOptions] = BsonSchemaCodec.bsonCodec(
       schema,
-      BsonSchemaCodec.Config(
+      BsonSchemaCodec.Config.withClassNameMapping(
         classNameMapping = _.toLowerCase
       )
     )
@@ -39,8 +39,8 @@ object BsonConfig {
     implicit lazy val schema: Schema[WithDiscriminatorOptions] = DeriveSchema.gen
     implicit lazy val codec: BsonCodec[WithDiscriminatorOptions] = BsonSchemaCodec.bsonCodec(
       schema,
-      BsonSchemaCodec.Config(
-        sumTypeHandling = BsonSchemaCodec.Config.SumTypeHandling.DiscriminatorField("type")
+      BsonSchemaCodec.Config.withSumTypeHandling(
+        sumTypeHandling = BsonSchemaCodec.SumTypeHandling.DiscriminatorField("type")
       )
     )
   }
@@ -54,8 +54,8 @@ object BsonConfig {
     implicit lazy val schema: Schema[WithoutDiscriminatorOptions] = DeriveSchema.gen
     implicit lazy val codec: BsonCodec[WithoutDiscriminatorOptions] = BsonSchemaCodec.bsonCodec(
       schema,
-      BsonSchemaCodec.Config(
-        sumTypeHandling = BsonSchemaCodec.Config.SumTypeHandling.WrapperWithClassNameField
+      BsonSchemaCodec.Config.withSumTypeHandling(
+        sumTypeHandling = BsonSchemaCodec.SumTypeHandling.WrapperWithClassNameField
       )
     )
   }

--- a/zio-schema-bson/src/test/scala/zio/schema/codec/BsonSchemaCodecSpec.scala
+++ b/zio-schema-bson/src/test/scala/zio/schema/codec/BsonSchemaCodecSpec.scala
@@ -238,6 +238,36 @@ object BsonSchemaCodecSpec extends ZIOSpecDefault {
             doc("b" -> int(1)) -> SchemaConfig.TransientField("defaultValue", 1),
             doc("a" -> str("str"), "b" -> int(1)) -> SchemaConfig.TransientField("str", 1)
           )
+        ),
+        suite("Config with DiscriminatorField")(
+          testEncodeExamples[BsonConfig.WithDiscriminatorOptions](
+            BsonConfig.WithDiscriminatorOptions.A("str") -> doc("type" -> str("A"), "s" -> str("str")),
+            BsonConfig.WithDiscriminatorOptions.B("str") -> doc("type" -> str("B"), "s" -> str("str"))
+          ),
+          testDecodeExamples[BsonConfig.WithDiscriminatorOptions](
+            doc("type" -> str("A"), "s" -> str("str")) -> BsonConfig.WithDiscriminatorOptions.A("str"),
+            doc("type" -> str("B"), "s" -> str("str")) -> BsonConfig.WithDiscriminatorOptions.B("str")
+          )
+        ),
+        suite("Config with WrapperWithClassNameField")(
+          testEncodeExamples[BsonConfig.WithoutDiscriminatorOptions](
+            BsonConfig.WithoutDiscriminatorOptions.A("str") -> doc("A" -> doc("s" -> str("str"))),
+            BsonConfig.WithoutDiscriminatorOptions.B("str") -> doc("B" -> doc("s" -> str("str")))
+          ),
+          testDecodeExamples[BsonConfig.WithoutDiscriminatorOptions](
+            doc("A" -> doc("s" -> str("str"))) -> BsonConfig.WithoutDiscriminatorOptions.A("str"),
+            doc("B" -> doc("s" -> str("str"))) -> BsonConfig.WithoutDiscriminatorOptions.B("str")
+          )
+        ),
+        suite("Config with classNameTransform")(
+          testEncodeExamples[BsonConfig.WithClassNameTransformOptions](
+            BsonConfig.WithClassNameTransformOptions.A("str") -> doc("a" -> doc("s" -> str("str"))),
+            BsonConfig.WithClassNameTransformOptions.B("str") -> doc("b" -> doc("s" -> str("str")))
+          ),
+          testDecodeExamples[BsonConfig.WithClassNameTransformOptions](
+            doc("a" -> doc("s" -> str("str"))) -> BsonConfig.WithClassNameTransformOptions.A("str"),
+            doc("b" -> doc("s" -> str("str"))) -> BsonConfig.WithClassNameTransformOptions.B("str")
+          )
         )
       ),
       suite("bson annotations")(


### PR DESCRIPTION
zio-bson-magnolia has support for a configuration (in addition to annotations). We need this support in zio-schema-bson as well. Right now, I've only implemented discriminator and class name transformer support, since this is what my company needs.