### PR TITLE
restore behavior

### DIFF
--- a/zio-schema-derivation/shared/src/main/scala-2/zio/schema/DeriveSchema.scala
+++ b/zio-schema-derivation/shared/src/main/scala-2/zio/schema/DeriveSchema.scala
@@ -563,7 +563,7 @@ object DeriveSchema {
           child.typeSignature
           val childClass = child.asClass
           if (childClass.isSealed && childClass.isTrait)
-            Set(childClass.asType.toType)
+            knownSubclassesOf(childClass)
           else if (childClass.isCaseClass || (childClass.isClass && childClass.isAbstract)) {
             val st = concreteType(concreteType(tpe, parent.asType.toType), child.asType.toType)
             Set(appliedSubtype(st))

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -1794,7 +1794,7 @@ object JsonCodecSpec extends ZIOSpecDefault {
           Schema[GeoJSON.GeoJSON],
           GeoJSON.Feature(geometry = GeoJSON.Point(1.0 -> 2.0))
         )
-      },
+      } @@ TestAspect.scala2Only,
       test("of case classes with discriminator") {
         assertEncodesThenDecodes(Schema[Command], Command.Cash) &>
           assertEncodesThenDecodes(Schema[Command], Command.Buy(100))

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -1789,6 +1789,12 @@ object JsonCodecSpec extends ZIOSpecDefault {
           RecordExampleWithDiscriminator(f1 = Some("test"), f2 = None)
         )
       },
+      test("nested ADT with discriminator field") {
+        assertEncodesThenDecodes(
+          Schema[GeoJSON.GeoJSON],
+          GeoJSON.Feature(geometry = GeoJSON.Point(1.0 -> 2.0))
+        )
+      },
       test("of case classes with discriminator") {
         assertEncodesThenDecodes(Schema[Command], Command.Cash) &>
           assertEncodesThenDecodes(Schema[Command], Command.Buy(100))
@@ -3093,5 +3099,30 @@ object JsonCodecSpec extends ZIOSpecDefault {
 
   object BigProduct {
     implicit val schema: Schema[BigProduct] = DeriveSchema.gen
+  }
+
+  object GeoJSON {
+    @discriminatorName("type") sealed trait Geometry                            extends Product with Serializable
+    @discriminatorName("type") sealed trait SimpleGeometry                      extends Geometry
+    case class Point(coordinates: (Double, Double))                             extends SimpleGeometry
+    case class MultiPoint(coordinates: Chunk[(Double, Double)])                 extends SimpleGeometry
+    case class LineString(coordinates: Chunk[(Double, Double)])                 extends SimpleGeometry
+    case class MultiLineString(coordinates: Chunk[Chunk[(Double, Double)]])     extends SimpleGeometry
+    case class Polygon(coordinates: Chunk[Chunk[(Double, Double)]])             extends SimpleGeometry
+    case class MultiPolygon(coordinates: Chunk[Chunk[Chunk[(Double, Double)]]]) extends SimpleGeometry
+    case class GeometryCollection(geometries: Chunk[SimpleGeometry])            extends Geometry
+    @discriminatorName("type") sealed trait GeoJSON                             extends Product with Serializable
+    @discriminatorName("type") sealed trait SimpleGeoJSON                       extends GeoJSON
+    case class Feature(
+      properties: Map[String, String] = Map.empty,
+      geometry: Geometry,
+      bbox: Option[(Double, Double, Double, Double)] = None
+    ) extends SimpleGeoJSON
+    case class FeatureCollection(features: Chunk[SimpleGeoJSON], bbox: Option[(Double, Double, Double, Double)] = None)
+        extends GeoJSON
+
+    object GeoJSON {
+      implicit lazy val schema: Schema[GeoJSON] = DeriveSchema.gen
+    }
   }
 }


### PR DESCRIPTION
This reverts Scala2 DeriveSchema macro behaviour that was introduced by [this PR](https://github.com/zio/zio-schema/pull/749) - actually I think its the Scala3 DeriveSchema macro that needs changing (if possible) to match the behaviour of the Scala2 one.