### PR TITLE
Optimize `BinaryCodec::streamDecoder` implementations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,7 @@
-import sbtcrossproject.CrossPlugin.autoImport.*
-import BuildHelper.{crossProjectSettings, *}
-import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.*
+import sbtcrossproject.CrossPlugin.autoImport._
+import BuildHelper.{ crossProjectSettings, _ }
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
-import sbt.{Resolver, ThisBuild}
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -34,9 +33,7 @@ inThisBuild(
     licenses := Seq("Apache-2.0" -> url(s"${scmInfo.value.map(_.browseUrl).get}/blob/v${version.value}/LICENSE")),
     pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
     pgpPublicRing := file("/tmp/public.asc"),
-    pgpSecretRing := file("/tmp/secret.asc"),
-    resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
-    resolvers ++= Resolver.sonatypeOssRepos("staging")
+    pgpSecretRing := file("/tmp/secret.asc")
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
-import sbtcrossproject.CrossPlugin.autoImport._
-import BuildHelper.{ crossProjectSettings, _ }
-import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+import sbtcrossproject.CrossPlugin.autoImport.*
+import BuildHelper.{crossProjectSettings, *}
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.*
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
+import sbt.{Resolver, ThisBuild}
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -33,7 +34,9 @@ inThisBuild(
     licenses := Seq("Apache-2.0" -> url(s"${scmInfo.value.map(_.browseUrl).get}/blob/v${version.value}/LICENSE")),
     pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
     pgpPublicRing := file("/tmp/public.asc"),
-    pgpSecretRing := file("/tmp/secret.asc")
+    pgpSecretRing := file("/tmp/secret.asc"),
+    resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
+    resolvers ++= Resolver.sonatypeOssRepos("staging")
   )
 )
 

--- a/zio-schema-msg-pack/src/main/scala/zio/schema/codec/MessagePackCodec.scala
+++ b/zio-schema-msg-pack/src/main/scala/zio/schema/codec/MessagePackCodec.scala
@@ -28,13 +28,9 @@ object MessagePackCodec {
       }
 
       override def streamDecoder: ZPipeline[Any, DecodeError, Byte, A] =
-        ZPipeline.mapChunksZIO { chunk =>
-          ZIO.fromEither(
-            decodeChunk(chunk).map(Chunk(_))
-          )
-        }
+        ZPipeline.mapChunksEither(bytes => decodeChunk(bytes).map(Chunk.single))
 
-      private def decodeChunk(chunk: Chunk[Byte]) =
+      private def decodeChunk(chunk: Chunk[Byte]): Either[DecodeError, A] =
         new MessagePackDecoder(chunk)
           .decode(schema)
           .left

--- a/zio-schema-msg-pack/src/main/scala/zio/schema/codec/MessagePackCodec.scala
+++ b/zio-schema-msg-pack/src/main/scala/zio/schema/codec/MessagePackCodec.scala
@@ -6,7 +6,7 @@ import java.time._
 import zio.schema.codec.DecodeError.ReadError
 import zio.schema.{ Schema, StandardType }
 import zio.stream.ZPipeline
-import zio.{ Cause, Chunk, ZIO }
+import zio.{ Cause, Chunk }
 
 object MessagePackCodec {
   implicit def messagePackCodec[A](implicit schema: Schema[A]): BinaryCodec[A] =

--- a/zio-schema-protobuf/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
+++ b/zio-schema-protobuf/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
@@ -25,15 +25,13 @@ object ProtobufCodec {
         new Decoder(whole).decode(schema)
 
       override def streamDecoder: ZPipeline[Any, DecodeError, Byte, A] =
-        ZPipeline.mapChunksZIO(chunk => ZIO.fromEither(new Decoder(chunk).decode(schema).map(Chunk(_))))
+        ZPipeline.mapChunksEither(bytes => new Decoder(bytes).decode(schema).map(Chunk.single))
 
       override def encode(value: A): Chunk[Byte] =
         Encoder.process(schema, value)
 
       override def streamEncoder: ZPipeline[Any, Nothing, A, Byte] =
-        ZPipeline.mapChunks(
-          _.flatMap(encode)
-        )
+        ZPipeline.mapChunks(_.flatMap(encode))
     }
 
   object Protobuf {

--- a/zio-schema-protobuf/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
+++ b/zio-schema-protobuf/shared/src/main/scala/zio/schema/codec/ProtobufCodec.scala
@@ -15,7 +15,7 @@ import zio.schema.annotation.fieldDefaultValue
 import zio.schema.codec.DecodeError.{ ExtraFields, MalformedField, MissingField }
 import zio.schema.codec.ProtobufCodec.Protobuf.WireType.LengthDelimited
 import zio.stream.ZPipeline
-import zio.{ Cause, Chunk, ChunkBuilder, Unsafe, ZIO }
+import zio.{ Cause, Chunk, ChunkBuilder, Unsafe }
 
 object ProtobufCodec {
 

--- a/zio-schema-thrift/src/main/scala/zio/schema/codec/ThriftCodec.scala
+++ b/zio-schema-thrift/src/main/scala/zio/schema/codec/ThriftCodec.scala
@@ -27,11 +27,7 @@ object ThriftCodec {
           decodeChunk(whole)
 
       override def streamDecoder: ZPipeline[Any, DecodeError, Byte, A] =
-        ZPipeline.mapChunksZIO { chunk =>
-          ZIO.fromEither(
-            decodeChunk(chunk).map(Chunk(_))
-          )
-        }
+        ZPipeline.mapChunksEither(bytes => decodeChunk(bytes).map(Chunk.single))
 
       override def encode(value: A): Chunk[Byte] =
         new Encoder().encode(schema, value)

--- a/zio-schema-thrift/src/main/scala/zio/schema/codec/ThriftCodec.scala
+++ b/zio-schema-thrift/src/main/scala/zio/schema/codec/ThriftCodec.scala
@@ -14,7 +14,7 @@ import zio.schema.MutableSchemaBasedValueBuilder.{ CreateValueFromSchemaError, R
 import zio.schema._
 import zio.schema.codec.DecodeError.{ EmptyContent, MalformedFieldWithPath, ReadError, ReadErrorWithPath }
 import zio.stream.ZPipeline
-import zio.{ Cause, Chunk, Unsafe, ZIO }
+import zio.{ Cause, Chunk, Unsafe }
 
 object ThriftCodec {
 


### PR DESCRIPTION
Use the new `ZPipeline.mapChunksEither` and `ZPipeline.mapEitherChunked` methods from ZIO to avoid using ZIO with pure code