### PR TITLE
refactor: accumulate all errors in DynamicValue decoding using Valida…

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -120,7 +120,7 @@ object DynamicValueSpec extends ZIOSpecDefault {
           val result = dynamic.toTypedValueV(schema)
           assertTrue(
             result.isFailure &&
-            result.fold(errors => errors.size == 1, _ => false)
+              result.fold(errors => errors.size == 1, _ => false)
           )
         }
       )

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -116,7 +116,7 @@ sealed trait DynamicValue {
                 vDyn.toTypedValueLazyValidation(schema.valueSchema)
               )((k, v) => (k, v))
           })
-          .map(_.toMap)
+          .map(pairs => ListMap(pairs.toSeq: _*))
 
       case (_, l @ Schema.Lazy(_)) =>
         toTypedValueLazyValidation(l.schema)
@@ -219,7 +219,7 @@ object DynamicValue {
             Validation.fail(DecodeError.IncompatibleShape(values, structure))
         }
       })
-      .map(_.to(ListMap))
+      .map(pairs => ListMap(pairs.toSeq: _*))
   }
 
   final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue


### PR DESCRIPTION
### Improve DynamicValue error handling to accumulate all errors (#480)

#### **Description**
This PR refactors the error handling in `DynamicValue` decoding to use `zio.prelude.Validation`, enabling the accumulation of all errors encountered during the transformation of a `DynamicValue` into a typed value. Previously, the decoding logic used `Either`, which was fail-fast and only reported the first error.

**Key changes:**
- **Error Accumulation:** All decoding logic now uses `Validation`, so multiple errors (e.g., in record fields) are accumulated and reported together.
- **API Update:** The main API now exposes `toTypedValueV` (returns `Validation[DecodeError, A]`), with compatibility methods for `Either` and `Option`.
- **Backward Compatibility:** Deprecated the old fail-fast methods, which now internally use the new logic but only return the first error.
- **Tests:** Added and updated tests to verify that error accumulation works as intended, including a test that checks the number of accumulated errors.

Solves - #480 
/claim #480