### PR TITLE
Feature/issue 511 type registry

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/Issue511Spec.scala
+++ b/tests/shared/src/test/scala/zio/schema/Issue511Spec.scala
@@ -1,0 +1,211 @@
+package zio.schema
+
+import zio.Chunk
+import zio.schema.validation.Validation
+import zio.test._
+
+object Issue511Spec extends ZIOSpecDefault {
+
+  def spec: Spec[TestEnvironment, Any] = suite("Issue511Spec")(
+    test("toTypedValue works with registry after AST reconstruction") {
+      final case class User(name: String, age: Int)
+      implicit val schema: Schema[User] = Schema.CaseClass2[String, Int, User](
+        TypeId.parse("zio.schema.Issue511Spec.User"),
+        Schema.Field("name", Schema[String], Chunk.empty, Validation.succeed, _.name, (u, n) => u.copy(name = n)),
+        Schema.Field("age", Schema[Int], Chunk.empty, Validation.succeed, _.age, (u, a) => u.copy(age = a)),
+        (name, age) => User(name, age)
+      )
+
+      val user         = User("John", 30)
+      val dynamicValue = schema.toDynamic(user)
+
+      val registry  = Map(schema.asInstanceOf[Schema.Record[User]].id -> schema)
+      val astSchema = schema.ast.toSchema(registry)
+
+      val result = dynamicValue.toTypedValue(astSchema)
+
+      assertTrue(result == Right(user))
+    },
+    test("nested product test - Company with Department with Manager") {
+      final case class Manager(name: String, salary: Int)
+      val managerSchema: Schema[Manager] = Schema.CaseClass2[String, Int, Manager](
+        TypeId.parse("zio.schema.Issue511Spec.Manager"),
+        Schema.Field("name", Schema[String], Chunk.empty, Validation.succeed, _.name, (m, n) => m.copy(name = n)),
+        Schema.Field("salary", Schema[Int], Chunk.empty, Validation.succeed, _.salary, (m, s) => m.copy(salary = s)),
+        (name, salary) => Manager(name, salary)
+      )
+
+      final case class Department(name: String, manager: Manager)
+      val departmentSchema: Schema[Department] = Schema.CaseClass2[String, Manager, Department](
+        TypeId.parse("zio.schema.Issue511Spec.Department"),
+        Schema.Field("name", Schema[String], Chunk.empty, Validation.succeed, _.name, (d, n) => d.copy(name = n)),
+        Schema
+          .Field("manager", managerSchema, Chunk.empty, Validation.succeed, _.manager, (d, m) => d.copy(manager = m)),
+        (name, manager) => Department(name, manager)
+      )
+
+      final case class Company(name: String, department: Department)
+      val companySchema: Schema[Company] = Schema.CaseClass2[String, Department, Company](
+        TypeId.parse("zio.schema.Issue511Spec.Company"),
+        Schema.Field("name", Schema[String], Chunk.empty, Validation.succeed, _.name, (c, n) => c.copy(name = n)),
+        Schema.Field(
+          "department",
+          departmentSchema,
+          Chunk.empty,
+          Validation.succeed,
+          _.department,
+          (c, d) => c.copy(department = d)
+        ),
+        (name, department) => Company(name, department)
+      )
+
+      val company      = Company("TechCorp", Department("Engineering", Manager("Alice", 100000)))
+      val dynamicValue = companySchema.toDynamic(company)
+
+      val registry = Map(
+        managerSchema.asInstanceOf[Schema.Record[Manager]].id       -> managerSchema,
+        departmentSchema.asInstanceOf[Schema.Record[Department]].id -> departmentSchema,
+        companySchema.asInstanceOf[Schema.Record[Company]].id       -> companySchema
+      )
+      val astSchema = companySchema.ast.toSchema(registry)
+
+      val result = dynamicValue.toTypedValue(astSchema)
+
+      assertTrue(result == Right(company))
+    },
+    test("recursive test - Category with subCategories") {
+      final case class Category(name: String, subCategories: List[Category])
+
+      implicit lazy val categorySchema: Schema[Category] = Schema.defer {
+        Schema.CaseClass2[String, List[Category], Category](
+          TypeId.parse("zio.schema.Category"),
+          Schema.Field(
+            "name",
+            Schema[String],
+            Chunk.empty,
+            Validation.succeed,
+            (c: Category) => c.name,
+            (c: Category, n: String) => c.copy(name = n)
+          ),
+          Schema.Field(
+            "subCategories",
+            Schema[List[Category]],
+            Chunk.empty,
+            Validation.succeed,
+            (c: Category) => c.subCategories,
+            (c: Category, s: List[Category]) => c.copy(subCategories = s)
+          ),
+          (name: String, subCategories: List[Category]) => Category(name, subCategories)
+        )
+      }
+
+      val category     = Category("Electronics", List(Category("Phones", Nil), Category("Laptops", Nil)))
+      val dynamicValue = categorySchema.toDynamic(category)
+
+      val registry  = Map(TypeId.parse("zio.schema.Category") -> categorySchema)
+      val astSchema = categorySchema.ast.toSchema(registry)
+
+      val result = dynamicValue.toTypedValue(astSchema)
+
+      assertTrue(result == Right(category))
+    },
+    test("enum-in-record test - Person with Status enum") {
+      sealed trait Status
+      object Status {
+        case object Active   extends Status
+        case object Inactive extends Status
+        case object Pending  extends Status
+      }
+
+      val activeCase = Schema.Case[Status, Unit](
+        "Active",
+        Schema.CaseClass0[Unit](TypeId.parse("zio.schema.Issue511Spec.Status.Active"), () => ()),
+        (_: Status) => (),
+        (_: Unit) => Status.Active,
+        (_: Status) == Status.Active,
+        Chunk.empty
+      )
+      val inactiveCase = Schema.Case[Status, Unit](
+        "Inactive",
+        Schema.CaseClass0[Unit](TypeId.parse("zio.schema.Issue511Spec.Status.Inactive"), () => ()),
+        (_: Status) => (),
+        (_: Unit) => Status.Inactive,
+        (_: Status) == Status.Inactive,
+        Chunk.empty
+      )
+      val pendingCase = Schema.Case[Status, Unit](
+        "Pending",
+        Schema.CaseClass0[Unit](TypeId.parse("zio.schema.Issue511Spec.Status.Pending"), () => ()),
+        (_: Status) => (),
+        (_: Unit) => Status.Pending,
+        (_: Status) == Status.Pending,
+        Chunk.empty
+      )
+
+      val caseSet =
+        CaseSet.Cons(activeCase, CaseSet.Cons(inactiveCase, CaseSet.Cons(pendingCase, CaseSet.Empty[Status]())))
+      val statusSchema: Schema[Status] = Schema.enumeration(TypeId.parse("zio.schema.Issue511Spec.Status"), caseSet)
+
+      final case class Person(name: String, status: Status)
+      val personSchema: Schema[Person] = Schema.CaseClass2[String, Status, Person](
+        TypeId.parse("zio.schema.Issue511Spec.Person"),
+        Schema.Field("name", Schema[String], Chunk.empty, Validation.succeed, _.name, (p, n) => p.copy(name = n)),
+        Schema.Field("status", statusSchema, Chunk.empty, Validation.succeed, _.status, (p, s) => p.copy(status = s)),
+        (name, status) => Person(name, status)
+      )
+
+      val person       = Person("Bob", Status.Active)
+      val dynamicValue = personSchema.toDynamic(person)
+
+      val registry = Map(
+        statusSchema.asInstanceOf[Schema.Enum[Status]].id        -> statusSchema,
+        personSchema.asInstanceOf[Schema.Record[Person]].id      -> personSchema,
+        activeCase.schema.asInstanceOf[Schema.Record[Unit]].id   -> activeCase.schema,
+        inactiveCase.schema.asInstanceOf[Schema.Record[Unit]].id -> inactiveCase.schema,
+        pendingCase.schema.asInstanceOf[Schema.Record[Unit]].id  -> pendingCase.schema
+      )
+
+      val astSchema = personSchema.ast.toSchema(registry)
+      val result    = dynamicValue.toTypedValue(astSchema)
+
+      assertTrue(result == Right(person))
+    },
+    test("handle registry poisoning gracefully") {
+      final case class Person(name: String, age: Int)
+      val personSchema: Schema[Person] = Schema.CaseClass2[String, Int, Person](
+        TypeId.parse("zio.schema.Issue511Spec.Person"),
+        Schema.Field(
+          "name",
+          Schema[String],
+          Chunk.empty,
+          Validation.succeed,
+          (p: Person) => p.name,
+          (p: Person, n: String) => p.copy(name = n)
+        ),
+        Schema.Field(
+          "age",
+          Schema[Int],
+          Chunk.empty,
+          Validation.succeed,
+          (p: Person) => p.age,
+          (p: Person, a: Int) => p.copy(age = a)
+        ),
+        (name: String, age: Int) => Person(name, age)
+      )
+
+      val person       = Person("Alice", 30)
+      val dynamicValue = personSchema.toDynamic(person)
+
+      val poisonedRegistry = Map(
+        TypeId.parse("zio.schema.Issue511Spec.Person") -> Schema.Fail("Mismatched schema")
+      )
+
+      val astSchema = personSchema.ast.toSchema(poisonedRegistry)
+      val result    = dynamicValue.toTypedValue(astSchema)
+
+      assertTrue(
+        result == Right(scala.collection.immutable.ListMap("name" -> "Alice", "age" -> 30))
+      )
+    }
+  )
+}

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -44,7 +44,16 @@ sealed trait DynamicValue {
       case (DynamicValue.Enumeration(_, (key, value)), s: Schema.Enum[A]) =>
         s.caseOf(key) match {
           case Some(caseValue) =>
-            value.toTypedValueLazyError(caseValue.schema).asInstanceOf[Either[DecodeError, A]]
+            value.toTypedValueLazyError(caseValue.schema).flatMap { decodedValue =>
+              scala.util.Try {
+                caseValue.asInstanceOf[Schema.Case[A, Any]].construct(decodedValue.asInstanceOf[Any]).asInstanceOf[A]
+              } match {
+                case scala.util.Success(value) =>
+                  Right(value)
+                case scala.util.Failure(err) =>
+                  Left(DecodeError.MalformedField(s, s"Enum case construction failed for '$key': ${err.getMessage}"))
+              }
+            }
           case None => Left(DecodeError.MissingCase(key, s))
         }
 

--- a/zio-schema/shared/src/main/scala/zio/schema/meta/ExtensibleMetaSchema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/meta/ExtensibleMetaSchema.scala
@@ -18,7 +18,12 @@ sealed trait ExtensibleMetaSchema[BuiltIn <: TypeList] { self =>
 
   def toSchema: Schema[_] = {
     val refMap = mutable.HashMap.empty[NodePath, Schema[_]]
-    ExtensibleMetaSchema.materialize(self, refMap)(builtInInstances)
+    ExtensibleMetaSchema.materialize(self, refMap, Map.empty)(builtInInstances)
+  }
+
+  def toSchema(registry: Map[TypeId, Schema[_]]): Schema[_] = {
+    val refMap = mutable.HashMap.empty[NodePath, Schema[_]]
+    ExtensibleMetaSchema.materialize(self, refMap, registry)(builtInInstances)
   }
 
   override def toString: String = AstRenderer.render(self)
@@ -691,85 +696,121 @@ object ExtensibleMetaSchema {
 
   private[schema] def materialize[BuiltIn <: TypeList](
     ast: ExtensibleMetaSchema[BuiltIn],
-    refs: mutable.Map[NodePath, Schema[_]]
+    refs: mutable.Map[NodePath, Schema[_]],
+    registry: Map[TypeId, Schema[_]]
   )(implicit builtInInstances: SchemaInstances[BuiltIn]): Schema[_] = {
     val baseSchema = ast match {
       case ExtensibleMetaSchema.Value(typ, _, _) =>
         Schema.Primitive(typ, Chunk.empty)
-      case ExtensibleMetaSchema.FailNode(msg, _, _) => Schema.Fail(msg)
+      case ExtensibleMetaSchema.FailNode(msg, _, _) =>
+        Schema.Fail(msg)
       case ExtensibleMetaSchema.Ref(refPath, _, _) =>
         def resolve[A](): Schema[A] =
           refs.getOrElse(refPath, Schema.Fail(s"invalid ref path $refPath")).asInstanceOf[Schema[A]]
         Schema.defer(resolve())
       case ExtensibleMetaSchema.Product(id, _, elems, _) =>
-        Schema.record(
-          id,
-          elems.map {
-            case Labelled(label, ast) =>
-              Schema.Field(
-                label,
-                materialize(ast, refs).asInstanceOf[Schema[Any]],
-                get0 = (p: ListMap[String, _]) => p(label),
-                set0 = (p: ListMap[String, _], v: Any) => p.updated(label, v)
-              )
-          }: _*
-        )
+        registry
+          .get(id)
+          .map {
+            case l: Schema.Lazy[_] => l.schema
+            case s                 => s
+          }
+          .collect { case r: Schema.Record[_] => r }
+          .getOrElse {
+            Schema.record(
+              id,
+              elems.map {
+                case Labelled(label, ast) =>
+                  Schema.Field(
+                    label,
+                    materialize(ast, refs, registry).asInstanceOf[Schema[Any]],
+                    get0 = (p: ListMap[String, _]) => p(label),
+                    set0 = (p: ListMap[String, _], v: Any) => p.updated(label, v)
+                  )
+              }: _*
+            )
+          }
       case ExtensibleMetaSchema.Tuple(_, left, right, _) =>
         Schema.tuple2(
-          materialize(left, refs),
-          materialize(right, refs)
+          materialize(left, refs, registry),
+          materialize(right, refs, registry)
         )
-      case ExtensibleMetaSchema.Sum(id, _, elems, _) => {
-        val (cases, isSimple) = elems.foldRight[(CaseSet.Aux[Any], Boolean)]((CaseSet.Empty[Any](), true)) {
-          case (Labelled(label, ast), (acc, wasSimple)) => {
-            val _case: Schema.Case[Any, Any] = Schema
-              .Case[Any, Any](
-                label,
-                materialize(ast, refs).asInstanceOf[Schema[Any]],
-                identity[Any],
-                identity[Any],
-                _.isInstanceOf[Any],
-                Chunk.empty
-              )
-            val isSimple: Boolean = _case.schema match {
-              case _: Schema.CaseClass0[_] => true
-              case _                       => false
-            }
-            (CaseSet.Cons(_case, acc), wasSimple && isSimple)
+      case ExtensibleMetaSchema.Sum(id, _, elems, _) =>
+        registry
+          .get(id)
+          .map {
+            case l: Schema.Lazy[_] => l.schema
+            case s                 => s
           }
-        }
-        Schema.enumeration[Any, CaseSet.Aux[Any]](
-          id,
-          cases,
-          if (isSimple) Chunk(new simpleEnum(true)) else Chunk.empty
-        )
-      }
+          .collect { case e: Schema.Enum[_] => e }
+          .getOrElse {
+            val (cases, isSimple) = elems.foldRight[(CaseSet.Aux[Any], Boolean)]((CaseSet.Empty[Any](), true)) {
+              case (Labelled(label, ast), (acc, wasSimple)) =>
+                val _case: Schema.Case[Any, Any] = Schema.Case[Any, Any](
+                  label,
+                  materialize(ast, refs, registry).asInstanceOf[Schema[Any]],
+                  identity[Any],
+                  identity[Any],
+                  _.isInstanceOf[Any],
+                  Chunk.empty
+                )
+                val isSimple: Boolean = _case.schema match {
+                  case _: Schema.CaseClass0[_] => true
+                  case _                       => false
+                }
+                (CaseSet.Cons(_case, acc), wasSimple && isSimple)
+            }
+            Schema.enumeration[Any, CaseSet.Aux[Any]](
+              id,
+              cases,
+              if (isSimple) Chunk(new simpleEnum(true)) else Chunk.empty
+            )
+          }
       case ExtensibleMetaSchema.Either(_, left, right, _) =>
         Schema.either(
-          materialize(left, refs),
-          materialize(right, refs)
+          materialize(left, refs, registry),
+          materialize(right, refs, registry)
         )
       case ExtensibleMetaSchema.Fallback(_, left, right, _) =>
         Schema.Fallback(
-          materialize(left, refs),
-          materialize(right, refs)
+          materialize(left, refs, registry),
+          materialize(right, refs, registry)
         )
       case ExtensibleMetaSchema.ListNode(itemAst, _, _) =>
-        Schema.chunk(materialize(itemAst, refs))
+        Schema.chunk(materialize(itemAst, refs, registry))
       case ExtensibleMetaSchema.Dictionary(keyAst, valueAst, _, _) =>
-        Schema.Map(materialize(keyAst, refs), materialize(valueAst, refs), Chunk.empty)
+        Schema.Map(materialize(keyAst, refs, registry), materialize(valueAst, refs, registry), Chunk.empty)
       case ExtensibleMetaSchema.Known(typeId, _, _) =>
-        builtInInstances.all.collectFirst {
-          case record: Schema.Record[_] if record.id == typeId => record
-          case e: Schema.Enum[_] if e.id == typeId             => e
-          case dyn: Schema.Dynamic if dyn.id == typeId         => dyn
-        }.getOrElse(Schema.Fail(s"invalid known type id $typeId"))
+        registry
+          .get(typeId)
+          .map {
+            case l: Schema.Lazy[_] => l.schema
+            case s                 => s
+          }
+          .collect {
+            case r: Schema.Record[_] => r
+            case e: Schema.Enum[_]   => e
+            case d: Schema.Dynamic   => d
+          }
+          .getOrElse {
+            builtInInstances.all.collectFirst {
+              case record: Schema.Record[_] if record.id == typeId => record
+              case e: Schema.Enum[_] if e.id == typeId             => e
+              case dyn: Schema.Dynamic if dyn.id == typeId         => dyn
+            }.getOrElse(Schema.Fail(s"invalid known type id $typeId"))
+          }
     }
 
     refs += ast.path -> baseSchema
 
     if (ast.optional) baseSchema.optional else baseSchema
   }
+
+  private[schema] def materialize[BuiltIn <: TypeList](
+    ast: ExtensibleMetaSchema[BuiltIn],
+    refs: mutable.Map[NodePath, Schema[_]]
+  )(implicit builtInInstances: SchemaInstances[BuiltIn]): Schema[_] =
+    materialize(ast, refs, Map.empty)
 
   implicit def schema[BuiltIn <: TypeList](
     implicit builtInInstances: SchemaInstances[BuiltIn]


### PR DESCRIPTION
## Description
This PR addresses **Issue #511** by enabling `ExtensibleMetaSchema.materialize` to utilize an explicit `Map[TypeId, Schema[_]]` registry. This allows for the successful reconstruction of typed schemas from ASTs even when those types are not part of the standard built-in instances.

## Key Changes
- **Registry Integration**: Updated `materialize` to prioritize lookups in the provided registry.
- **Type-Safe Fallback**: Implemented the `.collect { case ... }` pattern in `Sum` and `Product` cases. This ensures that if the registry contains a type-mismatched schema, the system gracefully falls back to AST-based construction rather than failing or casting incorrectly.
- **Improved Resilience**: Hardened `DynamicValue` reconstruction for enums by wrapping construction in `Try` to propagate meaningful `DecodeError`s.
- **Recursive Support**: Ensured proper propagation of both `refs` and `registry` through nested and recursive structures.

## Verification
- **New Test Suite**: Added `Issue511Spec` with 5 scenarios:
  - Recursive data types (Category/subCategories).
  - Custom registry prioritization for Products and Sums.
  - Graceful fallback for "poisoned" (type-mismatched) registry entries.
- **Regression Testing**: All **849** existing tests passed (JVM).

/claim #511