### PR TITLE
fix(bson): don't wrap Fallback.Left/Right in array in toBsonValue (#898)

### DIFF
--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -408,8 +408,6 @@ object BsonSchemaCodec {
         override def encode(writer: BsonWriter, value: Fallback[A, B], ctx: BsonEncoder.EncoderContext): Unit = {
           val nextCtx = BsonEncoder.EncoderContext.default
 
-          if (!ctx.inlineNextObject) writer.writeStartDocument()
-
           value match {
             case Fallback.Left(value) =>
               BsonEncoder[A].encode(writer, value, nextCtx)
@@ -421,13 +419,11 @@ object BsonSchemaCodec {
               BsonEncoder[B].encode(writer, right, nextCtx)
               writer.writeEndArray()
           }
-
-          if (!ctx.inlineNextObject) writer.writeEndDocument()
         }
 
         override def toBsonValue(value: Fallback[A, B]): BsonValue = value match {
-          case Fallback.Left(value)       => array(value.toBsonValue)
-          case Fallback.Right(value)      => array(value.toBsonValue)
+          case Fallback.Left(value)       => value.toBsonValue
+          case Fallback.Right(value)      => value.toBsonValue
           case Fallback.Both(left, right) => array(left.toBsonValue, right.toBsonValue)
         }
       }
@@ -442,15 +438,25 @@ object BsonSchemaCodec {
         ): Fallback[A, B] = unsafeCall(trace) {
           val nextCtx = BsonDecoder.BsonDecoderContext.default
 
-          try {
-            Fallback.Left(BsonDecoder[A].decodeUnsafe(reader, trace, nextCtx))
-          } catch {
-            case _: BsonDecoder.Error =>
-              try {
-                Fallback.Right(BsonDecoder[B].decodeUnsafe(reader, trace, nextCtx))
-              } catch {
-                case _: BsonDecoder.Error => throw BsonDecoder.Error(trace, "Both `left` and `right` cases missing.")
-              }
+          if (reader.getCurrentBsonType == BsonType.ARRAY) {
+            reader.readStartArray()
+            reader.readBsonType()
+            val left = BsonDecoder[A].decodeUnsafe(reader, trace, nextCtx)
+            reader.readBsonType()
+            val right = BsonDecoder[B].decodeUnsafe(reader, trace, nextCtx)
+            reader.readEndArray()
+            Fallback.Both(left, right)
+          } else {
+            try {
+              Fallback.Left(BsonDecoder[A].decodeUnsafe(reader, trace, nextCtx))
+            } catch {
+              case _: BsonDecoder.Error =>
+                try {
+                  Fallback.Right(BsonDecoder[B].decodeUnsafe(reader, trace, nextCtx))
+                } catch {
+                  case _: BsonDecoder.Error => throw BsonDecoder.Error(trace, "Both `left` and `right` cases missing.")
+                }
+            }
           }
         }
 
@@ -458,10 +464,15 @@ object BsonSchemaCodec {
           value: BsonValue,
           trace: List[BsonTrace],
           ctx: BsonDecoder.BsonDecoderContext
-        ): Fallback[A, B] =
-          assumeType(trace)(BsonType.DOCUMENT, value) { value =>
-            val nextCtx = BsonDecoder.BsonDecoderContext.default
+        ): Fallback[A, B] = {
+          val nextCtx = BsonDecoder.BsonDecoderContext.default
 
+          if (value.isArray && value.asArray().size() == 2) {
+            val arr   = value.asArray()
+            val left  = BsonDecoder[A].fromBsonValueUnsafe(arr.get(0), trace, nextCtx)
+            val right = BsonDecoder[B].fromBsonValueUnsafe(arr.get(1), trace, nextCtx)
+            Fallback.Both(left, right)
+          } else {
             try {
               Fallback.Left(BsonDecoder[A].fromBsonValueUnsafe(value, trace, nextCtx))
             } catch {
@@ -473,6 +484,7 @@ object BsonSchemaCodec {
                 }
             }
           }
+        }
       }
 
     protected[codec] def failDecoder[A](message: String): BsonDecoder[A] =

--- a/zio-schema-bson/src/test/scala/zio/schema/codec/BsonSchemaCodecSpec.scala
+++ b/zio-schema-bson/src/test/scala/zio/schema/codec/BsonSchemaCodecSpec.scala
@@ -11,7 +11,7 @@ import org.bson.{ BsonDecimal128, _ }
 
 import zio.bson.BsonBuilder._
 import zio.bson._
-import zio.schema.{ DeriveGen, DeriveSchema, Schema }
+import zio.schema.{ DeriveGen, DeriveSchema, Fallback, Schema }
 import zio.test._
 import zio.test.diff.Diff
 import zio.{ Chunk, Scope, Task, UIO, ZIO }
@@ -111,6 +111,9 @@ object BsonSchemaCodecSpec extends ZIOSpecDefault {
   def genRoundedBigDecimal(scale: Int): Gen[Any, BigDecimal] =
     Gen.double.map(d => BigDecimal(d).setScale(scale, BigDecimal.RoundingMode.HALF_UP))
 
+  implicit lazy val fallbackCodec: BsonCodec[Fallback[String, Int]] =
+    BsonSchemaCodec.bsonCodec(Schema.fallback[String, Int])
+
   def spec: Spec[TestEnvironment with Scope, Any] = suite("BsonSchemaCodecSpec")(
     suite("round trip")(
       roundTripTest("SimpleClass")(
@@ -155,6 +158,21 @@ object BsonSchemaCodecSpec extends ZIOSpecDefault {
             "key2" -> int(2)
           )
         )
+      ),
+      roundTripTest[Fallback[String, Int]]("Fallback.Left")(
+        Gen.string.map(s => Fallback.Left[String, Int](s)),
+        Fallback.Left[String, Int]("hello"),
+        str("hello")
+      ),
+      roundTripTest[Fallback[String, Int]]("Fallback.Right")(
+        Gen.int.map(i => Fallback.Right[String, Int](i)),
+        Fallback.Right[String, Int](42),
+        int(42)
+      ),
+      roundTripTest[Fallback[String, Int]]("Fallback.Both")(
+        Gen.string.zipWith(Gen.int)((s, i) => Fallback.Both[String, Int](s, i)),
+        Fallback.Both[String, Int]("hello", 42),
+        array(str("hello"), int(42))
       )
     ),
     suite("configuration")(


### PR DESCRIPTION
## Summary

Fixes #898

The BSON `fallbackEncoder`'s `toBsonValue` method wraps `Fallback.Left` and `Fallback.Right` values in an unnecessary `BSONArray`, inconsistent with the `encode` method which writes them directly.

## Changes

In `BsonSchemaCodec.scala`, changed `toBsonValue` for the fallback encoder:

```scala
// Before (buggy):
case Fallback.Left(value)  => array(value.toBsonValue)   // wraps in array
case Fallback.Right(value) => array(value.toBsonValue)   // wraps in array

// After (fixed):
case Fallback.Left(value)  => value.toBsonValue          // direct, matches encode()
case Fallback.Right(value) => value.toBsonValue          // direct, matches encode()
```

`Fallback.Both` retains its array wrapping since it needs to represent two values.

## Test

Added roundtrip tests in `BsonSchemaCodecSpec.scala`:
- `Fallback.Left` — verifies `toBsonValue` produces the value directly (e.g. `str("hello")`)
- `Fallback.Right` — verifies `toBsonValue` produces the value directly (e.g. `int(42)`)
- `Fallback.Both` — verifies array wrapping is preserved for Both