### PR TITLE
fix(bson): handle missing optional fields in GenericRecord decoder (#940)

### DIFF
--- a/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
+++ b/zio-schema-bson/src/main/scala/zio/schema/codec/BsonSchemaCodec.scala
@@ -1240,7 +1240,13 @@ object BsonSchemaCodec {
 
           reader.readEndDocument()
 
-          (ListMap.newBuilder[String, Any] ++= builder.result()).result()
+          val result = (ListMap.newBuilder[String, Any] ++= builder.result()).result()
+          structure.foldLeft(result) { (map, field) =>
+            if (map.contains(field.name)) map
+            else if ((field.optional || field.transient) && field.defaultValue.isDefined)
+              map + (field.name -> field.defaultValue.get)
+            else map
+          }
         }
 
         override def fromBsonValueUnsafe(
@@ -1248,7 +1254,7 @@ object BsonSchemaCodec {
           trace: List[BsonTrace],
           ctx: BsonDecoder.BsonDecoderContext
         ): ListMap[String, Any] = assumeType(trace)(BsonType.DOCUMENT, value) { value =>
-          ListMap(
+          val result = ListMap(
             value
               .asDocument()
               .asScala
@@ -1265,6 +1271,12 @@ object BsonSchemaCodec {
                   }
               }: _*
           )
+          structure.foldLeft(result) { (map, field) =>
+            if (map.contains(field.name)) map
+            else if ((field.optional || field.transient) && field.defaultValue.isDefined)
+              map + (field.name -> field.defaultValue.get)
+            else map
+          }
         }
       }
 

--- a/zio-schema-bson/src/test/scala/zio/schema/codec/BsonSchemaCodecSpec.scala
+++ b/zio-schema-bson/src/test/scala/zio/schema/codec/BsonSchemaCodecSpec.scala
@@ -114,6 +114,37 @@ object BsonSchemaCodecSpec extends ZIOSpecDefault {
   implicit lazy val fallbackCodec: BsonCodec[Fallback[String, Int]] =
     BsonSchemaCodec.bsonCodec(Schema.fallback[String, Int])
 
+  case class GenericRecordBig(
+    a: Option[String] = None,
+    b: Option[String] = None,
+    c: Option[String] = None,
+    d: Option[String] = None,
+    e: Option[String] = None,
+    f: Option[String] = None,
+    g: Option[String] = None,
+    h: Option[String] = None,
+    i: Option[String] = None,
+    j: Option[String] = None,
+    k: Option[String] = None,
+    l: Option[String] = None,
+    m: Option[String] = None,
+    n: Option[String] = None,
+    o: Option[String] = None,
+    p: Option[String] = None,
+    q: Option[String] = None,
+    r: Option[String] = None,
+    s: Option[String] = None,
+    t: Option[String] = None,
+    u: Option[String] = None,
+    v: Option[String] = None,
+    w: Option[String] = None
+  )
+
+  object GenericRecordBig {
+    implicit val schema: Schema[GenericRecordBig]        = DeriveSchema.gen
+    implicit lazy val codec: BsonCodec[GenericRecordBig] = BsonSchemaCodec.bsonCodec(schema)
+  }
+
   def spec: Spec[TestEnvironment with Scope, Any] = suite("BsonSchemaCodecSpec")(
     suite("round trip")(
       roundTripTest("SimpleClass")(
@@ -482,6 +513,12 @@ object BsonSchemaCodecSpec extends ZIOSpecDefault {
           )
         )
       )
+    ),
+    suite("GenericRecord")(
+      test("decodes GenericRecord with missing optional fields") {
+        val result = BsonDocument.parse("{}").as[GenericRecordBig]
+        assertTrue(result.isRight)
+      }
     )
   )
 


### PR DESCRIPTION
## Summary
- Fixes `recordDecoder` (used for `Schema.GenericRecord` / case classes with 22+ fields) to fill in default values for missing optional and transient fields
- Previously, only fields present in the BSON document were included — missing optional fields caused "Field X is missing" errors instead of being filled with their defaults
- Adds the same default-filling logic that `caseClassDecoder` already has, applied to both `decodeUnsafe` and `fromBsonValueUnsafe` paths

Fixes #940