### PR TITLE
Improve DynamicValue error handling

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -2,8 +2,8 @@ package zio.schema
 
 import scala.collection.immutable.ListMap
 
-import zio.prelude.ZValidation
 import zio._
+import zio.prelude.ZValidation
 import zio.schema.Schema.Primitive
 import zio.schema.SchemaGen._
 import zio.test.Assertion._
@@ -114,22 +114,27 @@ object DynamicValueSpec extends ZIOSpecDefault {
           val person = Person("Alice", 30)
           val result = DynamicValue.fromSchemaAndValue(Person.schema, person).toTypedValueAccumulating[Person]
 
-          result match {
-            case ZValidation.Success(_, value) => assertTrue(value == person)
-            case ZValidation.Failure(_, _)     => assertTrue(false)
-          }
+          assert(result)(equalTo(zio.prelude.Validation.succeed(person)))
         },
         test("matches toTypedValue on successful primitive decodes") {
           check(SchemaGen.anyPrimitiveAndValue) {
             case (schema, value) =>
               val dynamic = DynamicValue.fromSchemaAndValue(schema, value)
 
-              (dynamic.toTypedValue(schema), dynamic.toTypedValueAccumulating(schema)) match {
-                case (Right(fast), ZValidation.Success(_, accumulating)) => assertTrue(fast == accumulating)
-                case (Left(_), _)                                        => assertTrue(false)
-                case (_, ZValidation.Failure(_, _))                      => assertTrue(false)
-              }
+              assertTrue(dynamic.toTypedValue(schema) == Right(value)) &&
+              assertTrue(dynamic.toTypedValueAccumulating(schema) == zio.prelude.Validation.succeed(value))
           }
+        },
+        test("decodes records using schema field order") {
+          val reorderedRecord = DynamicValue.Record(
+            TypeId.parse("zio.schema.DynamicValueSpec.Person"),
+            ListMap(
+              "age"  -> DynamicValue.Primitive(30, StandardType.IntType),
+              "name" -> DynamicValue.Primitive("Alice", StandardType.StringType)
+            )
+          )
+
+          assert(reorderedRecord.toTypedValueAccumulating[Person])(equalTo(zio.prelude.Validation.succeed(Person("Alice", 30))))
         },
         test("accumulates multiple record field errors") {
           val badRecord = DynamicValue.Record(
@@ -154,6 +159,36 @@ object DynamicValueSpec extends ZIOSpecDefault {
 
           assertTrue(result.isFailure) &&
           assertTrue(errorCount(result) >= 2)
+        },
+        test("accumulates set element errors") {
+          val badSet = DynamicValue.SetValue(
+            Set(
+              DynamicValue.Primitive("first", StandardType.StringType),
+              DynamicValue.Primitive("second", StandardType.StringType)
+            )
+          )
+          val result = badSet.toTypedValueAccumulating[Set[Int]]
+
+          assertTrue(result.isFailure) &&
+          assertTrue(errorCount(result) >= 2)
+        },
+        test("accumulates map key and value errors") {
+          val badMap = DynamicValue.Dictionary(
+            Chunk(
+              (
+                DynamicValue.Primitive("bad-key-1", StandardType.StringType),
+                DynamicValue.Primitive("bad-value-1", StandardType.StringType)
+              ),
+              (
+                DynamicValue.Primitive("bad-key-2", StandardType.StringType),
+                DynamicValue.Primitive("bad-value-2", StandardType.StringType)
+              )
+            )
+          )
+          val result = badMap.toTypedValueAccumulating[Map[Int, Int]]
+
+          assertTrue(result.isFailure) &&
+          assertTrue(errorCount(result) >= 4)
         },
         test("accumulates sequence element errors") {
           val badSequence = DynamicValue.Sequence(

--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -1,5 +1,8 @@
 package zio.schema
 
+import scala.collection.immutable.ListMap
+
+import zio.prelude.ZValidation
 import zio._
 import zio.schema.Schema.Primitive
 import zio.schema.SchemaGen._
@@ -7,6 +10,11 @@ import zio.test.Assertion._
 import zio.test.{ Sized, TestConfig, _ }
 
 object DynamicValueSpec extends ZIOSpecDefault {
+  final case class Person(name: String, age: Int)
+
+  object Person {
+    implicit val schema: Schema[Person] = DeriveSchema.gen[Person]
+  }
 
   def spec: Spec[Environment, Any] =
     suite("DynamicValueSpec")(
@@ -100,6 +108,65 @@ object DynamicValueSpec extends ZIOSpecDefault {
             assertTrue(json2 == Right(json))
           }
         } @@ TestAspect.size(250) @@ TestAspect.ignore
+      ),
+      suite("accumulating decode")(
+        test("succeeds for valid record round-trips") {
+          val person = Person("Alice", 30)
+          val result = DynamicValue.fromSchemaAndValue(Person.schema, person).toTypedValueAccumulating[Person]
+
+          result match {
+            case ZValidation.Success(_, value) => assertTrue(value == person)
+            case ZValidation.Failure(_, _)     => assertTrue(false)
+          }
+        },
+        test("matches toTypedValue on successful primitive decodes") {
+          check(SchemaGen.anyPrimitiveAndValue) {
+            case (schema, value) =>
+              val dynamic = DynamicValue.fromSchemaAndValue(schema, value)
+
+              (dynamic.toTypedValue(schema), dynamic.toTypedValueAccumulating(schema)) match {
+                case (Right(fast), ZValidation.Success(_, accumulating)) => assertTrue(fast == accumulating)
+                case (Left(_), _)                                        => assertTrue(false)
+                case (_, ZValidation.Failure(_, _))                      => assertTrue(false)
+              }
+          }
+        },
+        test("accumulates multiple record field errors") {
+          val badRecord = DynamicValue.Record(
+            TypeId.parse("zio.schema.DynamicValueSpec.Person"),
+            ListMap(
+              "name" -> DynamicValue.Primitive(42, StandardType.IntType),
+              "age"  -> DynamicValue.Primitive("not-an-int", StandardType.StringType)
+            )
+          )
+          val accumulating = badRecord.toTypedValueAccumulating[Person]
+
+          assertTrue(badRecord.toTypedValue[Person].isLeft) &&
+          assertTrue(accumulating.isFailure) &&
+          assertTrue(errorCount(accumulating) >= 2)
+        },
+        test("accumulates tuple element errors") {
+          val badTuple = DynamicValue.Tuple(
+            DynamicValue.Primitive("not-an-int", StandardType.StringType),
+            DynamicValue.Primitive("also-not-an-int", StandardType.StringType)
+          )
+          val result = badTuple.toTypedValueAccumulating[(Int, Int)]
+
+          assertTrue(result.isFailure) &&
+          assertTrue(errorCount(result) >= 2)
+        },
+        test("accumulates sequence element errors") {
+          val badSequence = DynamicValue.Sequence(
+            Chunk(
+              DynamicValue.Primitive("first", StandardType.StringType),
+              DynamicValue.Primitive("second", StandardType.StringType)
+            )
+          )
+          val result = badSequence.toTypedValueAccumulating[List[Int]]
+
+          assertTrue(result.isFailure) &&
+          assertTrue(errorCount(result) >= 2)
+        }
       )
     )
 
@@ -113,6 +180,12 @@ object DynamicValueSpec extends ZIOSpecDefault {
   private def dynamicValueLaw[R, A](gen: Gen[R, A], schema: Schema[A]): URIO[R with TestConfig, TestResult] =
     check(gen) { a =>
       assert(schema.fromDynamic(schema.toDynamic(a)))(isRight(equalTo(a)))
+    }
+
+  private def errorCount[A](result: zio.prelude.Validation[String, A]): Int =
+    result match {
+      case ZValidation.Failure(_, errs) => errs.size
+      case ZValidation.Success(_, _)    => 0
     }
 
 }

--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -134,7 +134,9 @@ object DynamicValueSpec extends ZIOSpecDefault {
             )
           )
 
-          assert(reorderedRecord.toTypedValueAccumulating[Person])(equalTo(zio.prelude.Validation.succeed(Person("Alice", 30))))
+          assert(reorderedRecord.toTypedValueAccumulating[Person])(
+            equalTo(zio.prelude.Validation.succeed(Person("Alice", 30)))
+          )
         },
         test("accumulates multiple record field errors") {
           val badRecord = DynamicValue.Record(

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -74,12 +74,12 @@ sealed trait DynamicValue {
 
       case (DynamicValue.Sequence(values), schema: Schema.Sequence[col, t, _]) =>
         values
-          .foldLeft[Validation[DecodeError, Chunk[t]]](Validation.succeed(Chunk.empty)) { (acc, value) =>
+          .foldLeft[Validation[DecodeError, List[t]]](Validation.succeed(List.empty[t])) { (acc, value) =>
             acc.zipWithPar(
               value.toTypedValueAccumulatingLazyError(schema.elementSchema)
-            )(_ :+ _)
+            )((decoded, value) => value :: decoded)
           }
-          .map(schema.fromChunk)
+          .map(values => schema.fromChunk(Chunk.fromIterable(values.reverse)))
 
       case (DynamicValue.SetValue(values), schema: Schema.Set[t]) =>
         values.foldLeft[Validation[DecodeError, Set[t]]](Validation.succeed(Set.empty[t])) { (acc, value) =>
@@ -316,17 +316,29 @@ object DynamicValue {
     values: ListMap[String, DynamicValue],
     structure: Chunk[Schema.Field[_, _]]
   ): Validation[DecodeError, ListMap[String, _]] = {
-    val keys = values.keySet
-    keys.foldLeft[Validation[DecodeError, ListMap[String, Any]]](Validation.succeed(ListMap.empty)) {
-      case (acc, key) =>
-        (structure.find(_.name == key), values.get(key)) match {
-          case (Some(field), Some(value)) =>
-            acc.zipWithPar(
-              value.toTypedValueAccumulatingLazyError(field.schema)
-            )((record, value) => record + (key -> value))
-          case _ =>
-            acc.zipWithPar(Validation.fail(DecodeError.IncompatibleShape(values, structure)))((record, _) => record)
-        }
+    val fieldNames: Set[String] = structure.map(field => field.name: String).toSet
+
+    val decodedFields =
+      structure.foldLeft[Validation[DecodeError, ListMap[String, Any]]](Validation.succeed(ListMap.empty)) {
+        case (acc, field) =>
+          val decodedField =
+            values.get(field.name) match {
+              case Some(value) =>
+                value.toTypedValueAccumulatingLazyError(field.schema).map(field.name -> _)
+              case None =>
+                Validation.fail(DecodeError.IncompatibleShape(values, structure))
+            }
+
+          acc.zipWithPar(decodedField) {
+            case (record, (name, value)) =>
+              record + (name -> value)
+          }
+      }
+
+    values.keySet.diff(fieldNames).foldLeft(decodedFields) { (acc, _) =>
+      acc.zipWithPar(
+        Validation.fail(DecodeError.IncompatibleShape(values, structure))
+      )((record, _) => record)
     }
   }
 

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 
 import scala.collection.immutable.ListMap
 
+import zio.prelude.Validation
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
 import zio.{ Cause, Chunk, Unsafe }
@@ -26,6 +27,110 @@ sealed trait DynamicValue {
 
   def toTypedValueOption[A](implicit schema: Schema[A]): Option[A] =
     toTypedValueLazyError.toOption
+
+  def toTypedValueAccumulating[A](implicit schema: Schema[A]): Validation[String, A] =
+    toTypedValueAccumulatingLazyError.mapError(_.message)
+
+  private def toTypedValueAccumulatingLazyError[A](implicit schema: Schema[A]): Validation[DecodeError, A] =
+    (self, schema) match {
+      case (DynamicValue.Primitive(value, p), Schema.Primitive(p2, _)) if p == p2 =>
+        Validation.succeed(value.asInstanceOf[A])
+
+      case (DynamicValue.Record(_, values), Schema.GenericRecord(_, structure, _)) =>
+        DynamicValue
+          .decodeStructureAccumulating(values, structure.toChunk)
+          .asInstanceOf[Validation[DecodeError, A]]
+
+      case (DynamicValue.Record(_, values), s: Schema.Record[A]) =>
+        DynamicValue
+          .decodeStructureAccumulating(values, s.fields)
+          .map(m => Chunk.fromIterable(m.values))
+          .flatMap { values =>
+            s.construct(values)(Unsafe.unsafe) match {
+              case Left(err) => Validation.fail(DecodeError.MalformedField(s, err))
+              case Right(a)  => Validation.succeed(a)
+            }
+          }
+
+      case (DynamicValue.Enumeration(_, (key, value)), s: Schema.Enum[A]) =>
+        s.caseOf(key) match {
+          case Some(caseValue) =>
+            value
+              .toTypedValueAccumulatingLazyError(caseValue.schema)
+              .asInstanceOf[Validation[DecodeError, A]]
+          case None => Validation.fail(DecodeError.MissingCase(key, s))
+        }
+
+      case (DynamicValue.LeftValue(value), Schema.Either(schema1, _, _)) =>
+        value.toTypedValueAccumulatingLazyError(schema1).map(Left(_))
+
+      case (DynamicValue.RightValue(value), Schema.Either(_, schema1, _)) =>
+        value.toTypedValueAccumulatingLazyError(schema1).map(Right(_))
+
+      case (DynamicValue.Tuple(leftValue, rightValue), Schema.Tuple2(leftSchema, rightSchema, _)) =>
+        val typedLeft  = leftValue.toTypedValueAccumulatingLazyError(leftSchema)
+        val typedRight = rightValue.toTypedValueAccumulatingLazyError(rightSchema)
+        typedLeft.zipWithPar(typedRight)((a, b) => (a -> b).asInstanceOf[A])
+
+      case (DynamicValue.Sequence(values), schema: Schema.Sequence[col, t, _]) =>
+        values
+          .foldLeft[Validation[DecodeError, Chunk[t]]](Validation.succeed(Chunk.empty)) { (acc, value) =>
+            acc.zipWithPar(
+              value.toTypedValueAccumulatingLazyError(schema.elementSchema)
+            )(_ :+ _)
+          }
+          .map(schema.fromChunk)
+
+      case (DynamicValue.SetValue(values), schema: Schema.Set[t]) =>
+        values.foldLeft[Validation[DecodeError, Set[t]]](Validation.succeed(Set.empty[t])) { (acc, value) =>
+          acc.zipWithPar(
+            value.toTypedValueAccumulatingLazyError(schema.elementSchema)
+          )(_ + _)
+        }
+
+      case (DynamicValue.SomeValue(value), Schema.Optional(schema: Schema[_], _)) =>
+        value.toTypedValueAccumulatingLazyError(schema).map(Some(_))
+
+      case (DynamicValue.NoneValue, Schema.Optional(_, _)) =>
+        Validation.succeed(None)
+
+      case (value, Schema.Transform(schema, f, _, _, _)) =>
+        value
+          .toTypedValueAccumulatingLazyError(schema)
+          .flatMap { value =>
+            f(value) match {
+              case Left(err) => Validation.fail(DecodeError.MalformedField(schema, err))
+              case Right(a)  => Validation.succeed(a)
+            }
+          }
+
+      case (DynamicValue.Dictionary(entries), schema: Schema.Map[k, v]) =>
+        entries.foldLeft[Validation[DecodeError, Map[k, v]]](Validation.succeed(Map.empty[k, v])) { (acc, entry) =>
+          val typedKey   = entry._1.toTypedValueAccumulatingLazyError(schema.keySchema)
+          val typedValue = entry._2.toTypedValueAccumulatingLazyError(schema.valueSchema)
+          acc.zipWithPar(
+            typedKey.zipWithPar(typedValue)(_ -> _)
+          )(_ + _)
+        }
+
+      case (_, l @ Schema.Lazy(_)) =>
+        toTypedValueAccumulatingLazyError(l.schema)
+
+      case (DynamicValue.Error(message), _) =>
+        Validation.fail(DecodeError.ReadError(Cause.empty, message))
+
+      case (DynamicValue.Tuple(dyn, DynamicValue.DynamicAst(ast)), _) =>
+        val valueSchema = ast.toSchema.asInstanceOf[Schema[Any]]
+        dyn
+          .toTypedValueAccumulatingLazyError(valueSchema)
+          .map(a => (a -> valueSchema).asInstanceOf[A])
+
+      case (dyn, Schema.Dynamic(_)) =>
+        Validation.succeed(dyn.asInstanceOf[A])
+
+      case _ =>
+        Validation.fail(DecodeError.CastError(self, schema))
+    }
 
   private def toTypedValueLazyError[A](implicit schema: Schema[A]): Either[DecodeError, A] =
     (self, schema) match {
@@ -204,6 +309,24 @@ object DynamicValue {
             Left(DecodeError.IncompatibleShape(values, structure))
         }
       case (Left(err), _) => Left(err)
+    }
+  }
+
+  def decodeStructureAccumulating(
+    values: ListMap[String, DynamicValue],
+    structure: Chunk[Schema.Field[_, _]]
+  ): Validation[DecodeError, ListMap[String, _]] = {
+    val keys = values.keySet
+    keys.foldLeft[Validation[DecodeError, ListMap[String, Any]]](Validation.succeed(ListMap.empty)) {
+      case (acc, key) =>
+        (structure.find(_.name == key), values.get(key)) match {
+          case (Some(field), Some(value)) =>
+            acc.zipWithPar(
+              value.toTypedValueAccumulatingLazyError(field.schema)
+            )((record, value) => record + (key -> value))
+          case _ =>
+            acc.zipWithPar(Validation.fail(DecodeError.IncompatibleShape(values, structure)))((record, _) => record)
+        }
     }
   }
 


### PR DESCRIPTION
Fixes #480

## Summary
- add `DynamicValue.toTypedValueAccumulating` as a backward-compatible accumulating API
- accumulate decode errors across records, tuples, sequences, sets, and dictionary entries
- add focused `DynamicValueSpec` coverage for success-path parity and multi-error accumulation

## Validation
- `testsJVM/testOnly zio.schema.DynamicValueSpec`
- `zioSchemaJVM/scalafmtCheck`
- `testsJVM/scalafmtCheck`

/claim #480