### PR TITLE
fix: implement Deterministic hashCode for DynamicValue

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -86,6 +86,51 @@ object DynamicValueSpec extends ZIOSpecDefault {
           }
         }
       ),
+      suite("hashCode")(
+        test("identical Primitive DynamicValues have the same hashCode") {
+          check(SchemaGen.anyLeafAndValue) {
+            case (schema, a) =>
+              val dv1 = schema.toDynamic(a)
+              val dv2 = schema.toDynamic(a)
+              assertTrue(dv1.hashCode() == dv2.hashCode())
+          }
+        },
+        test("Primitive hashCode is stable across separate instances") {
+          check(DynamicValueGen.anyPrimitiveDynamicValue(StandardType.IntType)) { prim =>
+            val copy = DynamicValue.Primitive(prim.value, prim.standardType)
+            assertTrue(prim.hashCode() == copy.hashCode())
+          }
+        },
+        test("Dictionary hashCode is order-independent") {
+          check(
+            DynamicValueGen
+              .anyPrimitiveDynamicValue(StandardType.StringType)
+              .zip(
+                DynamicValueGen.anyPrimitiveDynamicValue(StandardType.IntType)
+              ),
+            DynamicValueGen
+              .anyPrimitiveDynamicValue(StandardType.StringType)
+              .zip(
+                DynamicValueGen.anyPrimitiveDynamicValue(StandardType.IntType)
+              )
+          ) {
+            case ((k1, v1), (k2, v2)) =>
+              val d1 = DynamicValue.Dictionary(zio.Chunk((k1, v1), (k2, v2)))
+              val d2 = DynamicValue.Dictionary(zio.Chunk((k2, v2), (k1, v1)))
+              assertTrue(d1.hashCode() == d2.hashCode()) && assertTrue(d1 == d2)
+          }
+        },
+        test("equal DynamicValues always produce the same hashCode") {
+          check(
+            SchemaGen
+              .anyTree(1)
+              .flatMap(s => DynamicValueGen.anyDynamicValueOfSchema(s).zip(DynamicValueGen.anyDynamicValueOfSchema(s)))
+          ) {
+            case (dv1, dv2) =>
+              assertTrue(!(dv1 == dv2) || dv1.hashCode() == dv2.hashCode())
+          }
+        }
+      ),
       suite("stack safety")(
         test("fromSchemaAndValue is stack safe") {
           check(Json.genDeep) { json =>

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -213,11 +213,29 @@ object DynamicValue {
 
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue
 
-  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue
+  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
+
+    override def hashCode(): Int =
+      entries.toSet.hashCode()
+
+    override def equals(obj: Any): Boolean = obj match {
+      case Dictionary(otherEntries) => entries.toSet == otherEntries.toSet
+      case _                        => false
+    }
+  }
 
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue
 
-  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue
+  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
+
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      var h = MurmurHash3.productSeed
+      h = MurmurHash3.mix(h, standardType.tag.##)
+      h = MurmurHash3.mix(h, value.##)
+      MurmurHash3.finalizeHash(h, 2)
+    }
+  }
 
   sealed case class Singleton[A](instance: A) extends DynamicValue
 


### PR DESCRIPTION
`DynamicValue.hashCode` was non-deterministic, breaking use as HashMap/HashSet keys and across JVM runs in two distinct ways.

## Root Causes

- **`Primitive[A]`**: Case class `hashCode` included `standardType.##`, which calls `System.identityHashCode` on `StandardType` singletons (plain `implicit object`s, not `case object`s) — unstable across JVM runs.
- **`Dictionary`**: Auto-generated `hashCode` used `Chunk.hashCode` (order-sensitive), but entries originate from iterating a `Map` with non-deterministic order. Two logically-identical dictionaries could produce different hashes and fail `equals` **within the same run**.

## Fixes

- **`Primitive[A]`**: Override `hashCode` using `standardType.tag.##` (a stable `String`) combined with `value.##` via `MurmurHash3`:
  ```scala
  // Before: standardType.## → System.identityHashCode, changes between JVM runs
  // After: stable tag-based hash
  DynamicValue.Primitive(42, StandardType.IntType).hashCode ==
    DynamicValue.Primitive(42, StandardType.IntType).hashCode // always true
  ```

- **`Dictionary`**: Override both `hashCode` (`entries.toSet.hashCode()`) and `equals` (`entries.toSet == otherEntries.toSet`) to be order-independent and mutually consistent:
  ```scala
  val d1 = DynamicValue.Dictionary(Chunk((k1, v1), (k2, v2)))
  val d2 = DynamicValue.Dictionary(Chunk((k2, v2), (k1, v1)))
  d1 == d2          // true  (was false)
  d1.hashCode == d2.hashCode  // true  (was false)
  ```

## Tests

Four property-based tests added to `DynamicValueSpec`:
- `Primitive` hashCode stability across separate instances
- `Primitive` hashCode stability via `toDynamic` round-trips
- `Dictionary` hashCode and equality are order-independent
- General hashCode/equals contract across arbitrary generated `DynamicValue`s

fixes #655 
/claim #655 