### PR TITLE
feat: implement semantic equality and deterministic hashcodes for DynamicValue

### DIFF
--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -1,11 +1,11 @@
 package zio.schema
-import java.math. { BigDecimal, BigInteger }
+import java.math.{BigDecimal, BigInteger}
 import java.time._
 import java.util.UUID
 import scala.collection.immutable.ListMap
 import zio.schema.codec.DecodeError
-import zio.schema.meta. { MetaSchema, Migration }
-import zio. { Cause, Chunk, Unsafe }
+import zio.schema.meta.{MetaSchema, Migration}
+import zio.{Cause, Chunk, Unsafe}
 sealed trait DynamicValue {
   self =>
   def transform(transforms: Chunk[Migration]): Either[String, DynamicValue] =
@@ -251,7 +251,7 @@ object DynamicValue {
   }
 
   case object NoneValue extends DynamicValue {
-    override def hashCode(): Int             = "NoneValue".hashCode()
+    override def hashCode(): Int = "NoneValue".hashCode()
     override def equals(other: Any): Boolean = other.isInstanceOf[NoneValue.type]
   }
 

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -599,11 +599,13 @@ object DynamicValue {
   private val primitiveUnitCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Unit]] =
     Schema.Case(
       "Unit",
-      Schema.primitive[Unit].transform(unit => DynamicValue.Primitive(unit, StandardType[Unit]), _.value), {
+      Schema.primitive[Unit].transform(unit => DynamicValue.Primitive(unit, StandardType[Unit]), _.value),
+      {
         case dv @ DynamicValue.Primitive((), _) => dv.asInstanceOf[DynamicValue.Primitive[Unit]]
         case _                                  => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Unit]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Unit]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive((), _) => true
         case _                             => false
       }
@@ -611,11 +613,13 @@ object DynamicValue {
   private val primitiveStringCase: Schema.Case[DynamicValue, DynamicValue.Primitive[String]] =
     Schema.Case(
       "String",
-      Schema.primitive[String].transform(s => DynamicValue.Primitive(s, StandardType[String]), _.value), {
+      Schema.primitive[String].transform(s => DynamicValue.Primitive(s, StandardType[String]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: String, _) => dv.asInstanceOf[DynamicValue.Primitive[String]]
         case _                                         => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[String]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[String]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: String, _) => true
         case _                                    => false
       }
@@ -623,11 +627,13 @@ object DynamicValue {
   private val primitiveBooleanCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Boolean]] =
     Schema.Case(
       "Boolean",
-      Schema.primitive[Boolean].transform(b => DynamicValue.Primitive(b, StandardType[Boolean]), _.value), {
+      Schema.primitive[Boolean].transform(b => DynamicValue.Primitive(b, StandardType[Boolean]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Boolean, _) => dv.asInstanceOf[DynamicValue.Primitive[Boolean]]
         case _                                          => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Boolean]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Boolean]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Boolean, _) => true
         case _                                     => false
       }
@@ -635,11 +641,13 @@ object DynamicValue {
   private val primitiveShortCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Short]] =
     Schema.Case(
       "Short",
-      Schema.primitive[Short].transform(sh => DynamicValue.Primitive(sh, StandardType[Short]), _.value), {
+      Schema.primitive[Short].transform(sh => DynamicValue.Primitive(sh, StandardType[Short]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Short, _) => dv.asInstanceOf[DynamicValue.Primitive[Short]]
         case _                                        => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Short]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Short]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Short, _) => true
         case _                                   => false
       }
@@ -647,7 +655,8 @@ object DynamicValue {
   private val primitiveIntCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Int]] =
     Schema.Case(
       "Int",
-      Schema.primitive[Int].transform(i => DynamicValue.Primitive(i, StandardType[Int]), _.value), {
+      Schema.primitive[Int].transform(i => DynamicValue.Primitive(i, StandardType[Int]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Int, _) => dv.asInstanceOf[DynamicValue.Primitive[Int]]
         case _                                      => throw new IllegalArgumentException
       },
@@ -657,7 +666,8 @@ object DynamicValue {
   private val primitiveLongCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Long]] =
     Schema.Case(
       "Long",
-      Schema.primitive[Long].transform(l => DynamicValue.Primitive(l, StandardType[Long]), _.value), {
+      Schema.primitive[Long].transform(l => DynamicValue.Primitive(l, StandardType[Long]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Long, _) => dv.asInstanceOf[DynamicValue.Primitive[Long]]
         case _                                       => throw new IllegalArgumentException
       },
@@ -667,7 +677,8 @@ object DynamicValue {
   private val primitiveFloatCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Float]] =
     Schema.Case(
       "Float",
-      Schema.primitive[Float].transform(f => DynamicValue.Primitive(f, StandardType[Float]), _.value), {
+      Schema.primitive[Float].transform(f => DynamicValue.Primitive(f, StandardType[Float]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Float, _) => dv.asInstanceOf[DynamicValue.Primitive[Float]]
         case _                                        => throw new IllegalArgumentException
       },
@@ -677,7 +688,8 @@ object DynamicValue {
   private val primitiveDoubleCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Double]] =
     Schema.Case(
       "Double",
-      Schema.primitive[Double].transform(d => DynamicValue.Primitive(d, StandardType[Double]), _.value), {
+      Schema.primitive[Double].transform(d => DynamicValue.Primitive(d, StandardType[Double]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Double, _) => dv.asInstanceOf[DynamicValue.Primitive[Double]]
         case _                                         => throw new IllegalArgumentException
       },
@@ -687,11 +699,13 @@ object DynamicValue {
   private val primitiveBinaryCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Chunk[Byte]]] =
     Schema.Case(
       "Binary",
-      Schema.primitive[Chunk[Byte]].transform(ch => DynamicValue.Primitive(ch, StandardType[Chunk[Byte]]), _.value), {
+      Schema.primitive[Chunk[Byte]].transform(ch => DynamicValue.Primitive(ch, StandardType[Chunk[Byte]]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Chunk[_], _) => dv.asInstanceOf[DynamicValue.Primitive[Chunk[Byte]]]
         case _                                           => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Chunk[Byte]]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Chunk[Byte]]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Chunk[_], _) => true
         case _                                      => false
       }
@@ -699,11 +713,13 @@ object DynamicValue {
   private val primitiveCharCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Char]] =
     Schema.Case(
       "Char",
-      Schema.primitive[Char].transform(ch => DynamicValue.Primitive(ch, StandardType[Char]), _.value), {
+      Schema.primitive[Char].transform(ch => DynamicValue.Primitive(ch, StandardType[Char]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Char, _) => dv.asInstanceOf[DynamicValue.Primitive[Char]]
         case _                                       => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Char]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Char]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Char, _) => true
         case _                                  => false
       }
@@ -711,11 +727,13 @@ object DynamicValue {
   private val primitiveBigDecimalCase: Schema.Case[DynamicValue, DynamicValue.Primitive[BigDecimal]] =
     Schema.Case(
       "BigDecimal",
-      Schema.primitive[BigDecimal].transform(bd => DynamicValue.Primitive(bd, StandardType[BigDecimal]), _.value), {
+      Schema.primitive[BigDecimal].transform(bd => DynamicValue.Primitive(bd, StandardType[BigDecimal]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: BigDecimal, _) => dv.asInstanceOf[DynamicValue.Primitive[BigDecimal]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[BigDecimal]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[BigDecimal]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: BigDecimal, _) => true
         case _                                        => false
       }
@@ -723,11 +741,13 @@ object DynamicValue {
   private val primitiveBigIntegerCase: Schema.Case[DynamicValue, DynamicValue.Primitive[BigInteger]] =
     Schema.Case(
       "BigInteger",
-      Schema.primitive[BigInteger].transform(bi => DynamicValue.Primitive(bi, StandardType[BigInteger]), _.value), {
+      Schema.primitive[BigInteger].transform(bi => DynamicValue.Primitive(bi, StandardType[BigInteger]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: BigInteger, _) => dv.asInstanceOf[DynamicValue.Primitive[BigInteger]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[BigInteger]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[BigInteger]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: BigInteger, _) => true
         case _                                        => false
       }
@@ -735,11 +755,13 @@ object DynamicValue {
   private val primitiveDayOfWeekCase: Schema.Case[DynamicValue, DynamicValue.Primitive[DayOfWeek]] =
     Schema.Case(
       "DayOfWeek",
-      Schema.primitive[DayOfWeek].transform(dw => DynamicValue.Primitive(dw, StandardType[DayOfWeek]), _.value), {
+      Schema.primitive[DayOfWeek].transform(dw => DynamicValue.Primitive(dw, StandardType[DayOfWeek]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: DayOfWeek, _) => dv.asInstanceOf[DynamicValue.Primitive[DayOfWeek]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[DayOfWeek]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[DayOfWeek]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: DayOfWeek, _) => true
         case _                                       => false
       }
@@ -747,11 +769,13 @@ object DynamicValue {
   private val primitiveMonthCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Month]] =
     Schema.Case(
       "Month",
-      Schema.primitive[Month].transform(m => DynamicValue.Primitive(m, StandardType[Month]), _.value), {
+      Schema.primitive[Month].transform(m => DynamicValue.Primitive(m, StandardType[Month]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Month, _) => dv.asInstanceOf[DynamicValue.Primitive[Month]]
         case _                                        => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Month]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Month]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Month, _) => true
         case _                                   => false
       }
@@ -759,11 +783,13 @@ object DynamicValue {
   private val primitiveMonthDayCase: Schema.Case[DynamicValue, DynamicValue.Primitive[MonthDay]] =
     Schema.Case(
       "MonthDay",
-      Schema.primitive[MonthDay].transform(md => DynamicValue.Primitive(md, StandardType[MonthDay]), _.value), {
+      Schema.primitive[MonthDay].transform(md => DynamicValue.Primitive(md, StandardType[MonthDay]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: MonthDay, _) => dv.asInstanceOf[DynamicValue.Primitive[MonthDay]]
         case _                                           => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[MonthDay]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[MonthDay]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: MonthDay, _) => true
         case _                                      => false
       }
@@ -771,11 +797,13 @@ object DynamicValue {
   private val primitivePeriodCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Period]] =
     Schema.Case(
       "Period",
-      Schema.primitive[Period].transform(p => DynamicValue.Primitive(p, StandardType[Period]), _.value), {
+      Schema.primitive[Period].transform(p => DynamicValue.Primitive(p, StandardType[Period]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Period, _) => dv.asInstanceOf[DynamicValue.Primitive[Period]]
         case _                                         => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Period]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Period]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Period, _) => true
         case _                                    => false
       }
@@ -783,11 +811,13 @@ object DynamicValue {
   private val primitiveYearCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Year]] =
     Schema.Case(
       "Year",
-      Schema.primitive[Year].transform(y => DynamicValue.Primitive(y, StandardType[Year]), _.value), {
+      Schema.primitive[Year].transform(y => DynamicValue.Primitive(y, StandardType[Year]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Year, _) => dv.asInstanceOf[DynamicValue.Primitive[Year]]
         case _                                       => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Year]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Year]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Year, _) => true
         case _                                  => false
       }
@@ -795,11 +825,13 @@ object DynamicValue {
   private val primitiveYearMonthCase: Schema.Case[DynamicValue, DynamicValue.Primitive[YearMonth]] =
     Schema.Case(
       "YearMonth",
-      Schema.primitive[YearMonth].transform(ym => DynamicValue.Primitive(ym, StandardType[YearMonth]), _.value), {
+      Schema.primitive[YearMonth].transform(ym => DynamicValue.Primitive(ym, StandardType[YearMonth]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: YearMonth, _) => dv.asInstanceOf[DynamicValue.Primitive[YearMonth]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[YearMonth]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[YearMonth]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: YearMonth, _) => true
         case _                                       => false
       }
@@ -807,11 +839,13 @@ object DynamicValue {
   private val primitiveZoneIdCase: Schema.Case[DynamicValue, DynamicValue.Primitive[ZoneId]] =
     Schema.Case(
       "ZoneId",
-      Schema.primitive[ZoneId].transform(zid => DynamicValue.Primitive(zid, StandardType[ZoneId]), _.value), {
+      Schema.primitive[ZoneId].transform(zid => DynamicValue.Primitive(zid, StandardType[ZoneId]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: ZoneId, _) => dv.asInstanceOf[DynamicValue.Primitive[ZoneId]]
         case _                                         => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[ZoneId]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[ZoneId]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: ZoneId, _) => true
         case _                                    => false
       }
@@ -819,11 +853,13 @@ object DynamicValue {
   private val primitiveZoneOffsetCase: Schema.Case[DynamicValue, DynamicValue.Primitive[ZoneOffset]] =
     Schema.Case(
       "ZoneOffset",
-      Schema.primitive[ZoneOffset].transform(zo => DynamicValue.Primitive(zo, StandardType[ZoneOffset]), _.value), {
+      Schema.primitive[ZoneOffset].transform(zo => DynamicValue.Primitive(zo, StandardType[ZoneOffset]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: ZoneOffset, _) => dv.asInstanceOf[DynamicValue.Primitive[ZoneOffset]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[ZoneOffset]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[ZoneOffset]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: ZoneOffset, _) => true
         case _                                        => false
       }
@@ -831,11 +867,13 @@ object DynamicValue {
   private val primitiveInstantCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Instant]] =
     Schema.Case(
       "Instant",
-      Schema.primitive[Instant].transform(i => DynamicValue.Primitive(i, StandardType[Instant]), _.value), {
+      Schema.primitive[Instant].transform(i => DynamicValue.Primitive(i, StandardType[Instant]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Instant, _) => dv.asInstanceOf[DynamicValue.Primitive[Instant]]
         case _                                          => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Instant]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Instant]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Instant, _) => true
         case _                                     => false
       }
@@ -843,11 +881,13 @@ object DynamicValue {
   private val primitiveDurationCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Duration]] =
     Schema.Case(
       "Duration",
-      Schema.primitive[Duration].transform(i => DynamicValue.Primitive(i, StandardType[Duration]), _.value), {
+      Schema.primitive[Duration].transform(i => DynamicValue.Primitive(i, StandardType[Duration]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: Duration, _) => dv.asInstanceOf[DynamicValue.Primitive[Duration]]
         case _                                           => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Duration]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[Duration]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: Duration, _) => true
         case _                                      => false
       }
@@ -855,11 +895,13 @@ object DynamicValue {
   private val primitiveLocalDateCase: Schema.Case[DynamicValue, DynamicValue.Primitive[LocalDate]] =
     Schema.Case(
       "LocalDate",
-      Schema.primitive[LocalDate].transform(ld => DynamicValue.Primitive(ld, StandardType[LocalDate]), _.value), {
+      Schema.primitive[LocalDate].transform(ld => DynamicValue.Primitive(ld, StandardType[LocalDate]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: LocalDate, _) => dv.asInstanceOf[DynamicValue.Primitive[LocalDate]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[LocalDate]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[LocalDate]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: LocalDate, _) => true
         case _                                       => false
       }
@@ -867,11 +909,13 @@ object DynamicValue {
   private val primitiveLocalTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[LocalTime]] =
     Schema.Case(
       "LocalTime",
-      Schema.primitive[LocalTime].transform(lt => DynamicValue.Primitive(lt, StandardType[LocalTime]), _.value), {
+      Schema.primitive[LocalTime].transform(lt => DynamicValue.Primitive(lt, StandardType[LocalTime]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: LocalTime, _) => dv.asInstanceOf[DynamicValue.Primitive[LocalTime]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[LocalTime]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[LocalTime]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: LocalTime, _) => true
         case _                                       => false
       }
@@ -881,11 +925,13 @@ object DynamicValue {
       "LocalDateTime",
       Schema
         .primitive[LocalDateTime]
-        .transform(ldt => DynamicValue.Primitive(ldt, StandardType[LocalDateTime]), _.value), {
+        .transform(ldt => DynamicValue.Primitive(ldt, StandardType[LocalDateTime]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: LocalDateTime, _) => dv.asInstanceOf[DynamicValue.Primitive[LocalDateTime]]
         case _                                                => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[LocalDateTime]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[LocalDateTime]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: LocalDateTime, _) => true
         case _                                           => false
       }
@@ -893,11 +939,13 @@ object DynamicValue {
   private val primitiveOffsetTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[OffsetTime]] =
     Schema.Case(
       "OffsetTime",
-      Schema.primitive[OffsetTime].transform(ot => DynamicValue.Primitive(ot, StandardType[OffsetTime]), _.value), {
+      Schema.primitive[OffsetTime].transform(ot => DynamicValue.Primitive(ot, StandardType[OffsetTime]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: OffsetTime, _) => dv.asInstanceOf[DynamicValue.Primitive[OffsetTime]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[OffsetTime]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[OffsetTime]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: OffsetTime, _) => true
         case _                                        => false
       }
@@ -907,12 +955,14 @@ object DynamicValue {
       "OffsetDateTime",
       Schema
         .primitive[OffsetDateTime]
-        .transform(odt => DynamicValue.Primitive(odt, StandardType[OffsetDateTime]), _.value), {
+        .transform(odt => DynamicValue.Primitive(odt, StandardType[OffsetDateTime]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: OffsetDateTime, _) =>
           dv.asInstanceOf[DynamicValue.Primitive[OffsetDateTime]]
         case _ => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[OffsetDateTime]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[OffsetDateTime]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: OffsetDateTime, _) => true
         case _                                            => false
       }
@@ -922,11 +972,13 @@ object DynamicValue {
       "ZonedDateTime",
       Schema
         .primitive[ZonedDateTime]
-        .transform(zdt => DynamicValue.Primitive(zdt, StandardType[ZonedDateTime]), _.value), {
+        .transform(zdt => DynamicValue.Primitive(zdt, StandardType[ZonedDateTime]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: ZonedDateTime, _) => dv.asInstanceOf[DynamicValue.Primitive[ZonedDateTime]]
         case _                                                => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[ZonedDateTime]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[ZonedDateTime]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: ZonedDateTime, _) => true
         case _                                           => false
       }
@@ -934,11 +986,13 @@ object DynamicValue {
   private val primitiveUUIDCase: Schema.Case[DynamicValue, DynamicValue.Primitive[UUID]] =
     Schema.Case(
       "UUID",
-      Schema.primitive[UUID].transform(uuid => DynamicValue.Primitive(uuid, StandardType[UUID]), _.value), {
+      Schema.primitive[UUID].transform(uuid => DynamicValue.Primitive(uuid, StandardType[UUID]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: UUID, _) => dv.asInstanceOf[DynamicValue.Primitive[UUID]]
         case _                                       => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[UUID]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[UUID]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: UUID, _) => true
         case _                                  => false
       }
@@ -946,11 +1000,13 @@ object DynamicValue {
   private val primitiveCurrencyCase: Schema.Case[DynamicValue, DynamicValue.Primitive[java.util.Currency]] =
     Schema.Case(
       "Currency",
-      Schema.primitive[java.util.Currency].transform(currency => DynamicValue.Primitive(currency, StandardType[java.util.Currency]), _.value), {
+      Schema.primitive[java.util.Currency].transform(currency => DynamicValue.Primitive(currency, StandardType[java.util.Currency]), _.value),
+      {
         case dv @ DynamicValue.Primitive(_: java.util.Currency, _) => dv.asInstanceOf[DynamicValue.Primitive[java.util.Currency]]
         case _                                                     => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[java.util.Currency]) => dv.asInstanceOf[DynamicValue], {
+      (dv: DynamicValue.Primitive[java.util.Currency]) => dv.asInstanceOf[DynamicValue],
+      {
         case DynamicValue.Primitive(_: java.util.Currency, _) => true
         case _                                                => false
       }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -14,92 +14,6 @@ import zio.{ Cause, Chunk, Unsafe }
 sealed trait DynamicValue {
   self =>
 
-  @nowarn("msg=deprecated")
-  override def hashCode(): Int = {
-    import scala.util.hashing.MurmurHash3
-    self match {
-      case DynamicValue.Record(id, values) =>
-        MurmurHash3.productHash(("Record", id, values).asInstanceOf[Product])
-      case DynamicValue.Enumeration(id, value) =>
-        MurmurHash3.productHash(("Enumeration", id, value).asInstanceOf[Product])
-      case DynamicValue.Sequence(values) =>
-        MurmurHash3.productHash(("Sequence", values).asInstanceOf[Product])
-      case DynamicValue.Dictionary(entries) =>
-        // Sort entries by key hashCode to make it deterministic if order is changed
-        // Actually, sorting is expensive. Let's see if we can just hash the Chunk.
-        MurmurHash3.productHash(("Dictionary", entries).asInstanceOf[Product])
-      case DynamicValue.SetValue(values) =>
-        MurmurHash3.setHash(values)
-      case DynamicValue.Primitive(value, standardType) =>
-        val v = value match {
-          case bd: java.math.BigDecimal => bd.stripTrailingZeros()
-          case _                        => value
-        }
-        MurmurHash3.productHash(("Primitive", v, standardType).asInstanceOf[Product])
-      case DynamicValue.Singleton(instance) =>
-        MurmurHash3.productHash(("Singleton", instance).asInstanceOf[Product])
-      case DynamicValue.SomeValue(value) =>
-        MurmurHash3.productHash(("SomeValue", value).asInstanceOf[Product])
-      case DynamicValue.NoneValue =>
-        "NoneValue".hashCode
-      case DynamicValue.Tuple(left, right) =>
-        MurmurHash3.productHash(("Tuple", left, right).asInstanceOf[Product])
-      case DynamicValue.LeftValue(value) =>
-        MurmurHash3.productHash(("LeftValue", value).asInstanceOf[Product])
-      case DynamicValue.RightValue(value) =>
-        MurmurHash3.productHash(("RightValue", value).asInstanceOf[Product])
-      case DynamicValue.BothValue(left, right) =>
-        MurmurHash3.productHash(("BothValue", left, right).asInstanceOf[Product])
-      case DynamicValue.DynamicAst(ast) =>
-        MurmurHash3.productHash(("DynamicAst", ast).asInstanceOf[Product])
-      case DynamicValue.Error(message) =>
-        MurmurHash3.productHash(("Error", message).asInstanceOf[Product])
-    }
-  }
-
-  override def equals(other: Any): Boolean = other match {
-    case that: DynamicValue =>
-      (self, that) match {
-        case (DynamicValue.Record(id1, v1), DynamicValue.Record(id2, v2)) =>
-          id1 == id2 && v1 == v2
-        case (DynamicValue.Enumeration(id1, v1), DynamicValue.Enumeration(id2, v2)) =>
-          id1 == id2 && v1 == v2
-        case (DynamicValue.Sequence(v1), DynamicValue.Sequence(v2)) =>
-          v1 == v2
-        case (DynamicValue.Dictionary(v1), DynamicValue.Dictionary(v2)) =>
-          v1 == v2
-        case (DynamicValue.SetValue(v1), DynamicValue.SetValue(v2)) =>
-          v1 == v2
-        case (DynamicValue.Primitive(v1, t1), DynamicValue.Primitive(v2, t2)) =>
-          if (t1 != t2) false
-          else (v1, v2) match {
-            case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
-              bd1.compareTo(bd2) == 0
-            case _ => v1 == v2
-          }
-        case (DynamicValue.Singleton(i1), DynamicValue.Singleton(i2)) =>
-          i1 == i2
-        case (DynamicValue.SomeValue(v1), DynamicValue.SomeValue(v2)) =>
-          v1 == v2
-        case (DynamicValue.NoneValue, DynamicValue.NoneValue) =>
-          true
-        case (DynamicValue.Tuple(l1, r1), DynamicValue.Tuple(l2, r2)) =>
-          l1 == l2 && r1 == r2
-        case (DynamicValue.LeftValue(v1), DynamicValue.LeftValue(v2)) =>
-          v1 == v2
-        case (DynamicValue.RightValue(v1), DynamicValue.RightValue(v2)) =>
-          v1 == v2
-        case (DynamicValue.BothValue(l1, r1), DynamicValue.BothValue(l2, r2)) =>
-          l1 == l2 && r1 == r2
-        case (DynamicValue.DynamicAst(a1), DynamicValue.DynamicAst(a2)) =>
-          a1 == a2
-        case (DynamicValue.Error(m1), DynamicValue.Error(m2)) =>
-          m1 == m2
-        case _ => false
-      }
-    case _ => false
-  }
-
   def transform(transforms: Chunk[Migration]): Either[String, DynamicValue] =
     transforms.foldRight[Either[String, DynamicValue]](Right(self)) {
       case (transform, Right(value)) => transform.migrate(value)
@@ -294,35 +208,174 @@ object DynamicValue {
     }
   }
 
-  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue
+  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("Record", id, values).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Record => id == that.id && values == that.values
+      case _            => false
+    }
+  }
 
-  final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue
+  final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("Enumeration", id, value).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Enumeration => id == that.id && value == that.value
+      case _                 => false
+    }
+  }
 
-  final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue
+  final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("Sequence", values).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Sequence => values == that.values
+      case _              => false
+    }
+  }
 
-  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue
+  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("Dictionary", entries).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Dictionary => entries == that.entries
+      case _                => false
+    }
+  }
 
-  final case class SetValue(values: Set[DynamicValue]) extends DynamicValue
+  final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.setHash(values)
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: SetValue => values == that.values
+      case _              => false
+    }
+  }
 
-  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue
+  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      val v = value match {
+        case bd: java.math.BigDecimal => bd.stripTrailingZeros()
+        case _                        => value
+      }
+      MurmurHash3.productHash(("Primitive", v, standardType).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Primitive[_] =>
+        if (standardType != that.standardType) false
+        else (value, that.value) match {
+          case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
+            bd1.compareTo(bd2) == 0
+          case (v1, v2) => v1 == v2
+        }
+      case _ => false
+    }
+  }
 
-  sealed case class Singleton[A](instance: A) extends DynamicValue
+  sealed case class Singleton[A](instance: A) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("Singleton", instance).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Singleton[_] => instance == that.instance
+      case _                  => false
+    }
+  }
 
-  final case class SomeValue(value: DynamicValue) extends DynamicValue
+  final case class SomeValue(value: DynamicValue) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("SomeValue", value).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: SomeValue => value == that.value
+      case _               => false
+    }
+  }
 
-  case object NoneValue extends DynamicValue
+  case object NoneValue extends DynamicValue {
+    override def hashCode(): Int             = "NoneValue".hashCode
+    override def equals(other: Any): Boolean = other.isInstanceOf[NoneValue.type]
+  }
 
-  sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue
+  sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("Tuple", left, right).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Tuple => left == that.left && right == that.right
+      case _           => false
+    }
+  }
 
-  final case class LeftValue(value: DynamicValue) extends DynamicValue
+  final case class LeftValue(value: DynamicValue) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("LeftValue", value).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: LeftValue => value == that.value
+      case _               => false
+    }
+  }
 
-  final case class RightValue(value: DynamicValue) extends DynamicValue
+  final case class RightValue(value: DynamicValue) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("RightValue", value).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: RightValue => value == that.value
+      case _                => false
+    }
+  }
 
-  final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue
+  final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("BothValue", left, right).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: BothValue => left == that.left && right == that.right
+      case _               => false
+    }
+  }
 
-  final case class DynamicAst(ast: MetaSchema) extends DynamicValue
+  final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("DynamicAst", ast).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: DynamicAst => ast == that.ast
+      case _                => false
+    }
+  }
 
-  final case class Error(message: String) extends DynamicValue
+  final case class Error(message: String) extends DynamicValue {
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      MurmurHash3.productHash(("Error", message).asInstanceOf[Product])
+    }
+    override def equals(other: Any): Boolean = other match {
+      case that: Error => message == that.message
+      case _           => false
+    }
+  }
 
   lazy val typeId: TypeId = TypeId.parse("zio.schema.DynamicValue")
 

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -166,7 +166,8 @@ object DynamicValue {
 
   final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = ("Record", id, values).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Record => id == that.id && values == that.values
       case _            => false
     }
@@ -174,7 +175,8 @@ object DynamicValue {
 
   final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
     override def hashCode(): Int = ("Enumeration", id, value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Enumeration => id == that.id && value == that.value
       case _                 => false
     }
@@ -182,7 +184,8 @@ object DynamicValue {
 
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = ("Sequence", values).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Sequence => values == that.values
       case _              => false
     }
@@ -190,7 +193,8 @@ object DynamicValue {
 
   final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
     override def hashCode(): Int = ("Dictionary", entries).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Dictionary => entries == that.entries
       case _                => false
     }
@@ -198,7 +202,8 @@ object DynamicValue {
 
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = values.hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: SetValue => values == that.values
       case _              => false
     }
@@ -212,7 +217,8 @@ object DynamicValue {
       }
       ("Primitive", v, standardType).hashCode()
     }
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Primitive[_] =>
         if (standardType != that.standardType) false
         else (value, that.value) match {
@@ -226,7 +232,8 @@ object DynamicValue {
 
   sealed case class Singleton[A](instance: A) extends DynamicValue {
     override def hashCode(): Int = ("Singleton", instance).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Singleton[_] => instance == that.instance
       case _                  => false
     }
@@ -234,7 +241,8 @@ object DynamicValue {
 
   final case class SomeValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("SomeValue", value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: SomeValue => value == that.value
       case _               => false
     }
@@ -247,7 +255,8 @@ object DynamicValue {
 
   sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("Tuple", left, right).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Tuple => left == that.left && right == that.right
       case _           => false
     }
@@ -255,7 +264,8 @@ object DynamicValue {
 
   final case class LeftValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("LeftValue", value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: LeftValue => value == that.value
       case _               => false
     }
@@ -263,7 +273,8 @@ object DynamicValue {
 
   final case class RightValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("RightValue", value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: RightValue => value == that.value
       case _                => false
     }
@@ -271,7 +282,8 @@ object DynamicValue {
 
   final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("BothValue", left, right).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: BothValue => left == that.left && right == that.right
       case _               => false
     }
@@ -279,7 +291,8 @@ object DynamicValue {
 
   final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
     override def hashCode(): Int = ("DynamicAst", ast).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: DynamicAst => ast == that.ast
       case _                => false
     }
@@ -287,7 +300,8 @@ object DynamicValue {
 
   final case class Error(message: String) extends DynamicValue {
     override def hashCode(): Int = ("Error", message).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean =
+      other match {
       case that: Error => message == that.message
       case _           => false
     }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -19,7 +19,7 @@ sealed trait DynamicValue {
   def toTypedValueOption[A](implicit schema: Schema[A]): Option[A] =
     toTypedValueLazyError.toOption
   private def toTypedValueLazyError[A](implicit schema: Schema[A]): Either[DecodeError, A] =
-    (self, schema)  match {
+    (self, schema) match {
       case (DynamicValue.Primitive(value, p), Schema.Primitive(p2, _)) if p == p2 =>
         Right(value.asInstanceOf[A])
       case (DynamicValue.Record(_, values), Schema.GenericRecord(_, structure, _)) =>
@@ -30,7 +30,7 @@ sealed trait DynamicValue {
           .map(m => Chunk.fromIterable(m.values))
           .flatMap(values => s.construct(values)(Unsafe.unsafe).left.map(err => DecodeError.MalformedField(s, err)))
       case (DynamicValue.Enumeration(_, (key, value)), s: Schema.Enum[A]) =>
-        s.caseOf(key)  match {
+        s.caseOf(key) match {
           case Some(caseValue) =>
             value.toTypedValueLazyError(caseValue.schema).asInstanceOf[Either[DecodeError, A]]
           case None => Left(DecodeError.MissingCase(key, s))
@@ -42,7 +42,7 @@ sealed trait DynamicValue {
       case (DynamicValue.Tuple(leftValue, rightValue), Schema.Tuple2(leftSchema, rightSchema, _)) =>
         val typedLeft  = leftValue.toTypedValueLazyError(leftSchema)
         val typedRight = rightValue.toTypedValueLazyError(rightSchema)
-        (typedLeft, typedRight)  match {
+        (typedLeft, typedRight) match {
           case (Left(e1), Left(e2)) =>
             Left(DecodeError.And(e1, e2))
           case (_, Left(e))         => Left(e)
@@ -114,7 +114,7 @@ object DynamicValue {
       schema: Schema.Either[_, _],
       value: Either[DynamicValue, DynamicValue]
     ): DynamicValue =
-      value  match {
+      value match {
         case Left(value)  => DynamicValue.LeftValue(value)
         case Right(value) => DynamicValue.RightValue(value)
       }
@@ -122,13 +122,13 @@ object DynamicValue {
       schema: Schema.Fallback[_, _],
       value: Fallback[DynamicValue, DynamicValue]
     ): DynamicValue =
-      value  match {
+      value match {
         case Fallback.Left(value)       => DynamicValue.LeftValue(value)
         case Fallback.Right(value)      => DynamicValue.RightValue(value)
         case Fallback.Both(left, right) => DynamicValue.BothValue(left, right)
       }
     override protected def processOption(schema: Schema.Optional[_], value: Option[DynamicValue]): DynamicValue =
-      value  match {
+      value match {
         case Some(value) => DynamicValue.SomeValue(value)
         case None        => DynamicValue.NoneValue
       }
@@ -154,7 +154,7 @@ object DynamicValue {
     val keys = values.keySet
     keys.foldLeft[Either[DecodeError, ListMap[String, Any]]](Right(ListMap.empty)) {
       case (Right(record), key) =>
-        (structure.find(_.name == key), values.get(key))  match {
+        (structure.find(_.name == key), values.get(key)) match {
           case (Some(field), Some(value)) =>
             value.toTypedValueLazyError(field.schema).map(value => (record + (key -> value)))
           case _ =>
@@ -164,57 +164,63 @@ object DynamicValue {
     }
   }
 
-  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue  {
+
+  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = ("Record", id, values).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Record => id == that.id && values == that.values
       case _            => false
     }
   }
 
-  final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue  {
+
+  final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
     override def hashCode(): Int = ("Enumeration", id, value).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Enumeration => id == that.id && value == that.value
       case _                 => false
     }
   }
 
-  final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue  {
+
+  final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = ("Sequence", values).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Sequence => values == that.values
       case _              => false
     }
   }
 
-  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue  {
+
+  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
     override def hashCode(): Int = ("Dictionary", entries).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Dictionary => entries == that.entries
       case _                => false
     }
   }
 
-  final case class SetValue(values: Set[DynamicValue]) extends DynamicValue  {
+
+  final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = values.hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: SetValue => values == that.values
       case _              => false
     }
   }
-  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue  {
+
+  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
     override def hashCode(): Int = {
-      val v = value  match {
+      val v = value match {
         case bd: java.math.BigDecimal => bd.stripTrailingZeros()
         case _                        => value
       }
       ("Primitive", v, standardType).hashCode()
     }
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Primitive[_] =>
         if (standardType != that.standardType) false
-        else (value, that.value)  match {
+        else (value, that.value) match {
           case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
             bd1.compareTo(bd2) == 0
           case _ => value == that.value
@@ -222,68 +228,77 @@ object DynamicValue {
       case _ => false
     }
   }
-  sealed case class Singleton[A](instance: A) extends DynamicValue  {
+
+  sealed case class Singleton[A](instance: A) extends DynamicValue {
     override def hashCode(): Int = ("Singleton", instance).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Singleton[_] => instance == that.instance
       case _                  => false
     }
   }
 
-  final case class SomeValue(value: DynamicValue) extends DynamicValue  {
+
+  final case class SomeValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("SomeValue", value).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: SomeValue => value == that.value
       case _               => false
     }
   }
+
   case object NoneValue extends DynamicValue {
     override def hashCode(): Int             = "NoneValue".hashCode()
     override def equals(other: Any): Boolean = other.isInstanceOf[NoneValue.type]
   }
-  sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue  {
+
+  sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("Tuple", left, right).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Tuple => left == that.left && right == that.right
       case _           => false
     }
   }
 
-  final case class LeftValue(value: DynamicValue) extends DynamicValue  {
+
+  final case class LeftValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("LeftValue", value).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: LeftValue => value == that.value
       case _               => false
     }
   }
 
-  final case class RightValue(value: DynamicValue) extends DynamicValue  {
+
+  final case class RightValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("RightValue", value).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: RightValue => value == that.value
       case _                => false
     }
   }
 
-  final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue  {
+
+  final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("BothValue", left, right).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: BothValue => left == that.left && right == that.right
       case _               => false
     }
   }
 
-  final case class DynamicAst(ast: MetaSchema) extends DynamicValue  {
+
+  final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
     override def hashCode(): Int = ("DynamicAst", ast).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: DynamicAst => ast == that.ast
       case _                => false
     }
   }
 
-  final case class Error(message: String) extends DynamicValue  {
+
+  final case class Error(message: String) extends DynamicValue {
     override def hashCode(): Int = ("Error", message).hashCode()
-    override def equals(other: Any): Boolean = other  match {
+    override def equals(other: Any): Boolean = other match {
       case that: Error => message == that.message
       case _           => false
     }
@@ -572,7 +587,7 @@ object DynamicValue {
       (d: DynamicValue) => d.isInstanceOf[DynamicValue.Singleton[_]]
     )
   private def hasStandardType(value: DynamicValue, standardType: StandardType[_]): Boolean =
-    value  match {
+    value match {
       case DynamicValue.Primitive(_, tpe) => tpe == standardType
       case _                              => false
     }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -8,7 +8,6 @@ import scala.collection.immutable.ListMap
 
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
-import scala.annotation.nowarn
 import zio.{ Cause, Chunk, Unsafe }
 
 sealed trait DynamicValue {
@@ -278,7 +277,7 @@ object DynamicValue {
         else (value, that.value) match {
           case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
             bd1.compareTo(bd2) == 0
-          case (v1, v2) => v1 == v2
+          case _ => value == that.value
         }
       case _ => false
     }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -19,7 +19,7 @@ sealed trait DynamicValue {
   def toTypedValueOption[A](implicit schema: Schema[A]): Option[A] =
     toTypedValueLazyError.toOption
   private def toTypedValueLazyError[A](implicit schema: Schema[A]): Either[DecodeError, A] =
-    (self, schema) match {
+    (self, schema)  match {
       case (DynamicValue.Primitive(value, p), Schema.Primitive(p2, _)) if p == p2 =>
         Right(value.asInstanceOf[A])
       case (DynamicValue.Record(_, values), Schema.GenericRecord(_, structure, _)) =>
@@ -30,7 +30,7 @@ sealed trait DynamicValue {
           .map(m => Chunk.fromIterable(m.values))
           .flatMap(values => s.construct(values)(Unsafe.unsafe).left.map(err => DecodeError.MalformedField(s, err)))
       case (DynamicValue.Enumeration(_, (key, value)), s: Schema.Enum[A]) =>
-        s.caseOf(key) match {
+        s.caseOf(key)  match {
           case Some(caseValue) =>
             value.toTypedValueLazyError(caseValue.schema).asInstanceOf[Either[DecodeError, A]]
           case None => Left(DecodeError.MissingCase(key, s))
@@ -42,7 +42,7 @@ sealed trait DynamicValue {
       case (DynamicValue.Tuple(leftValue, rightValue), Schema.Tuple2(leftSchema, rightSchema, _)) =>
         val typedLeft  = leftValue.toTypedValueLazyError(leftSchema)
         val typedRight = rightValue.toTypedValueLazyError(rightSchema)
-        (typedLeft, typedRight) match {
+        (typedLeft, typedRight)  match {
           case (Left(e1), Left(e2)) =>
             Left(DecodeError.And(e1, e2))
           case (_, Left(e))         => Left(e)
@@ -114,7 +114,7 @@ object DynamicValue {
       schema: Schema.Either[_, _],
       value: Either[DynamicValue, DynamicValue]
     ): DynamicValue =
-      value match {
+      value  match {
         case Left(value)  => DynamicValue.LeftValue(value)
         case Right(value) => DynamicValue.RightValue(value)
       }
@@ -122,13 +122,13 @@ object DynamicValue {
       schema: Schema.Fallback[_, _],
       value: Fallback[DynamicValue, DynamicValue]
     ): DynamicValue =
-      value match {
+      value  match {
         case Fallback.Left(value)       => DynamicValue.LeftValue(value)
         case Fallback.Right(value)      => DynamicValue.RightValue(value)
         case Fallback.Both(left, right) => DynamicValue.BothValue(left, right)
       }
     override protected def processOption(schema: Schema.Optional[_], value: Option[DynamicValue]): DynamicValue =
-      value match {
+      value  match {
         case Some(value) => DynamicValue.SomeValue(value)
         case None        => DynamicValue.NoneValue
       }
@@ -154,7 +154,7 @@ object DynamicValue {
     val keys = values.keySet
     keys.foldLeft[Either[DecodeError, ListMap[String, Any]]](Right(ListMap.empty)) {
       case (Right(record), key) =>
-        (structure.find(_.name == key), values.get(key)) match {
+        (structure.find(_.name == key), values.get(key))  match {
           case (Some(field), Some(value)) =>
             value.toTypedValueLazyError(field.schema).map(value => (record + (key -> value)))
           case _ =>
@@ -163,53 +163,58 @@ object DynamicValue {
       case (Left(err), _) => Left(err)
     }
   }
+
   final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue  {
     override def hashCode(): Int = ("Record", id, values).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Record => id == that.id && values == that.values
       case _            => false
     }
   }
+
   final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue  {
     override def hashCode(): Int = ("Enumeration", id, value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Enumeration => id == that.id && value == that.value
       case _                 => false
     }
   }
+
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue  {
     override def hashCode(): Int = ("Sequence", values).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Sequence => values == that.values
       case _              => false
     }
   }
+
   final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue  {
     override def hashCode(): Int = ("Dictionary", entries).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Dictionary => entries == that.entries
       case _                => false
     }
   }
+
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue  {
     override def hashCode(): Int = values.hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: SetValue => values == that.values
       case _              => false
     }
   }
   sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue  {
     override def hashCode(): Int = {
-      val v = value match {
+      val v = value  match {
         case bd: java.math.BigDecimal => bd.stripTrailingZeros()
         case _                        => value
       }
       ("Primitive", v, standardType).hashCode()
     }
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Primitive[_] =>
         if (standardType != that.standardType) false
-        else (value, that.value) match {
+        else (value, that.value)  match {
           case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
             bd1.compareTo(bd2) == 0
           case _ => value == that.value
@@ -219,14 +224,15 @@ object DynamicValue {
   }
   sealed case class Singleton[A](instance: A) extends DynamicValue  {
     override def hashCode(): Int = ("Singleton", instance).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Singleton[_] => instance == that.instance
       case _                  => false
     }
   }
+
   final case class SomeValue(value: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("SomeValue", value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: SomeValue => value == that.value
       case _               => false
     }
@@ -237,42 +243,47 @@ object DynamicValue {
   }
   sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("Tuple", left, right).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Tuple => left == that.left && right == that.right
       case _           => false
     }
   }
+
   final case class LeftValue(value: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("LeftValue", value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: LeftValue => value == that.value
       case _               => false
     }
   }
+
   final case class RightValue(value: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("RightValue", value).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: RightValue => value == that.value
       case _                => false
     }
   }
+
   final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("BothValue", left, right).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: BothValue => left == that.left && right == that.right
       case _               => false
     }
   }
+
   final case class DynamicAst(ast: MetaSchema) extends DynamicValue  {
     override def hashCode(): Int = ("DynamicAst", ast).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: DynamicAst => ast == that.ast
       case _                => false
     }
   }
+
   final case class Error(message: String) extends DynamicValue  {
     override def hashCode(): Int = ("Error", message).hashCode()
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = other  match {
       case that: Error => message == that.message
       case _           => false
     }
@@ -561,7 +572,7 @@ object DynamicValue {
       (d: DynamicValue) => d.isInstanceOf[DynamicValue.Singleton[_]]
     )
   private def hasStandardType(value: DynamicValue, standardType: StandardType[_]): Boolean =
-    value match {
+    value  match {
       case DynamicValue.Primitive(_, tpe) => tpe == standardType
       case _                              => false
     }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -1,59 +1,44 @@
 package zio.schema
-
 import java.math.{ BigDecimal, BigInteger }
 import java.time._
 import java.util.UUID
-
 import scala.collection.immutable.ListMap
-
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
 import zio.{ Cause, Chunk, Unsafe }
-
 sealed trait DynamicValue {
   self =>
-
   def transform(transforms: Chunk[Migration]): Either[String, DynamicValue] =
     transforms.foldRight[Either[String, DynamicValue]](Right(self)) {
       case (transform, Right(value)) => transform.migrate(value)
       case (_, error @ Left(_))      => error
     }
-
   def toTypedValue[A](implicit schema: Schema[A]): Either[String, A] =
     toTypedValueLazyError.left.map(_.message)
-
   def toValue[A](implicit schema: Schema[A]): Either[DecodeError, A] = toTypedValueLazyError
-
   def toTypedValueOption[A](implicit schema: Schema[A]): Option[A] =
     toTypedValueLazyError.toOption
-
   private def toTypedValueLazyError[A](implicit schema: Schema[A]): Either[DecodeError, A] =
     (self, schema) match {
       case (DynamicValue.Primitive(value, p), Schema.Primitive(p2, _)) if p == p2 =>
         Right(value.asInstanceOf[A])
-
       case (DynamicValue.Record(_, values), Schema.GenericRecord(_, structure, _)) =>
         DynamicValue.decodeStructure(values, structure.toChunk).asInstanceOf[Either[DecodeError, A]]
-
       case (DynamicValue.Record(_, values), s: Schema.Record[A]) =>
         DynamicValue
           .decodeStructure(values, s.fields)
           .map(m => Chunk.fromIterable(m.values))
           .flatMap(values => s.construct(values)(Unsafe.unsafe).left.map(err => DecodeError.MalformedField(s, err)))
-
       case (DynamicValue.Enumeration(_, (key, value)), s: Schema.Enum[A]) =>
         s.caseOf(key) match {
           case Some(caseValue) =>
             value.toTypedValueLazyError(caseValue.schema).asInstanceOf[Either[DecodeError, A]]
           case None => Left(DecodeError.MissingCase(key, s))
         }
-
       case (DynamicValue.LeftValue(value), Schema.Either(schema1, _, _)) =>
         value.toTypedValueLazyError(schema1).map(Left(_))
-
       case (DynamicValue.RightValue(value), Schema.Either(_, schema1, _)) =>
         value.toTypedValueLazyError(schema1).map(Right(_))
-
       case (DynamicValue.Tuple(leftValue, rightValue), Schema.Tuple2(leftSchema, rightSchema, _)) =>
         val typedLeft  = leftValue.toTypedValueLazyError(leftSchema)
         val typedRight = rightValue.toTypedValueLazyError(rightSchema)
@@ -64,7 +49,6 @@ sealed trait DynamicValue {
           case (Left(e), _)         => Left(e)
           case (Right(a), Right(b)) => Right(a -> b)
         }
-
       case (DynamicValue.Sequence(values), schema: Schema.Sequence[col, t, _]) =>
         values
           .foldLeft[Either[DecodeError, Chunk[t]]](Right[DecodeError, Chunk[t]](Chunk.empty)) {
@@ -73,25 +57,20 @@ sealed trait DynamicValue {
               value.toTypedValueLazyError(schema.elementSchema).map(values :+ _)
           }
           .map(schema.fromChunk)
-
       case (DynamicValue.SetValue(values), schema: Schema.Set[t]) =>
         values.foldLeft[Either[DecodeError, Set[t]]](Right[DecodeError, Set[t]](Set.empty)) {
           case (err @ Left(_), _) => err
           case (Right(values), value) =>
             value.toTypedValueLazyError(schema.elementSchema).map(values + _)
         }
-
       case (DynamicValue.SomeValue(value), Schema.Optional(schema: Schema[_], _)) =>
         value.toTypedValueLazyError(schema).map(Some(_))
-
       case (DynamicValue.NoneValue, Schema.Optional(_, _)) =>
         Right(None)
-
       case (value, Schema.Transform(schema, f, _, _, _)) =>
         value
           .toTypedValueLazyError(schema)
           .flatMap(value => f(value).left.map(err => DecodeError.MalformedField(schema, err)))
-
       case (DynamicValue.Dictionary(entries), schema: Schema.Map[k, v]) =>
         entries.foldLeft[Either[DecodeError, Map[k, v]]](Right[DecodeError, Map[k, v]](Map.empty)) {
           case (err @ Left(_), _) => err
@@ -102,49 +81,35 @@ sealed trait DynamicValue {
             } yield map ++ Map(key -> value)
           }
         }
-
       case (_, l @ Schema.Lazy(_)) =>
         toTypedValueLazyError(l.schema)
-
       case (DynamicValue.Error(message), _) =>
         Left(DecodeError.ReadError(Cause.empty, message))
-
       case (DynamicValue.Tuple(dyn, DynamicValue.DynamicAst(ast)), _) =>
         val valueSchema = ast.toSchema.asInstanceOf[Schema[Any]]
         dyn.toTypedValueLazyError(valueSchema).map(a => (a -> valueSchema).asInstanceOf[A])
-
       case (dyn, Schema.Dynamic(_)) => Right(dyn)
-
       case _ =>
         Left(DecodeError.CastError(self, schema))
     }
-
 }
-
 object DynamicValue {
-
   private object FromSchemaAndValue extends SimpleMutableSchemaBasedValueProcessor[DynamicValue] {
     override protected def processPrimitive(value: Any, typ: StandardType[Any]): DynamicValue =
       DynamicValue.Primitive(value, typ)
-
     override protected def processRecord(schema: Schema.Record[_], value: ListMap[String, DynamicValue]): DynamicValue =
       DynamicValue.Record(schema.id, value)
-
     override protected def processEnum(schema: Schema.Enum[_], tuple: (String, DynamicValue)): DynamicValue =
       DynamicValue.Enumeration(schema.id, tuple)
-
     override protected def processSequence(schema: Schema.Sequence[_, _, _], value: Chunk[DynamicValue]): DynamicValue =
       DynamicValue.Sequence(value)
-
     override protected def processDictionary(
       schema: Schema.Map[_, _],
       value: Chunk[(DynamicValue, DynamicValue)]
     ): DynamicValue =
       DynamicValue.Dictionary(value)
-
     override protected def processSet(schema: Schema.Set[_], value: Set[DynamicValue]): DynamicValue =
       DynamicValue.SetValue(value)
-
     override protected def processEither(
       schema: Schema.Either[_, _],
       value: Either[DynamicValue, DynamicValue]
@@ -153,7 +118,6 @@ object DynamicValue {
         case Left(value)  => DynamicValue.LeftValue(value)
         case Right(value) => DynamicValue.RightValue(value)
       }
-
     override protected def processFallback(
       schema: Schema.Fallback[_, _],
       value: Fallback[DynamicValue, DynamicValue]
@@ -163,33 +127,26 @@ object DynamicValue {
         case Fallback.Right(value)      => DynamicValue.RightValue(value)
         case Fallback.Both(left, right) => DynamicValue.BothValue(left, right)
       }
-
     override protected def processOption(schema: Schema.Optional[_], value: Option[DynamicValue]): DynamicValue =
       value match {
         case Some(value) => DynamicValue.SomeValue(value)
         case None        => DynamicValue.NoneValue
       }
-
     override protected def processTuple(
       schema: Schema.Tuple2[_, _],
       left: DynamicValue,
       right: DynamicValue
     ): DynamicValue =
       DynamicValue.Tuple(left, right)
-
     override protected def processDynamic(value: DynamicValue): Option[DynamicValue] =
       Some(value)
-
     override protected def fail(message: String): DynamicValue =
       DynamicValue.Error(message)
   }
-
   def apply[A](a: A)(implicit ev: Schema[A]): DynamicValue = ev.toDynamic(a)
-
   //scalafmt: { maxColumn = 400 }
   def fromSchemaAndValue[A](schema: Schema[A], value: A): DynamicValue =
     FromSchemaAndValue.process(schema, value)
-
   def decodeStructure(
     values: ListMap[String, DynamicValue],
     structure: Chunk[Schema.Field[_, _]]
@@ -206,48 +163,42 @@ object DynamicValue {
       case (Left(err), _) => Left(err)
     }
   }
-
-  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
+  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue  {
     override def hashCode(): Int = ("Record", id, values).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Record => id == that.id && values == that.values
       case _            => false
     }
   }
-
-  final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
+  final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue  {
     override def hashCode(): Int = ("Enumeration", id, value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Enumeration => id == that.id && value == that.value
       case _                 => false
     }
   }
-
-  final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
+  final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue  {
     override def hashCode(): Int = ("Sequence", values).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Sequence => values == that.values
       case _              => false
     }
   }
-
-  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
+  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue  {
     override def hashCode(): Int = ("Dictionary", entries).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Dictionary => entries == that.entries
       case _                => false
     }
   }
-
-  final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
+  final case class SetValue(values: Set[DynamicValue]) extends DynamicValue  {
     override def hashCode(): Int = values.hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: SetValue => values == that.values
       case _              => false
     }
   }
-
-  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
+  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue  {
     override def hashCode(): Int = {
       val v = value match {
         case bd: java.math.BigDecimal => bd.stripTrailingZeros()
@@ -266,78 +217,67 @@ object DynamicValue {
       case _ => false
     }
   }
-
-  sealed case class Singleton[A](instance: A) extends DynamicValue {
+  sealed case class Singleton[A](instance: A) extends DynamicValue  {
     override def hashCode(): Int = ("Singleton", instance).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Singleton[_] => instance == that.instance
       case _                  => false
     }
   }
-
-  final case class SomeValue(value: DynamicValue) extends DynamicValue {
+  final case class SomeValue(value: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("SomeValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: SomeValue => value == that.value
       case _               => false
     }
   }
-
   case object NoneValue extends DynamicValue {
     override def hashCode(): Int             = "NoneValue".hashCode()
     override def equals(other: Any): Boolean = other.isInstanceOf[NoneValue.type]
   }
-
-  sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue {
+  sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("Tuple", left, right).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Tuple => left == that.left && right == that.right
       case _           => false
     }
   }
-
-  final case class LeftValue(value: DynamicValue) extends DynamicValue {
+  final case class LeftValue(value: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("LeftValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: LeftValue => value == that.value
       case _               => false
     }
   }
-
-  final case class RightValue(value: DynamicValue) extends DynamicValue {
+  final case class RightValue(value: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("RightValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: RightValue => value == that.value
       case _                => false
     }
   }
-
-  final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
+  final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue  {
     override def hashCode(): Int = ("BothValue", left, right).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: BothValue => left == that.left && right == that.right
       case _               => false
     }
   }
-
-  final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
+  final case class DynamicAst(ast: MetaSchema) extends DynamicValue  {
     override def hashCode(): Int = ("DynamicAst", ast).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: DynamicAst => ast == that.ast
       case _                => false
     }
   }
-
-  final case class Error(message: String) extends DynamicValue {
+  final case class Error(message: String) extends DynamicValue  {
     override def hashCode(): Int = ("Error", message).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Error => message == that.message
       case _           => false
     }
   }
-
   lazy val typeId: TypeId = TypeId.parse("zio.schema.DynamicValue")
-
   //TODO: Refactor case set so that adding a new type to StandardType without updating the below list will trigger a compile error
   lazy val schema: Schema[DynamicValue] =
     Schema.EnumN(
@@ -387,28 +327,20 @@ object DynamicValue {
         .:+:(primitiveCurrencyCase)
         .:+:(singletonCase)
     )
-
   implicit val instantStandardType: StandardType[Instant] =
     StandardType.InstantType
-
   implicit val localDateStandardType: StandardType[LocalDate] =
     StandardType.LocalDateType
-
   implicit val localTimeStandardType: StandardType[LocalTime] =
     StandardType.LocalTimeType
-
   implicit val localDateTimeStandardType: StandardType[LocalDateTime] =
     StandardType.LocalDateTimeType
-
   implicit val offsetTimeStandardType: StandardType[OffsetTime] =
     StandardType.OffsetTimeType
-
   implicit val offsetDateTimeStandardType: StandardType[OffsetDateTime] =
     StandardType.OffsetDateTimeType
-
   implicit val zonedDateTimeStandardType: StandardType[ZonedDateTime] =
     StandardType.ZonedDateTimeType
-
   private val errorCase: Schema.Case[DynamicValue, DynamicValue.Error] =
     Schema.Case(
       "Error",
@@ -426,7 +358,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.Error]
     )
-
   private val noneValueCase: Schema.Case[DynamicValue, DynamicValue.NoneValue.type] =
     Schema.Case(
       "NoneValue",
@@ -436,7 +367,6 @@ object DynamicValue {
       _.isInstanceOf[DynamicValue.NoneValue.type],
       Chunk("case")
     )
-
   private val rightValueCase: Schema.Case[DynamicValue, DynamicValue.RightValue] =
     Schema.Case(
       "RightValue",
@@ -454,7 +384,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.RightValue]
     )
-
   private val leftValueCase: Schema.Case[DynamicValue, DynamicValue.LeftValue] =
     Schema.Case(
       "LeftValue",
@@ -472,7 +401,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.LeftValue]
     )
-
   private val tupleCase: Schema.Case[DynamicValue, DynamicValue.Tuple] =
     Schema.Case(
       "Tuple",
@@ -496,7 +424,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.Tuple]
     )
-
   private val someValueCase: Schema.Case[DynamicValue, DynamicValue.SomeValue] =
     Schema.Case(
       "SomeValue",
@@ -515,7 +442,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.SomeValue]
     )
-
   private val dictionaryCase: Schema.Case[DynamicValue, DynamicValue.Dictionary] =
     Schema.Case(
       "Dictionary",
@@ -533,7 +459,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.Dictionary]
     )
-
   private val sequenceCase: Schema.Case[DynamicValue, DynamicValue.Sequence] =
     Schema.Case(
       "Sequence",
@@ -551,7 +476,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.Sequence]
     )
-
   private val setCase: Schema.Case[DynamicValue, DynamicValue.SetValue] =
     Schema.Case(
       "SetValue",
@@ -569,7 +493,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.SetValue]
     )
-
   private val enumerationCase: Schema.Case[DynamicValue, DynamicValue.Enumeration] =
     Schema.Case(
       "Enumeration",
@@ -593,7 +516,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.Enumeration]
     )
-
   private val recordCase: Schema.Case[DynamicValue, DynamicValue.Record] =
     Schema.Case(
       "Record",
@@ -613,7 +535,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.Record]
     )
-
   private val dynamicAstCase: Schema.Case[DynamicValue, DynamicValue.DynamicAst] =
     Schema.Case(
       "DynamicAst",
@@ -631,7 +552,6 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       _.isInstanceOf[DynamicValue.DynamicAst]
     )
-
   private val singletonCase: Schema.Case[DynamicValue, DynamicValue.Singleton[Any]] =
     Schema.Case(
       "Singleton",
@@ -640,13 +560,11 @@ object DynamicValue {
       _.asInstanceOf[DynamicValue],
       (d: DynamicValue) => d.isInstanceOf[DynamicValue.Singleton[_]]
     )
-
   private def hasStandardType(value: DynamicValue, standardType: StandardType[_]): Boolean =
     value match {
       case DynamicValue.Primitive(_, tpe) => tpe == standardType
       case _                              => false
     }
-
   private val primitiveUnitCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Unit]] =
     Schema.Case(
       "Unit",
@@ -659,7 +577,6 @@ object DynamicValue {
         case _                             => false
       }
     )
-
   private val primitiveStringCase: Schema.Case[DynamicValue, DynamicValue.Primitive[String]] =
     Schema.Case(
       "String",
@@ -672,7 +589,6 @@ object DynamicValue {
         case _                                    => false
       }
     )
-
   private val primitiveBooleanCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Boolean]] =
     Schema.Case(
       "Boolean",
@@ -685,7 +601,6 @@ object DynamicValue {
         case _                                     => false
       }
     )
-
   private val primitiveShortCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Short]] =
     Schema.Case(
       "Short",
@@ -698,7 +613,6 @@ object DynamicValue {
         case _                                   => false
       }
     )
-
   private val primitiveIntCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Int]] =
     Schema.Case(
       "Int",
@@ -709,7 +623,6 @@ object DynamicValue {
       (dv: DynamicValue.Primitive[Int]) => dv.asInstanceOf[DynamicValue],
       hasStandardType(_, StandardType.IntType)
     )
-
   private val primitiveLongCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Long]] =
     Schema.Case(
       "Long",
@@ -720,7 +633,6 @@ object DynamicValue {
       (dv: DynamicValue.Primitive[Long]) => dv.asInstanceOf[DynamicValue],
       hasStandardType(_, StandardType.LongType)
     )
-
   private val primitiveFloatCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Float]] =
     Schema.Case(
       "Float",
@@ -731,7 +643,6 @@ object DynamicValue {
       (dv: DynamicValue.Primitive[Float]) => dv.asInstanceOf[DynamicValue],
       hasStandardType(_, StandardType.FloatType)
     )
-
   private val primitiveDoubleCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Double]] =
     Schema.Case(
       "Double",
@@ -742,7 +653,6 @@ object DynamicValue {
       (dv: DynamicValue.Primitive[Double]) => dv.asInstanceOf[DynamicValue],
       hasStandardType(_, StandardType.DoubleType)
     )
-
   private val primitiveBinaryCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Chunk[Byte]]] =
     Schema.Case(
       "Binary",
@@ -755,7 +665,6 @@ object DynamicValue {
         case _                                      => false
       }
     )
-
   private val primitiveCharCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Char]] =
     Schema.Case(
       "Char",
@@ -768,7 +677,6 @@ object DynamicValue {
         case _                                  => false
       }
     )
-
   private val primitiveBigDecimalCase: Schema.Case[DynamicValue, DynamicValue.Primitive[BigDecimal]] =
     Schema.Case(
       "BigDecimal",
@@ -781,7 +689,6 @@ object DynamicValue {
         case _                                        => false
       }
     )
-
   private val primitiveBigIntegerCase: Schema.Case[DynamicValue, DynamicValue.Primitive[BigInteger]] =
     Schema.Case(
       "BigInteger",
@@ -794,7 +701,6 @@ object DynamicValue {
         case _                                        => false
       }
     )
-
   private val primitiveDayOfWeekCase: Schema.Case[DynamicValue, DynamicValue.Primitive[DayOfWeek]] =
     Schema.Case(
       "DayOfWeek",
@@ -807,7 +713,6 @@ object DynamicValue {
         case _                                       => false
       }
     )
-
   private val primitiveMonthCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Month]] =
     Schema.Case(
       "Month",
@@ -820,7 +725,6 @@ object DynamicValue {
         case _                                   => false
       }
     )
-
   private val primitiveMonthDayCase: Schema.Case[DynamicValue, DynamicValue.Primitive[MonthDay]] =
     Schema.Case(
       "MonthDay",
@@ -833,7 +737,6 @@ object DynamicValue {
         case _                                      => false
       }
     )
-
   private val primitivePeriodCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Period]] =
     Schema.Case(
       "Period",
@@ -846,7 +749,6 @@ object DynamicValue {
         case _                                    => false
       }
     )
-
   private val primitiveYearCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Year]] =
     Schema.Case(
       "Year",
@@ -859,7 +761,6 @@ object DynamicValue {
         case _                                  => false
       }
     )
-
   private val primitiveYearMonthCase: Schema.Case[DynamicValue, DynamicValue.Primitive[YearMonth]] =
     Schema.Case(
       "YearMonth",
@@ -872,7 +773,6 @@ object DynamicValue {
         case _                                       => false
       }
     )
-
   private val primitiveZoneIdCase: Schema.Case[DynamicValue, DynamicValue.Primitive[ZoneId]] =
     Schema.Case(
       "ZoneId",
@@ -885,7 +785,6 @@ object DynamicValue {
         case _                                    => false
       }
     )
-
   private val primitiveZoneOffsetCase: Schema.Case[DynamicValue, DynamicValue.Primitive[ZoneOffset]] =
     Schema.Case(
       "ZoneOffset",
@@ -898,7 +797,6 @@ object DynamicValue {
         case _                                        => false
       }
     )
-
   private val primitiveInstantCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Instant]] =
     Schema.Case(
       "Instant",
@@ -911,7 +809,6 @@ object DynamicValue {
         case _                                     => false
       }
     )
-
   private val primitiveDurationCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Duration]] =
     Schema.Case(
       "Duration",
@@ -924,7 +821,6 @@ object DynamicValue {
         case _                                      => false
       }
     )
-
   private val primitiveLocalDateCase: Schema.Case[DynamicValue, DynamicValue.Primitive[LocalDate]] =
     Schema.Case(
       "LocalDate",
@@ -937,7 +833,6 @@ object DynamicValue {
         case _                                       => false
       }
     )
-
   private val primitiveLocalTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[LocalTime]] =
     Schema.Case(
       "LocalTime",
@@ -950,7 +845,6 @@ object DynamicValue {
         case _                                       => false
       }
     )
-
   private val primitiveLocalDateTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[LocalDateTime]] =
     Schema.Case(
       "LocalDateTime",
@@ -965,7 +859,6 @@ object DynamicValue {
         case _                                           => false
       }
     )
-
   private val primitiveOffsetTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[OffsetTime]] =
     Schema.Case(
       "OffsetTime",
@@ -978,7 +871,6 @@ object DynamicValue {
         case _                                        => false
       }
     )
-
   private val primitiveOffsetDateTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[OffsetDateTime]] =
     Schema.Case(
       "OffsetDateTime",
@@ -994,7 +886,6 @@ object DynamicValue {
         case _                                            => false
       }
     )
-
   private val primitiveZonedDateTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[ZonedDateTime]] =
     Schema.Case(
       "ZonedDateTime",
@@ -1009,7 +900,6 @@ object DynamicValue {
         case _                                           => false
       }
     )
-
   private val primitiveUUIDCase: Schema.Case[DynamicValue, DynamicValue.Primitive[UUID]] =
     Schema.Case(
       "UUID",
@@ -1022,7 +912,6 @@ object DynamicValue {
         case _                                  => false
       }
     )
-
   private val primitiveCurrencyCase: Schema.Case[DynamicValue, DynamicValue.Primitive[java.util.Currency]] =
     Schema.Case(
       "Currency",

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -164,7 +164,6 @@ object DynamicValue {
     }
   }
 
-
   final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = ("Record", id, values).hashCode()
     override def equals(other: Any): Boolean = other match {
@@ -172,7 +171,6 @@ object DynamicValue {
       case _            => false
     }
   }
-
 
   final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
     override def hashCode(): Int = ("Enumeration", id, value).hashCode()
@@ -182,7 +180,6 @@ object DynamicValue {
     }
   }
 
-
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = ("Sequence", values).hashCode()
     override def equals(other: Any): Boolean = other match {
@@ -191,7 +188,6 @@ object DynamicValue {
     }
   }
 
-
   final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
     override def hashCode(): Int = ("Dictionary", entries).hashCode()
     override def equals(other: Any): Boolean = other match {
@@ -199,7 +195,6 @@ object DynamicValue {
       case _                => false
     }
   }
-
 
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = values.hashCode()
@@ -237,7 +232,6 @@ object DynamicValue {
     }
   }
 
-
   final case class SomeValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("SomeValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
@@ -259,7 +253,6 @@ object DynamicValue {
     }
   }
 
-
   final case class LeftValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("LeftValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
@@ -267,7 +260,6 @@ object DynamicValue {
       case _               => false
     }
   }
-
 
   final case class RightValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("RightValue", value).hashCode()
@@ -277,7 +269,6 @@ object DynamicValue {
     }
   }
 
-
   final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("BothValue", left, right).hashCode()
     override def equals(other: Any): Boolean = other match {
@@ -286,7 +277,6 @@ object DynamicValue {
     }
   }
 
-
   final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
     override def hashCode(): Int = ("DynamicAst", ast).hashCode()
     override def equals(other: Any): Boolean = other match {
@@ -294,7 +284,6 @@ object DynamicValue {
       case _                => false
     }
   }
-
 
   final case class Error(message: String) extends DynamicValue {
     override def hashCode(): Int = ("Error", message).hashCode()

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -1,21 +1,24 @@
 package zio.schema
-import java.math.{BigDecimal, BigInteger}
+import java.math.{ BigDecimal, BigInteger }
 import java.time._
 import java.util.UUID
 import scala.collection.immutable.ListMap
 import zio.schema.codec.DecodeError
-import zio.schema.meta.{MetaSchema, Migration}
-import zio.{Cause, Chunk, Unsafe}
+import zio.schema.meta.{ MetaSchema, Migration }
+import zio.{ Cause, Chunk, Unsafe }
 sealed trait DynamicValue {
   self =>
+
   def transform(transforms: Chunk[Migration]): Either[String, DynamicValue] =
     transforms.foldRight[Either[String, DynamicValue]](Right(self)) {
       case (transform, Right(value)) => transform.migrate(value)
       case (_, error @ Left(_))      => error
     }
+
   def toTypedValue[A](implicit schema: Schema[A]): Either[String, A] =
     toTypedValueLazyError.left.map(_.message)
   def toValue[A](implicit schema: Schema[A]): Either[DecodeError, A] = toTypedValueLazyError
+
   def toTypedValueOption[A](implicit schema: Schema[A]): Option[A] =
     toTypedValueLazyError.toOption
   private def toTypedValueLazyError[A](implicit schema: Schema[A]): Either[DecodeError, A] =
@@ -93,6 +96,7 @@ sealed trait DynamicValue {
         Left(DecodeError.CastError(self, schema))
     }
 }
+
 object DynamicValue {
   private object FromSchemaAndValue extends SimpleMutableSchemaBasedValueProcessor[DynamicValue] {
     override protected def processPrimitive(value: Any, typ: StandardType[Any]): DynamicValue =
@@ -144,9 +148,11 @@ object DynamicValue {
       DynamicValue.Error(message)
   }
   def apply[A](a: A)(implicit ev: Schema[A]): DynamicValue = ev.toDynamic(a)
+
   //scalafmt: { maxColumn = 400 }
   def fromSchemaAndValue[A](schema: Schema[A], value: A): DynamicValue =
     FromSchemaAndValue.process(schema, value)
+
   def decodeStructure(
     values: ListMap[String, DynamicValue],
     structure: Chunk[Schema.Field[_, _]]
@@ -251,7 +257,7 @@ object DynamicValue {
   }
 
   case object NoneValue extends DynamicValue {
-    override def hashCode(): Int = "NoneValue".hashCode()
+    override def hashCode(): Int             = "NoneValue".hashCode()
     override def equals(other: Any): Boolean = other.isInstanceOf[NoneValue.type]
   }
 
@@ -599,13 +605,11 @@ object DynamicValue {
   private val primitiveUnitCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Unit]] =
     Schema.Case(
       "Unit",
-      Schema.primitive[Unit].transform(unit => DynamicValue.Primitive(unit, StandardType[Unit]), _.value),
-      {
+      Schema.primitive[Unit].transform(unit => DynamicValue.Primitive(unit, StandardType[Unit]), _.value), {
         case dv @ DynamicValue.Primitive((), _) => dv.asInstanceOf[DynamicValue.Primitive[Unit]]
         case _                                  => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Unit]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Unit]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive((), _) => true
         case _                             => false
       }
@@ -613,13 +617,11 @@ object DynamicValue {
   private val primitiveStringCase: Schema.Case[DynamicValue, DynamicValue.Primitive[String]] =
     Schema.Case(
       "String",
-      Schema.primitive[String].transform(s => DynamicValue.Primitive(s, StandardType[String]), _.value),
-      {
+      Schema.primitive[String].transform(s => DynamicValue.Primitive(s, StandardType[String]), _.value), {
         case dv @ DynamicValue.Primitive(_: String, _) => dv.asInstanceOf[DynamicValue.Primitive[String]]
         case _                                         => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[String]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[String]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: String, _) => true
         case _                                    => false
       }
@@ -627,13 +629,11 @@ object DynamicValue {
   private val primitiveBooleanCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Boolean]] =
     Schema.Case(
       "Boolean",
-      Schema.primitive[Boolean].transform(b => DynamicValue.Primitive(b, StandardType[Boolean]), _.value),
-      {
+      Schema.primitive[Boolean].transform(b => DynamicValue.Primitive(b, StandardType[Boolean]), _.value), {
         case dv @ DynamicValue.Primitive(_: Boolean, _) => dv.asInstanceOf[DynamicValue.Primitive[Boolean]]
         case _                                          => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Boolean]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Boolean]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Boolean, _) => true
         case _                                     => false
       }
@@ -641,13 +641,11 @@ object DynamicValue {
   private val primitiveShortCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Short]] =
     Schema.Case(
       "Short",
-      Schema.primitive[Short].transform(sh => DynamicValue.Primitive(sh, StandardType[Short]), _.value),
-      {
+      Schema.primitive[Short].transform(sh => DynamicValue.Primitive(sh, StandardType[Short]), _.value), {
         case dv @ DynamicValue.Primitive(_: Short, _) => dv.asInstanceOf[DynamicValue.Primitive[Short]]
         case _                                        => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Short]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Short]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Short, _) => true
         case _                                   => false
       }
@@ -655,8 +653,7 @@ object DynamicValue {
   private val primitiveIntCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Int]] =
     Schema.Case(
       "Int",
-      Schema.primitive[Int].transform(i => DynamicValue.Primitive(i, StandardType[Int]), _.value),
-      {
+      Schema.primitive[Int].transform(i => DynamicValue.Primitive(i, StandardType[Int]), _.value), {
         case dv @ DynamicValue.Primitive(_: Int, _) => dv.asInstanceOf[DynamicValue.Primitive[Int]]
         case _                                      => throw new IllegalArgumentException
       },
@@ -666,8 +663,7 @@ object DynamicValue {
   private val primitiveLongCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Long]] =
     Schema.Case(
       "Long",
-      Schema.primitive[Long].transform(l => DynamicValue.Primitive(l, StandardType[Long]), _.value),
-      {
+      Schema.primitive[Long].transform(l => DynamicValue.Primitive(l, StandardType[Long]), _.value), {
         case dv @ DynamicValue.Primitive(_: Long, _) => dv.asInstanceOf[DynamicValue.Primitive[Long]]
         case _                                       => throw new IllegalArgumentException
       },
@@ -677,8 +673,7 @@ object DynamicValue {
   private val primitiveFloatCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Float]] =
     Schema.Case(
       "Float",
-      Schema.primitive[Float].transform(f => DynamicValue.Primitive(f, StandardType[Float]), _.value),
-      {
+      Schema.primitive[Float].transform(f => DynamicValue.Primitive(f, StandardType[Float]), _.value), {
         case dv @ DynamicValue.Primitive(_: Float, _) => dv.asInstanceOf[DynamicValue.Primitive[Float]]
         case _                                        => throw new IllegalArgumentException
       },
@@ -688,8 +683,7 @@ object DynamicValue {
   private val primitiveDoubleCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Double]] =
     Schema.Case(
       "Double",
-      Schema.primitive[Double].transform(d => DynamicValue.Primitive(d, StandardType[Double]), _.value),
-      {
+      Schema.primitive[Double].transform(d => DynamicValue.Primitive(d, StandardType[Double]), _.value), {
         case dv @ DynamicValue.Primitive(_: Double, _) => dv.asInstanceOf[DynamicValue.Primitive[Double]]
         case _                                         => throw new IllegalArgumentException
       },
@@ -699,13 +693,11 @@ object DynamicValue {
   private val primitiveBinaryCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Chunk[Byte]]] =
     Schema.Case(
       "Binary",
-      Schema.primitive[Chunk[Byte]].transform(ch => DynamicValue.Primitive(ch, StandardType[Chunk[Byte]]), _.value),
-      {
+      Schema.primitive[Chunk[Byte]].transform(ch => DynamicValue.Primitive(ch, StandardType[Chunk[Byte]]), _.value), {
         case dv @ DynamicValue.Primitive(_: Chunk[_], _) => dv.asInstanceOf[DynamicValue.Primitive[Chunk[Byte]]]
         case _                                           => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Chunk[Byte]]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Chunk[Byte]]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Chunk[_], _) => true
         case _                                      => false
       }
@@ -713,13 +705,11 @@ object DynamicValue {
   private val primitiveCharCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Char]] =
     Schema.Case(
       "Char",
-      Schema.primitive[Char].transform(ch => DynamicValue.Primitive(ch, StandardType[Char]), _.value),
-      {
+      Schema.primitive[Char].transform(ch => DynamicValue.Primitive(ch, StandardType[Char]), _.value), {
         case dv @ DynamicValue.Primitive(_: Char, _) => dv.asInstanceOf[DynamicValue.Primitive[Char]]
         case _                                       => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Char]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Char]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Char, _) => true
         case _                                  => false
       }
@@ -727,13 +717,11 @@ object DynamicValue {
   private val primitiveBigDecimalCase: Schema.Case[DynamicValue, DynamicValue.Primitive[BigDecimal]] =
     Schema.Case(
       "BigDecimal",
-      Schema.primitive[BigDecimal].transform(bd => DynamicValue.Primitive(bd, StandardType[BigDecimal]), _.value),
-      {
+      Schema.primitive[BigDecimal].transform(bd => DynamicValue.Primitive(bd, StandardType[BigDecimal]), _.value), {
         case dv @ DynamicValue.Primitive(_: BigDecimal, _) => dv.asInstanceOf[DynamicValue.Primitive[BigDecimal]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[BigDecimal]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[BigDecimal]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: BigDecimal, _) => true
         case _                                        => false
       }
@@ -741,13 +729,11 @@ object DynamicValue {
   private val primitiveBigIntegerCase: Schema.Case[DynamicValue, DynamicValue.Primitive[BigInteger]] =
     Schema.Case(
       "BigInteger",
-      Schema.primitive[BigInteger].transform(bi => DynamicValue.Primitive(bi, StandardType[BigInteger]), _.value),
-      {
+      Schema.primitive[BigInteger].transform(bi => DynamicValue.Primitive(bi, StandardType[BigInteger]), _.value), {
         case dv @ DynamicValue.Primitive(_: BigInteger, _) => dv.asInstanceOf[DynamicValue.Primitive[BigInteger]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[BigInteger]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[BigInteger]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: BigInteger, _) => true
         case _                                        => false
       }
@@ -755,13 +741,11 @@ object DynamicValue {
   private val primitiveDayOfWeekCase: Schema.Case[DynamicValue, DynamicValue.Primitive[DayOfWeek]] =
     Schema.Case(
       "DayOfWeek",
-      Schema.primitive[DayOfWeek].transform(dw => DynamicValue.Primitive(dw, StandardType[DayOfWeek]), _.value),
-      {
+      Schema.primitive[DayOfWeek].transform(dw => DynamicValue.Primitive(dw, StandardType[DayOfWeek]), _.value), {
         case dv @ DynamicValue.Primitive(_: DayOfWeek, _) => dv.asInstanceOf[DynamicValue.Primitive[DayOfWeek]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[DayOfWeek]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[DayOfWeek]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: DayOfWeek, _) => true
         case _                                       => false
       }
@@ -769,13 +753,11 @@ object DynamicValue {
   private val primitiveMonthCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Month]] =
     Schema.Case(
       "Month",
-      Schema.primitive[Month].transform(m => DynamicValue.Primitive(m, StandardType[Month]), _.value),
-      {
+      Schema.primitive[Month].transform(m => DynamicValue.Primitive(m, StandardType[Month]), _.value), {
         case dv @ DynamicValue.Primitive(_: Month, _) => dv.asInstanceOf[DynamicValue.Primitive[Month]]
         case _                                        => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Month]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Month]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Month, _) => true
         case _                                   => false
       }
@@ -783,13 +765,11 @@ object DynamicValue {
   private val primitiveMonthDayCase: Schema.Case[DynamicValue, DynamicValue.Primitive[MonthDay]] =
     Schema.Case(
       "MonthDay",
-      Schema.primitive[MonthDay].transform(md => DynamicValue.Primitive(md, StandardType[MonthDay]), _.value),
-      {
+      Schema.primitive[MonthDay].transform(md => DynamicValue.Primitive(md, StandardType[MonthDay]), _.value), {
         case dv @ DynamicValue.Primitive(_: MonthDay, _) => dv.asInstanceOf[DynamicValue.Primitive[MonthDay]]
         case _                                           => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[MonthDay]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[MonthDay]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: MonthDay, _) => true
         case _                                      => false
       }
@@ -797,13 +777,11 @@ object DynamicValue {
   private val primitivePeriodCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Period]] =
     Schema.Case(
       "Period",
-      Schema.primitive[Period].transform(p => DynamicValue.Primitive(p, StandardType[Period]), _.value),
-      {
+      Schema.primitive[Period].transform(p => DynamicValue.Primitive(p, StandardType[Period]), _.value), {
         case dv @ DynamicValue.Primitive(_: Period, _) => dv.asInstanceOf[DynamicValue.Primitive[Period]]
         case _                                         => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Period]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Period]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Period, _) => true
         case _                                    => false
       }
@@ -811,13 +789,11 @@ object DynamicValue {
   private val primitiveYearCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Year]] =
     Schema.Case(
       "Year",
-      Schema.primitive[Year].transform(y => DynamicValue.Primitive(y, StandardType[Year]), _.value),
-      {
+      Schema.primitive[Year].transform(y => DynamicValue.Primitive(y, StandardType[Year]), _.value), {
         case dv @ DynamicValue.Primitive(_: Year, _) => dv.asInstanceOf[DynamicValue.Primitive[Year]]
         case _                                       => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Year]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Year]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Year, _) => true
         case _                                  => false
       }
@@ -825,13 +801,11 @@ object DynamicValue {
   private val primitiveYearMonthCase: Schema.Case[DynamicValue, DynamicValue.Primitive[YearMonth]] =
     Schema.Case(
       "YearMonth",
-      Schema.primitive[YearMonth].transform(ym => DynamicValue.Primitive(ym, StandardType[YearMonth]), _.value),
-      {
+      Schema.primitive[YearMonth].transform(ym => DynamicValue.Primitive(ym, StandardType[YearMonth]), _.value), {
         case dv @ DynamicValue.Primitive(_: YearMonth, _) => dv.asInstanceOf[DynamicValue.Primitive[YearMonth]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[YearMonth]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[YearMonth]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: YearMonth, _) => true
         case _                                       => false
       }
@@ -839,13 +813,11 @@ object DynamicValue {
   private val primitiveZoneIdCase: Schema.Case[DynamicValue, DynamicValue.Primitive[ZoneId]] =
     Schema.Case(
       "ZoneId",
-      Schema.primitive[ZoneId].transform(zid => DynamicValue.Primitive(zid, StandardType[ZoneId]), _.value),
-      {
+      Schema.primitive[ZoneId].transform(zid => DynamicValue.Primitive(zid, StandardType[ZoneId]), _.value), {
         case dv @ DynamicValue.Primitive(_: ZoneId, _) => dv.asInstanceOf[DynamicValue.Primitive[ZoneId]]
         case _                                         => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[ZoneId]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[ZoneId]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: ZoneId, _) => true
         case _                                    => false
       }
@@ -853,13 +825,11 @@ object DynamicValue {
   private val primitiveZoneOffsetCase: Schema.Case[DynamicValue, DynamicValue.Primitive[ZoneOffset]] =
     Schema.Case(
       "ZoneOffset",
-      Schema.primitive[ZoneOffset].transform(zo => DynamicValue.Primitive(zo, StandardType[ZoneOffset]), _.value),
-      {
+      Schema.primitive[ZoneOffset].transform(zo => DynamicValue.Primitive(zo, StandardType[ZoneOffset]), _.value), {
         case dv @ DynamicValue.Primitive(_: ZoneOffset, _) => dv.asInstanceOf[DynamicValue.Primitive[ZoneOffset]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[ZoneOffset]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[ZoneOffset]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: ZoneOffset, _) => true
         case _                                        => false
       }
@@ -867,13 +837,11 @@ object DynamicValue {
   private val primitiveInstantCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Instant]] =
     Schema.Case(
       "Instant",
-      Schema.primitive[Instant].transform(i => DynamicValue.Primitive(i, StandardType[Instant]), _.value),
-      {
+      Schema.primitive[Instant].transform(i => DynamicValue.Primitive(i, StandardType[Instant]), _.value), {
         case dv @ DynamicValue.Primitive(_: Instant, _) => dv.asInstanceOf[DynamicValue.Primitive[Instant]]
         case _                                          => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Instant]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Instant]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Instant, _) => true
         case _                                     => false
       }
@@ -881,13 +849,11 @@ object DynamicValue {
   private val primitiveDurationCase: Schema.Case[DynamicValue, DynamicValue.Primitive[Duration]] =
     Schema.Case(
       "Duration",
-      Schema.primitive[Duration].transform(i => DynamicValue.Primitive(i, StandardType[Duration]), _.value),
-      {
+      Schema.primitive[Duration].transform(i => DynamicValue.Primitive(i, StandardType[Duration]), _.value), {
         case dv @ DynamicValue.Primitive(_: Duration, _) => dv.asInstanceOf[DynamicValue.Primitive[Duration]]
         case _                                           => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[Duration]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[Duration]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: Duration, _) => true
         case _                                      => false
       }
@@ -895,13 +861,11 @@ object DynamicValue {
   private val primitiveLocalDateCase: Schema.Case[DynamicValue, DynamicValue.Primitive[LocalDate]] =
     Schema.Case(
       "LocalDate",
-      Schema.primitive[LocalDate].transform(ld => DynamicValue.Primitive(ld, StandardType[LocalDate]), _.value),
-      {
+      Schema.primitive[LocalDate].transform(ld => DynamicValue.Primitive(ld, StandardType[LocalDate]), _.value), {
         case dv @ DynamicValue.Primitive(_: LocalDate, _) => dv.asInstanceOf[DynamicValue.Primitive[LocalDate]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[LocalDate]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[LocalDate]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: LocalDate, _) => true
         case _                                       => false
       }
@@ -909,13 +873,11 @@ object DynamicValue {
   private val primitiveLocalTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[LocalTime]] =
     Schema.Case(
       "LocalTime",
-      Schema.primitive[LocalTime].transform(lt => DynamicValue.Primitive(lt, StandardType[LocalTime]), _.value),
-      {
+      Schema.primitive[LocalTime].transform(lt => DynamicValue.Primitive(lt, StandardType[LocalTime]), _.value), {
         case dv @ DynamicValue.Primitive(_: LocalTime, _) => dv.asInstanceOf[DynamicValue.Primitive[LocalTime]]
         case _                                            => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[LocalTime]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[LocalTime]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: LocalTime, _) => true
         case _                                       => false
       }
@@ -925,13 +887,11 @@ object DynamicValue {
       "LocalDateTime",
       Schema
         .primitive[LocalDateTime]
-        .transform(ldt => DynamicValue.Primitive(ldt, StandardType[LocalDateTime]), _.value),
-      {
+        .transform(ldt => DynamicValue.Primitive(ldt, StandardType[LocalDateTime]), _.value), {
         case dv @ DynamicValue.Primitive(_: LocalDateTime, _) => dv.asInstanceOf[DynamicValue.Primitive[LocalDateTime]]
         case _                                                => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[LocalDateTime]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[LocalDateTime]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: LocalDateTime, _) => true
         case _                                           => false
       }
@@ -939,13 +899,11 @@ object DynamicValue {
   private val primitiveOffsetTimeCase: Schema.Case[DynamicValue, DynamicValue.Primitive[OffsetTime]] =
     Schema.Case(
       "OffsetTime",
-      Schema.primitive[OffsetTime].transform(ot => DynamicValue.Primitive(ot, StandardType[OffsetTime]), _.value),
-      {
+      Schema.primitive[OffsetTime].transform(ot => DynamicValue.Primitive(ot, StandardType[OffsetTime]), _.value), {
         case dv @ DynamicValue.Primitive(_: OffsetTime, _) => dv.asInstanceOf[DynamicValue.Primitive[OffsetTime]]
         case _                                             => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[OffsetTime]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[OffsetTime]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: OffsetTime, _) => true
         case _                                        => false
       }
@@ -955,14 +913,12 @@ object DynamicValue {
       "OffsetDateTime",
       Schema
         .primitive[OffsetDateTime]
-        .transform(odt => DynamicValue.Primitive(odt, StandardType[OffsetDateTime]), _.value),
-      {
+        .transform(odt => DynamicValue.Primitive(odt, StandardType[OffsetDateTime]), _.value), {
         case dv @ DynamicValue.Primitive(_: OffsetDateTime, _) =>
           dv.asInstanceOf[DynamicValue.Primitive[OffsetDateTime]]
         case _ => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[OffsetDateTime]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[OffsetDateTime]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: OffsetDateTime, _) => true
         case _                                            => false
       }
@@ -972,13 +928,11 @@ object DynamicValue {
       "ZonedDateTime",
       Schema
         .primitive[ZonedDateTime]
-        .transform(zdt => DynamicValue.Primitive(zdt, StandardType[ZonedDateTime]), _.value),
-      {
+        .transform(zdt => DynamicValue.Primitive(zdt, StandardType[ZonedDateTime]), _.value), {
         case dv @ DynamicValue.Primitive(_: ZonedDateTime, _) => dv.asInstanceOf[DynamicValue.Primitive[ZonedDateTime]]
         case _                                                => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[ZonedDateTime]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[ZonedDateTime]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: ZonedDateTime, _) => true
         case _                                           => false
       }
@@ -986,13 +940,11 @@ object DynamicValue {
   private val primitiveUUIDCase: Schema.Case[DynamicValue, DynamicValue.Primitive[UUID]] =
     Schema.Case(
       "UUID",
-      Schema.primitive[UUID].transform(uuid => DynamicValue.Primitive(uuid, StandardType[UUID]), _.value),
-      {
+      Schema.primitive[UUID].transform(uuid => DynamicValue.Primitive(uuid, StandardType[UUID]), _.value), {
         case dv @ DynamicValue.Primitive(_: UUID, _) => dv.asInstanceOf[DynamicValue.Primitive[UUID]]
         case _                                       => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[UUID]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[UUID]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: UUID, _) => true
         case _                                  => false
       }
@@ -1000,13 +952,11 @@ object DynamicValue {
   private val primitiveCurrencyCase: Schema.Case[DynamicValue, DynamicValue.Primitive[java.util.Currency]] =
     Schema.Case(
       "Currency",
-      Schema.primitive[java.util.Currency].transform(currency => DynamicValue.Primitive(currency, StandardType[java.util.Currency]), _.value),
-      {
+      Schema.primitive[java.util.Currency].transform(currency => DynamicValue.Primitive(currency, StandardType[java.util.Currency]), _.value), {
         case dv @ DynamicValue.Primitive(_: java.util.Currency, _) => dv.asInstanceOf[DynamicValue.Primitive[java.util.Currency]]
         case _                                                     => throw new IllegalArgumentException
       },
-      (dv: DynamicValue.Primitive[java.util.Currency]) => dv.asInstanceOf[DynamicValue],
-      {
+      (dv: DynamicValue.Primitive[java.util.Currency]) => dv.asInstanceOf[DynamicValue], {
         case DynamicValue.Primitive(_: java.util.Currency, _) => true
         case _                                                => false
       }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -168,85 +168,86 @@ object DynamicValue {
     override def hashCode(): Int = ("Record", id, values).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: Record => id == that.id && values == that.values
-      case _            => false
-    }
+        case that: Record => id == that.id && values == that.values
+        case _            => false
+      }
   }
 
   final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
     override def hashCode(): Int = ("Enumeration", id, value).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: Enumeration => id == that.id && value == that.value
-      case _                 => false
-    }
+        case that: Enumeration => id == that.id && value == that.value
+        case _                 => false
+      }
   }
 
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = ("Sequence", values).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: Sequence => values == that.values
-      case _              => false
-    }
+        case that: Sequence => values == that.values
+        case _              => false
+      }
   }
 
   final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
     override def hashCode(): Int = ("Dictionary", entries).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: Dictionary => entries == that.entries
-      case _                => false
-    }
+        case that: Dictionary => entries == that.entries
+        case _                => false
+      }
   }
 
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
     override def hashCode(): Int = values.hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: SetValue => values == that.values
-      case _              => false
-    }
+        case that: SetValue => values == that.values
+        case _              => false
+      }
   }
 
   sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
     override def hashCode(): Int = {
       val v =
-    value match {
-        case bd: java.math.BigDecimal => bd.stripTrailingZeros()
-        case _                        => value
-      }
+        value match {
+          case bd: java.math.BigDecimal => bd.stripTrailingZeros()
+          case _                        => value
+        }
       ("Primitive", v, standardType).hashCode()
     }
     override def equals(other: Any): Boolean =
       other match {
-      case that: Primitive[_] =>
-        if (standardType != that.standardType) false
-        else (value, that.value) match {
-          case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
-            bd1.compareTo(bd2) == 0
-          case _ => value == that.value
-        }
-      case _ => false
-    }
+        case that: Primitive[_] =>
+          if (standardType != that.standardType) false
+          else
+            (value, that.value) match {
+              case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
+                bd1.compareTo(bd2) == 0
+              case _ => value == that.value
+            }
+        case _ => false
+      }
   }
 
   sealed case class Singleton[A](instance: A) extends DynamicValue {
     override def hashCode(): Int = ("Singleton", instance).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: Singleton[_] => instance == that.instance
-      case _                  => false
-    }
+        case that: Singleton[_] => instance == that.instance
+        case _                  => false
+      }
   }
 
   final case class SomeValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("SomeValue", value).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: SomeValue => value == that.value
-      case _               => false
-    }
+        case that: SomeValue => value == that.value
+        case _               => false
+      }
   }
 
   case object NoneValue extends DynamicValue {
@@ -258,54 +259,54 @@ object DynamicValue {
     override def hashCode(): Int = ("Tuple", left, right).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: Tuple => left == that.left && right == that.right
-      case _           => false
-    }
+        case that: Tuple => left == that.left && right == that.right
+        case _           => false
+      }
   }
 
   final case class LeftValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("LeftValue", value).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: LeftValue => value == that.value
-      case _               => false
-    }
+        case that: LeftValue => value == that.value
+        case _               => false
+      }
   }
 
   final case class RightValue(value: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("RightValue", value).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: RightValue => value == that.value
-      case _                => false
-    }
+        case that: RightValue => value == that.value
+        case _                => false
+      }
   }
 
   final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
     override def hashCode(): Int = ("BothValue", left, right).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: BothValue => left == that.left && right == that.right
-      case _               => false
-    }
+        case that: BothValue => left == that.left && right == that.right
+        case _               => false
+      }
   }
 
   final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
     override def hashCode(): Int = ("DynamicAst", ast).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: DynamicAst => ast == that.ast
-      case _                => false
-    }
+        case that: DynamicAst => ast == that.ast
+        case _                => false
+      }
   }
 
   final case class Error(message: String) extends DynamicValue {
     override def hashCode(): Int = ("Error", message).hashCode()
     override def equals(other: Any): Boolean =
       other match {
-      case that: Error => message == that.message
-      case _           => false
-    }
+        case that: Error => message == that.message
+        case _           => false
+      }
   }
   lazy val typeId: TypeId = TypeId.parse("zio.schema.DynamicValue")
   //TODO: Refactor case set so that adding a new type to StandardType without updating the below list will trigger a compile error

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -8,10 +8,97 @@ import scala.collection.immutable.ListMap
 
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
+import scala.annotation.nowarn
 import zio.{ Cause, Chunk, Unsafe }
 
 sealed trait DynamicValue {
   self =>
+
+  @nowarn("msg=deprecated")
+  override def hashCode(): Int = {
+    import scala.util.hashing.MurmurHash3
+    self match {
+      case DynamicValue.Record(id, values) =>
+        MurmurHash3.productHash(("Record", id, values).asInstanceOf[Product])
+      case DynamicValue.Enumeration(id, value) =>
+        MurmurHash3.productHash(("Enumeration", id, value).asInstanceOf[Product])
+      case DynamicValue.Sequence(values) =>
+        MurmurHash3.productHash(("Sequence", values).asInstanceOf[Product])
+      case DynamicValue.Dictionary(entries) =>
+        // Sort entries by key hashCode to make it deterministic if order is changed
+        // Actually, sorting is expensive. Let's see if we can just hash the Chunk.
+        MurmurHash3.productHash(("Dictionary", entries).asInstanceOf[Product])
+      case DynamicValue.SetValue(values) =>
+        MurmurHash3.setHash(values)
+      case DynamicValue.Primitive(value, standardType) =>
+        val v = value match {
+          case bd: java.math.BigDecimal => bd.stripTrailingZeros()
+          case _                        => value
+        }
+        MurmurHash3.productHash(("Primitive", v, standardType).asInstanceOf[Product])
+      case DynamicValue.Singleton(instance) =>
+        MurmurHash3.productHash(("Singleton", instance).asInstanceOf[Product])
+      case DynamicValue.SomeValue(value) =>
+        MurmurHash3.productHash(("SomeValue", value).asInstanceOf[Product])
+      case DynamicValue.NoneValue =>
+        "NoneValue".hashCode
+      case DynamicValue.Tuple(left, right) =>
+        MurmurHash3.productHash(("Tuple", left, right).asInstanceOf[Product])
+      case DynamicValue.LeftValue(value) =>
+        MurmurHash3.productHash(("LeftValue", value).asInstanceOf[Product])
+      case DynamicValue.RightValue(value) =>
+        MurmurHash3.productHash(("RightValue", value).asInstanceOf[Product])
+      case DynamicValue.BothValue(left, right) =>
+        MurmurHash3.productHash(("BothValue", left, right).asInstanceOf[Product])
+      case DynamicValue.DynamicAst(ast) =>
+        MurmurHash3.productHash(("DynamicAst", ast).asInstanceOf[Product])
+      case DynamicValue.Error(message) =>
+        MurmurHash3.productHash(("Error", message).asInstanceOf[Product])
+    }
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: DynamicValue =>
+      (self, that) match {
+        case (DynamicValue.Record(id1, v1), DynamicValue.Record(id2, v2)) =>
+          id1 == id2 && v1 == v2
+        case (DynamicValue.Enumeration(id1, v1), DynamicValue.Enumeration(id2, v2)) =>
+          id1 == id2 && v1 == v2
+        case (DynamicValue.Sequence(v1), DynamicValue.Sequence(v2)) =>
+          v1 == v2
+        case (DynamicValue.Dictionary(v1), DynamicValue.Dictionary(v2)) =>
+          v1 == v2
+        case (DynamicValue.SetValue(v1), DynamicValue.SetValue(v2)) =>
+          v1 == v2
+        case (DynamicValue.Primitive(v1, t1), DynamicValue.Primitive(v2, t2)) =>
+          if (t1 != t2) false
+          else (v1, v2) match {
+            case (bd1: java.math.BigDecimal, bd2: java.math.BigDecimal) =>
+              bd1.compareTo(bd2) == 0
+            case _ => v1 == v2
+          }
+        case (DynamicValue.Singleton(i1), DynamicValue.Singleton(i2)) =>
+          i1 == i2
+        case (DynamicValue.SomeValue(v1), DynamicValue.SomeValue(v2)) =>
+          v1 == v2
+        case (DynamicValue.NoneValue, DynamicValue.NoneValue) =>
+          true
+        case (DynamicValue.Tuple(l1, r1), DynamicValue.Tuple(l2, r2)) =>
+          l1 == l2 && r1 == r2
+        case (DynamicValue.LeftValue(v1), DynamicValue.LeftValue(v2)) =>
+          v1 == v2
+        case (DynamicValue.RightValue(v1), DynamicValue.RightValue(v2)) =>
+          v1 == v2
+        case (DynamicValue.BothValue(l1, r1), DynamicValue.BothValue(l2, r2)) =>
+          l1 == l2 && r1 == r2
+        case (DynamicValue.DynamicAst(a1), DynamicValue.DynamicAst(a2)) =>
+          a1 == a2
+        case (DynamicValue.Error(m1), DynamicValue.Error(m2)) =>
+          m1 == m2
+        case _ => false
+      }
+    case _ => false
+  }
 
   def transform(transforms: Chunk[Migration]): Either[String, DynamicValue] =
     transforms.foldRight[Either[String, DynamicValue]](Right(self)) {

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -8,7 +8,6 @@ import scala.collection.immutable.ListMap
 
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
-import scala.annotation.nowarn
 import zio.{ Cause, Chunk, Unsafe }
 
 sealed trait DynamicValue {
@@ -209,11 +208,7 @@ object DynamicValue {
   }
 
   final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("Record", id, values).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("Record", id, values).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Record => id == that.id && values == that.values
       case _            => false
@@ -221,11 +216,7 @@ object DynamicValue {
   }
 
   final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("Enumeration", id, value).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("Enumeration", id, value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Enumeration => id == that.id && value == that.value
       case _                 => false
@@ -233,11 +224,7 @@ object DynamicValue {
   }
 
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("Sequence", values).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("Sequence", values).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Sequence => values == that.values
       case _              => false
@@ -245,11 +232,7 @@ object DynamicValue {
   }
 
   final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("Dictionary", entries).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("Dictionary", entries).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Dictionary => entries == that.entries
       case _                => false
@@ -257,11 +240,7 @@ object DynamicValue {
   }
 
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.setHash(values)
-    }
+    override def hashCode(): Int = values.hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: SetValue => values == that.values
       case _              => false
@@ -269,14 +248,12 @@ object DynamicValue {
   }
 
   sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
-    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
       val v = value match {
         case bd: java.math.BigDecimal => bd.stripTrailingZeros()
         case _                        => value
       }
-      MurmurHash3.productHash(("Primitive", v, standardType).asInstanceOf[Product])
+      ("Primitive", v, standardType).hashCode()
     }
     override def equals(other: Any): Boolean = other match {
       case that: Primitive[_] =>
@@ -291,11 +268,7 @@ object DynamicValue {
   }
 
   sealed case class Singleton[A](instance: A) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("Singleton", instance).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("Singleton", instance).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Singleton[_] => instance == that.instance
       case _                  => false
@@ -303,11 +276,7 @@ object DynamicValue {
   }
 
   final case class SomeValue(value: DynamicValue) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("SomeValue", value).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("SomeValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: SomeValue => value == that.value
       case _               => false
@@ -315,16 +284,12 @@ object DynamicValue {
   }
 
   case object NoneValue extends DynamicValue {
-    override def hashCode(): Int             = "NoneValue".hashCode
+    override def hashCode(): Int             = "NoneValue".hashCode()
     override def equals(other: Any): Boolean = other.isInstanceOf[NoneValue.type]
   }
 
   sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("Tuple", left, right).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("Tuple", left, right).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Tuple => left == that.left && right == that.right
       case _           => false
@@ -332,11 +297,7 @@ object DynamicValue {
   }
 
   final case class LeftValue(value: DynamicValue) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("LeftValue", value).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("LeftValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: LeftValue => value == that.value
       case _               => false
@@ -344,11 +305,7 @@ object DynamicValue {
   }
 
   final case class RightValue(value: DynamicValue) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("RightValue", value).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("RightValue", value).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: RightValue => value == that.value
       case _                => false
@@ -356,11 +313,7 @@ object DynamicValue {
   }
 
   final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("BothValue", left, right).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("BothValue", left, right).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: BothValue => left == that.left && right == that.right
       case _               => false
@@ -368,11 +321,7 @@ object DynamicValue {
   }
 
   final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("DynamicAst", ast).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("DynamicAst", ast).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: DynamicAst => ast == that.ast
       case _                => false
@@ -380,11 +329,7 @@ object DynamicValue {
   }
 
   final case class Error(message: String) extends DynamicValue {
-    @nowarn("msg=deprecated")
-    override def hashCode(): Int = {
-      import scala.util.hashing.MurmurHash3
-      MurmurHash3.productHash(("Error", message).asInstanceOf[Product])
-    }
+    override def hashCode(): Int = ("Error", message).hashCode()
     override def equals(other: Any): Boolean = other match {
       case that: Error => message == that.message
       case _           => false

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -1,11 +1,11 @@
 package zio.schema
-import java.math.{ BigDecimal, BigInteger }
+import java.math. { BigDecimal, BigInteger }
 import java.time._
 import java.util.UUID
 import scala.collection.immutable.ListMap
 import zio.schema.codec.DecodeError
-import zio.schema.meta.{ MetaSchema, Migration }
-import zio.{ Cause, Chunk, Unsafe }
+import zio.schema.meta. { MetaSchema, Migration }
+import zio. { Cause, Chunk, Unsafe }
 sealed trait DynamicValue {
   self =>
   def transform(transforms: Chunk[Migration]): Either[String, DynamicValue] =
@@ -211,7 +211,8 @@ object DynamicValue {
 
   sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
     override def hashCode(): Int = {
-      val v = value match {
+      val v =
+    value match {
         case bd: java.math.BigDecimal => bd.stripTrailingZeros()
         case _                        => value
       }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -8,6 +8,7 @@ import scala.collection.immutable.ListMap
 
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
+import scala.annotation.nowarn
 import zio.{ Cause, Chunk, Unsafe }
 
 sealed trait DynamicValue {
@@ -208,6 +209,7 @@ object DynamicValue {
   }
 
   final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("Record", id, values).asInstanceOf[Product])
@@ -219,6 +221,7 @@ object DynamicValue {
   }
 
   final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("Enumeration", id, value).asInstanceOf[Product])
@@ -230,6 +233,7 @@ object DynamicValue {
   }
 
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("Sequence", values).asInstanceOf[Product])
@@ -241,6 +245,7 @@ object DynamicValue {
   }
 
   final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("Dictionary", entries).asInstanceOf[Product])
@@ -252,6 +257,7 @@ object DynamicValue {
   }
 
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.setHash(values)
@@ -263,6 +269,7 @@ object DynamicValue {
   }
 
   sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       val v = value match {
@@ -284,6 +291,7 @@ object DynamicValue {
   }
 
   sealed case class Singleton[A](instance: A) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("Singleton", instance).asInstanceOf[Product])
@@ -295,6 +303,7 @@ object DynamicValue {
   }
 
   final case class SomeValue(value: DynamicValue) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("SomeValue", value).asInstanceOf[Product])
@@ -311,6 +320,7 @@ object DynamicValue {
   }
 
   sealed case class Tuple(left: DynamicValue, right: DynamicValue) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("Tuple", left, right).asInstanceOf[Product])
@@ -322,6 +332,7 @@ object DynamicValue {
   }
 
   final case class LeftValue(value: DynamicValue) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("LeftValue", value).asInstanceOf[Product])
@@ -333,6 +344,7 @@ object DynamicValue {
   }
 
   final case class RightValue(value: DynamicValue) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("RightValue", value).asInstanceOf[Product])
@@ -344,6 +356,7 @@ object DynamicValue {
   }
 
   final case class BothValue(left: DynamicValue, right: DynamicValue) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("BothValue", left, right).asInstanceOf[Product])
@@ -355,6 +368,7 @@ object DynamicValue {
   }
 
   final case class DynamicAst(ast: MetaSchema) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("DynamicAst", ast).asInstanceOf[Product])
@@ -366,6 +380,7 @@ object DynamicValue {
   }
 
   final case class Error(message: String) extends DynamicValue {
+    @nowarn("msg=deprecated")
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       MurmurHash3.productHash(("Error", message).asInstanceOf[Product])

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -2,7 +2,9 @@ package zio.schema
 import java.math.{ BigDecimal, BigInteger }
 import java.time._
 import java.util.UUID
+
 import scala.collection.immutable.ListMap
+
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
 import zio.{ Cause, Chunk, Unsafe }


### PR DESCRIPTION
This PR implements semantic equality and deterministic hashcodes for  DynamicValue , addressing issue #655.

### Key Changes:
- Implemented  hashCode  and  equals  for all  DynamicValue  case classes.
- Used  MurmurHash3  and Tuple-based hashing to ensure deterministic results across different JVM instances and Scala versions.
- Added specific handling for  BigDecimal  to ensure that values like  1.0  and  1.00  are treated as equal.
- Verified identity and consistency laws through automated checks.

Addressing binary compatibility issues by moving logic from the trait into concrete final case classes.