### PR TITLE
Fix #668: JSON codec built from auto-derived schema fails for enumerat

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1010,13 +1010,12 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
       val caseNameAliases: mutable.HashMap[String, Schema.Case[Z, Any]] =
         JsonDecoder.caseNameAliases(parentSchema, config)
 
-      if (parentSchema.cases.forall(_.schema.isInstanceOf[Schema.CaseClass0[_]])) { // if all cases are CaseClass0, decode as String
+      if (parentSchema.annotations.exists(_.isInstanceOf[simpleEnum])) { // if all cases are simple (case objects or simple nested enums), decode as String
         if (caseNameAliases.size <= 64) {
           new ZJsonDecoder[Z] {
             private[this] val stringMatrix = new StringMatrix(caseNameAliases.keys.toArray)
-            private[this] val cases = caseNameAliases.values.map { case_ =>
-              case_.schema.asInstanceOf[Schema.CaseClass0[Any]].defaultConstruct()
-            }.toArray.asInstanceOf[Array[Z]]
+            private[this] val cases =
+              caseNameAliases.values.map(constructEnumCase[Z, Any]).toVector
 
             override def unsafeDecode(trace: List[JsonError], in: RetractReader): Z = {
               val idx = Lexer.enumeration(trace, in, stringMatrix)
@@ -1030,7 +1029,7 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
 
             caseNameAliases.foreach {
               case (name, case_) =>
-                cases.put(name, case_.schema.asInstanceOf[Schema.CaseClass0[Z]].defaultConstruct())
+                cases.put(name, constructEnumCase(case_))
             }
 
             override def unsafeDecode(trace: List[JsonError], in: RetractReader): Z = {


### PR DESCRIPTION
## Summary
The JSON codec's `enumDecoder` used `isInstanceOf[CaseClass0[_]]` checks with unsafe `asInstanceOf` casts to determine simple enum handling, which was misaligned with the encoder's `simpleEnum` annotation check. This caused a `ClassCastException` when an enumeration contained intermediate sealed traits (producing `Schema.Enum` schemas instead of `Schema.CaseClass0`). The fix aligns the decoder with the encoder by using the `simpleEnum` annotation check and replaces unsafe casts with the existing type-safe `constructEnumCase` helper.

## Changes
- **`zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala`**: Changed `enumDecoder` to check the `simpleEnum` annotation (matching `enumEncoder` behavior) instead of checking whether all cases are `CaseClass0` instances. Replaced unsafe `asInstanceOf[Schema.CaseClass0[...]]` casts with calls to the existing `constructEnumCase` helper, which safely handles both `CaseClass0` and `Schema.Enum` cases.

## Testing
- Added `JsonCodecSpec668` with 10 test cases covering enumerations with intermediate types — all pass on Scala 2.13 and Scala 3.3.7.
- Full `zioSchemaJsonJVM/test` suite passes (298 tests on Scala 2.13, 304 on Scala 3).
- Full `zioSchemaDerivationJVM/test` suite passes (91 on Scala 2.13, 101 on Scala 3).

---

/claim #668