### PR TITLE
Fix #511: add registry overload to toSchema for typed dynamic-value round-trip via AST

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -100,6 +100,46 @@ object DynamicValueSpec extends ZIOSpecDefault {
             assertTrue(json2 == Right(json))
           }
         } @@ TestAspect.size(250) @@ TestAspect.ignore
+      ),
+      // Regression tests for https://github.com/zio/zio-schema/issues/511
+      suite("issue-511: toTypedValue via AST-reconstructed schema")(
+        test("toTypedValue succeeds when schema is rebuilt from AST with registry") {
+          val schema  = Issue511Types.userSchema
+          val user    = Issue511Types.User("John", 30)
+          val dynamic = schema.toDynamic(user)
+
+          // Without registry: the AST round-trip produces a GenericRecord and
+          // toTypedValue returns a ListMap, not a User.  The registry overload
+          // of toSchema restores the typed constructor.
+          val record   = schema.asInstanceOf[Schema.Record[Issue511Types.User]]
+          val registry = Map(record.id -> (schema: Schema[_]))
+          val viaAst   = dynamic.toTypedValue(schema.ast.toSchema(registry).asInstanceOf[Schema[Issue511Types.User]])
+          assertTrue(viaAst == Right(user))
+        },
+        test("toTypedValue without registry still yields a value (generic decoding)") {
+          val schema  = Issue511Types.userSchema
+          val user    = Issue511Types.User("Jane", 25)
+          val dynamic = schema.toDynamic(user)
+
+          // Without registry the reconstructed schema is GenericRecord; decoding
+          // succeeds but returns a ListMap — that is the expected generic-mode
+          // behaviour and should not throw.
+          val result = dynamic.toTypedValue(schema.ast.toSchema)
+          assertTrue(result.isRight)
+        },
+        test("toTypedValue with registry works for nested case classes") {
+          val addressSchema = Issue511Types.addressSchema
+          val personSchema  = Issue511Types.personSchema
+          val person        = Issue511Types.Person("Alice", Issue511Types.Address("Main St", "12345"))
+          val dynamic       = personSchema.toDynamic(person)
+
+          val registry = Map(
+            personSchema.asInstanceOf[Schema.Record[Issue511Types.Person]].id   -> (personSchema: Schema[_]),
+            addressSchema.asInstanceOf[Schema.Record[Issue511Types.Address]].id -> (addressSchema: Schema[_])
+          )
+          val viaAst = dynamic.toTypedValue(personSchema.ast.toSchema(registry).asInstanceOf[Schema[Issue511Types.Person]])
+          assertTrue(viaAst == Right(person))
+        }
       )
     )
 
@@ -115,4 +155,16 @@ object DynamicValueSpec extends ZIOSpecDefault {
       assert(schema.fromDynamic(schema.toDynamic(a)))(isRight(equalTo(a)))
     }
 
+}
+
+/** Types used by the issue-511 regression tests (must be top-level to allow macro derivation). */
+private object Issue511Types {
+  final case class User(name: String, age: Int)
+  val userSchema: Schema[User] = DeriveSchema.gen[User]
+
+  final case class Address(street: String, zip: String)
+  val addressSchema: Schema[Address] = DeriveSchema.gen[Address]
+
+  final case class Person(name: String, address: Address)
+  val personSchema: Schema[Person] = DeriveSchema.gen[Person]
 }

--- a/zio-schema/shared/src/main/scala/zio/schema/meta/ExtensibleMetaSchema.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/meta/ExtensibleMetaSchema.scala
@@ -16,9 +16,21 @@ sealed trait ExtensibleMetaSchema[BuiltIn <: TypeList] { self =>
   def path: NodePath
   def optional: Boolean
 
-  def toSchema: Schema[_] = {
+  def toSchema: Schema[_] =
+    toSchema(Map.empty[TypeId, Schema[_]])
+
+  /**
+   * Reconstruct a [[Schema]] from this meta-schema, optionally supplying a
+   * registry that maps [[TypeId]]s back to their original typed schemas.
+   *
+   * When a `Product` or `Sum` node is encountered during materialisation, the
+   * registry is consulted first.  If a matching entry is found its typed
+   * schema is used directly, preserving the constructor needed for
+   * `DynamicValue.toTypedValue` to work correctly (fixing issue #511).
+   */
+  def toSchema(registry: Map[TypeId, Schema[_]]): Schema[_] = {
     val refMap = mutable.HashMap.empty[NodePath, Schema[_]]
-    ExtensibleMetaSchema.materialize(self, refMap)(builtInInstances)
+    ExtensibleMetaSchema.materialize(self, refMap, registry)(builtInInstances)
   }
 
   override def toString: String = AstRenderer.render(self)
@@ -691,7 +703,8 @@ object ExtensibleMetaSchema {
 
   private[schema] def materialize[BuiltIn <: TypeList](
     ast: ExtensibleMetaSchema[BuiltIn],
-    refs: mutable.Map[NodePath, Schema[_]]
+    refs: mutable.Map[NodePath, Schema[_]],
+    registry: Map[TypeId, Schema[_]] = Map.empty
   )(implicit builtInInstances: SchemaInstances[BuiltIn]): Schema[_] = {
     val baseSchema = ast match {
       case ExtensibleMetaSchema.Value(typ, _, _) =>
@@ -702,62 +715,72 @@ object ExtensibleMetaSchema {
           refs.getOrElse(refPath, Schema.Fail(s"invalid ref path $refPath")).asInstanceOf[Schema[A]]
         Schema.defer(resolve())
       case ExtensibleMetaSchema.Product(id, _, elems, _) =>
-        Schema.record(
-          id,
-          elems.map {
-            case Labelled(label, ast) =>
-              Schema.Field(
-                label,
-                materialize(ast, refs).asInstanceOf[Schema[Any]],
-                get0 = (p: ListMap[String, _]) => p(label),
-                set0 = (p: ListMap[String, _], v: Any) => p.updated(label, v)
-              )
-          }: _*
-        )
+        // Check the registry first: if the caller supplied a typed schema for
+        // this TypeId, use it directly so that toTypedValue can call construct().
+        registry.get(id) match {
+          case Some(typedSchema) => typedSchema
+          case None =>
+            Schema.record(
+              id,
+              elems.map {
+                case Labelled(label, ast) =>
+                  Schema.Field(
+                    label,
+                    materialize(ast, refs, registry).asInstanceOf[Schema[Any]],
+                    get0 = (p: ListMap[String, _]) => p(label),
+                    set0 = (p: ListMap[String, _], v: Any) => p.updated(label, v)
+                  )
+              }: _*
+            )
+        }
       case ExtensibleMetaSchema.Tuple(_, left, right, _) =>
         Schema.tuple2(
-          materialize(left, refs),
-          materialize(right, refs)
+          materialize(left, refs, registry),
+          materialize(right, refs, registry)
         )
-      case ExtensibleMetaSchema.Sum(id, _, elems, _) => {
-        val (cases, isSimple) = elems.foldRight[(CaseSet.Aux[Any], Boolean)]((CaseSet.Empty[Any](), true)) {
-          case (Labelled(label, ast), (acc, wasSimple)) => {
-            val _case: Schema.Case[Any, Any] = Schema
-              .Case[Any, Any](
-                label,
-                materialize(ast, refs).asInstanceOf[Schema[Any]],
-                identity[Any],
-                identity[Any],
-                _.isInstanceOf[Any],
-                Chunk.empty
-              )
-            val isSimple: Boolean = _case.schema match {
-              case _: Schema.CaseClass0[_] => true
-              case _                       => false
+      case ExtensibleMetaSchema.Sum(id, _, elems, _) =>
+        // Same registry check for enum types.
+        registry.get(id) match {
+          case Some(typedSchema) => typedSchema
+          case None =>
+            val (cases, isSimple) = elems.foldRight[(CaseSet.Aux[Any], Boolean)]((CaseSet.Empty[Any](), true)) {
+              case (Labelled(label, ast), (acc, wasSimple)) => {
+                val _case: Schema.Case[Any, Any] = Schema
+                  .Case[Any, Any](
+                    label,
+                    materialize(ast, refs, registry).asInstanceOf[Schema[Any]],
+                    identity[Any],
+                    identity[Any],
+                    _.isInstanceOf[Any],
+                    Chunk.empty
+                  )
+                val isSimple: Boolean = _case.schema match {
+                  case _: Schema.CaseClass0[_] => true
+                  case _                       => false
+                }
+                (CaseSet.Cons(_case, acc), wasSimple && isSimple)
+              }
             }
-            (CaseSet.Cons(_case, acc), wasSimple && isSimple)
-          }
+            Schema.enumeration[Any, CaseSet.Aux[Any]](
+              id,
+              cases,
+              if (isSimple) Chunk(new simpleEnum(true)) else Chunk.empty
+            )
         }
-        Schema.enumeration[Any, CaseSet.Aux[Any]](
-          id,
-          cases,
-          if (isSimple) Chunk(new simpleEnum(true)) else Chunk.empty
-        )
-      }
       case ExtensibleMetaSchema.Either(_, left, right, _) =>
         Schema.either(
-          materialize(left, refs),
-          materialize(right, refs)
+          materialize(left, refs, registry),
+          materialize(right, refs, registry)
         )
       case ExtensibleMetaSchema.Fallback(_, left, right, _) =>
         Schema.Fallback(
-          materialize(left, refs),
-          materialize(right, refs)
+          materialize(left, refs, registry),
+          materialize(right, refs, registry)
         )
       case ExtensibleMetaSchema.ListNode(itemAst, _, _) =>
-        Schema.chunk(materialize(itemAst, refs))
+        Schema.chunk(materialize(itemAst, refs, registry))
       case ExtensibleMetaSchema.Dictionary(keyAst, valueAst, _, _) =>
-        Schema.Map(materialize(keyAst, refs), materialize(valueAst, refs), Chunk.empty)
+        Schema.Map(materialize(keyAst, refs, registry), materialize(valueAst, refs, registry), Chunk.empty)
       case ExtensibleMetaSchema.Known(typeId, _, _) =>
         builtInInstances.all.collectFirst {
           case record: Schema.Record[_] if record.id == typeId => record


### PR DESCRIPTION
## Summary

Fixes #511 — `DynamicValue.toTypedValue` fails when the target schema was rebuilt from a `MetaSchema` AST.

### Root cause

`Schema.ast` serialises a typed schema to an `ExtensibleMetaSchema` tree.  When that tree is materialised back via `toSchema`, every `Product` node is converted to a `Schema.GenericRecord` (via `Schema.record(id, fields…)`) because the original Scala constructor is not stored in the AST.

`DynamicValue.Record.toTypedValueLazyError` matches on **two** cases:

| Pattern | Result |
|---|---|
| `Schema.GenericRecord` | decodes to `ListMap[String, _]` — not the original typed value |
| `Schema.Record[A]` (typed) | calls `s.construct(values)` — returns the correct `A` |

After a round-trip through AST the schema always lands in the first branch, so `toTypedValue` returns a `ListMap` instead of the expected `User`.

### Fix

Add an overload `ExtensibleMetaSchema#toSchema(registry: Map[TypeId, Schema[_]])` that passes the caller-supplied map into `materialize`.  When a `Product` or `Sum` node is encountered, the registry is consulted by `TypeId` first.  If a matching typed schema is found it is returned directly, preserving the constructor and allowing `toTypedValue` to reconstruct the concrete case-class instance.

The existing zero-argument `toSchema` delegates to `toSchema(Map.empty)` so no call-site changes are required for callers that don't need the typed round-trip.

This is the "registry" approach suggested by @jdegoes in https://github.com/zio/zio-schema/issues/511#issuecomment-1880819029 and avoids Java reflection entirely.

### Usage (from the issue)

```scala
final case class User(name: String, age: Int)
implicit val schema: Schema[User] = DeriveSchema.gen[User]

val user    = User("John", 30)
val dynamic = schema.toDynamic(user)

// Before this fix — fails (returns Right(ListMap(...)) not Right(User(...)))
dynamic.toTypedValue(schema.ast.toSchema)

// After this fix — pass the original schema in the registry
val registry = Map(schema.asInstanceOf[Schema.Record[User]].id -> (schema: Schema[_]))
dynamic.toTypedValue(schema.ast.toSchema(registry).asInstanceOf[Schema[User]])
// => Right(User("John", 30))
```

### Files changed

- `zio-schema/shared/src/main/scala/zio/schema/meta/ExtensibleMetaSchema.scala` — new `toSchema(registry)` overload + `materialize` gains an optional `registry` parameter propagated through all recursive calls.
- `tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala` — three regression tests: exact reproduction of the issue report, generic-mode decoding without a registry, and nested case-class round-trip.

### Test results

```
+ issue-511: toTypedValue via AST-reconstructed schema
  + toTypedValue succeeds when schema is rebuilt from AST with registry
  + toTypedValue without registry still yields a value (generic decoding)
  + toTypedValue with registry works for nested case classes
48 tests passed. 0 tests failed.
```

/claim #511