### PR TITLE
Fix deterministic hashCode semantics for DynamicValue (#655)

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -1,5 +1,8 @@
 package zio.schema
 
+import scala.collection.immutable.ListMap
+import scala.util.hashing.MurmurHash3
+
 import zio._
 import zio.schema.Schema.Primitive
 import zio.schema.SchemaGen._
@@ -100,6 +103,61 @@ object DynamicValueSpec extends ZIOSpecDefault {
             assertTrue(json2 == Right(json))
           }
         } @@ TestAspect.size(250) @@ TestAspect.ignore
+      ),
+      suite("hashCode")(
+        test("Primitive uses the stable standard type tag") {
+          val value = DynamicValue.Primitive(42, StandardType.IntType)
+          val seed =
+            MurmurHash3.mix(MurmurHash3.stringHash("zio.schema.DynamicValue.Primitive"), StandardType.IntType.tag.##)
+          val expected = MurmurHash3.finalizeHash(MurmurHash3.mix(seed, 42.##), 2)
+
+          assertTrue(value.hashCode == expected)
+        },
+        test("Dictionary hashCode is independent from entry order") {
+          val key1 = DynamicValue.Primitive("one", StandardType.StringType)
+          val key2 = DynamicValue.Primitive("two", StandardType.StringType)
+          val one = DynamicValue.Dictionary(
+            Chunk(
+              key1 -> DynamicValue.Primitive(1, StandardType.IntType),
+              key2 -> DynamicValue.Primitive(2, StandardType.IntType)
+            )
+          )
+          val two = DynamicValue.Dictionary(
+            Chunk(
+              key2 -> DynamicValue.Primitive(2, StandardType.IntType),
+              key1 -> DynamicValue.Primitive(1, StandardType.IntType)
+            )
+          )
+
+          assertTrue(one.hashCode == two.hashCode)
+        },
+        test("Record hashCode is independent from field construction order") {
+          val id = TypeId.parse("zio.schema.tests.RecordHash")
+          val left = DynamicValue.Record(
+            id,
+            ListMap(
+              "a" -> DynamicValue.Primitive(1, StandardType.IntType),
+              "b" -> DynamicValue.Primitive("x", StandardType.StringType)
+            )
+          )
+          val right = DynamicValue.Record(
+            id,
+            ListMap(
+              "b" -> DynamicValue.Primitive("x", StandardType.StringType),
+              "a" -> DynamicValue.Primitive(1, StandardType.IntType)
+            )
+          )
+
+          assertTrue(left.hashCode == right.hashCode)
+        },
+        test("Singleton uses the runtime class name instead of identity") {
+          object Marker
+
+          val value    = DynamicValue.Singleton(Marker)
+          val expected = MurmurHash3.stringHash(Marker.getClass.getName)
+
+          assertTrue(value.hashCode == expected)
+        }
       )
     )
 

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -5,6 +5,7 @@ import java.time._
 import java.util.UUID
 
 import scala.collection.immutable.ListMap
+import scala.util.hashing.MurmurHash3
 
 import zio.schema.codec.DecodeError
 import zio.schema.meta.{ MetaSchema, Migration }
@@ -207,19 +208,49 @@ object DynamicValue {
     }
   }
 
-  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue
+  final case class Record(id: TypeId, values: ListMap[String, DynamicValue]) extends DynamicValue {
+    override def hashCode(): Int = {
+      val seed          = MurmurHash3.mix(RecordHashSeed, id.##)
+      val sortedEntries = values.iterator.toVector.sortBy(_._1)
+      val mixed = sortedEntries.foldLeft(seed) {
+        case (acc, (name, value)) =>
+          MurmurHash3.mix(acc, MurmurHash3.mix(name.##, value.hashCode()))
+      }
+      MurmurHash3.finalizeHash(mixed, sortedEntries.size + 1)
+    }
+  }
 
   final case class Enumeration(id: TypeId, value: (String, DynamicValue)) extends DynamicValue
 
   final case class Sequence(values: Chunk[DynamicValue]) extends DynamicValue
 
-  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue
+  final case class Dictionary(entries: Chunk[(DynamicValue, DynamicValue)]) extends DynamicValue {
+    override def hashCode(): Int = {
+      var acc   = DictionaryHashSeed
+      var index = 0
+      while (index < entries.length) {
+        val entry = entries(index)
+        acc += MurmurHash3.mix(entry._1.hashCode(), entry._2.hashCode())
+        index += 1
+      }
+      MurmurHash3.finalizeHash(acc, entries.length)
+    }
+  }
 
   final case class SetValue(values: Set[DynamicValue]) extends DynamicValue
 
-  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue
+  sealed case class Primitive[A](value: A, standardType: StandardType[A]) extends DynamicValue {
+    override def hashCode(): Int = {
+      val seed  = MurmurHash3.mix(PrimitiveHashSeed, standardType.tag.##)
+      val mixed = MurmurHash3.mix(seed, value.##)
+      MurmurHash3.finalizeHash(mixed, 2)
+    }
+  }
 
-  sealed case class Singleton[A](instance: A) extends DynamicValue
+  sealed case class Singleton[A](instance: A) extends DynamicValue {
+    override def hashCode(): Int =
+      MurmurHash3.stringHash(instance.getClass.getName)
+  }
 
   final case class SomeValue(value: DynamicValue) extends DynamicValue
 
@@ -238,6 +269,10 @@ object DynamicValue {
   final case class Error(message: String) extends DynamicValue
 
   lazy val typeId: TypeId = TypeId.parse("zio.schema.DynamicValue")
+
+  final private val RecordHashSeed     = MurmurHash3.stringHash("zio.schema.DynamicValue.Record")
+  final private val DictionaryHashSeed = MurmurHash3.stringHash("zio.schema.DynamicValue.Dictionary")
+  final private val PrimitiveHashSeed  = MurmurHash3.stringHash("zio.schema.DynamicValue.Primitive")
 
   //TODO: Refactor case set so that adding a new type to StandardType without updating the below list will trigger a compile error
   lazy val schema: Schema[DynamicValue] =


### PR DESCRIPTION
/claim #655

## Summary

This patch makes `DynamicValue.hashCode` deterministic for the unstable cases discussed in `#655` without changing `equals` or the decoding model.

Changes:
- `Primitive[A]` hashes from `standardType.tag` and the value hash instead of object-identity-sensitive pieces
- `Dictionary` hashes commutatively so equal maps do not depend on insertion order
- `Record` hashes from sorted field names so construction order does not leak into the hash
- `Singleton[A]` hashes from the runtime class name instead of instance identity

## Scope

I kept this intentionally narrow:
- no `equals` changes
- no schema materialization changes
- no workflow or build changes

## Validation

Focused validation:

```text
java -Xmx2G -jar C:\Users\Matteo\.sbt\launchers\1.12.11\sbt-launch.jar ";project testsJVM; testOnly zio.schema.DynamicValueSpec"
```

Result:

```text
49 tests passed. 0 tests failed. 1 tests ignored.
```

Added regression coverage for:
- primitive hash stability via `standardType.tag`
- dictionary hash independence from entry order
- record hash independence from field construction order
- singleton hash independence from object identity

## Notes

No documentation update needed.
