### PR TITLE
Add registry-based typed DynamicValue round-trips for ast schemas (#511)

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -1,5 +1,7 @@
 package zio.schema
 
+import scala.collection.immutable.ListMap
+
 import zio._
 import zio.schema.Schema.Primitive
 import zio.schema.SchemaGen._
@@ -7,6 +9,13 @@ import zio.test.Assertion._
 import zio.test.{ Sized, TestConfig, _ }
 
 object DynamicValueSpec extends ZIOSpecDefault {
+
+  final case class User511(name: String, age: Int)
+
+  object User511 {
+    implicit val schema: Schema.Record[User511] =
+      DeriveSchema.gen[User511].asInstanceOf[Schema.Record[User511]]
+  }
 
   def spec: Spec[Environment, Any] =
     suite("DynamicValueSpec")(
@@ -84,6 +93,17 @@ object DynamicValueSpec extends ZIOSpecDefault {
           check(SchemaGen.anyMapAndValue) {
             case (schema, a) => assert(schema.fromDynamic(schema.toDynamic(a)))(isRight(equalTo(a)))
           }
+        },
+        test("round-trips typed records through ast schemas with a registry (#511)") {
+          val user          = User511("John", 30)
+          val dynamic       = User511.schema.toDynamic(user)
+          val schemaFromAst = User511.schema.ast.toSchema.asInstanceOf[Schema[Any]]
+          val registry      = Map[TypeId, Schema[_]](User511.schema.id -> User511.schema)
+
+          assertTrue(
+            dynamic.toValue(schemaFromAst) == Right(ListMap("name" -> "John", "age" -> 30)),
+            dynamic.toValue(schemaFromAst, registry) == Right(user)
+          )
         }
       ),
       suite("stack safety")(

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -24,39 +24,60 @@ sealed trait DynamicValue {
 
   def toValue[A](implicit schema: Schema[A]): Either[DecodeError, A] = toTypedValueLazyError
 
+  def toTypedValue[A](schema: Schema[A], registry: Map[TypeId, Schema[_]]): Either[String, A] =
+    toTypedValueLazyError(schema, registry).left.map(_.message)
+
+  def toValue[A](schema: Schema[A], registry: Map[TypeId, Schema[_]]): Either[DecodeError, A] =
+    toTypedValueLazyError(schema, registry)
+
   def toTypedValueOption[A](implicit schema: Schema[A]): Option[A] =
     toTypedValueLazyError.toOption
 
+  def toTypedValueOption[A](schema: Schema[A], registry: Map[TypeId, Schema[_]]): Option[A] =
+    toTypedValueLazyError(schema, registry).toOption
+
   private def toTypedValueLazyError[A](implicit schema: Schema[A]): Either[DecodeError, A] =
+    toTypedValueLazyError(schema, Map.empty)
+
+  private def toTypedValueLazyError[A](
+    schema: Schema[A],
+    registry: Map[TypeId, Schema[_]]
+  ): Either[DecodeError, A] =
     (self, schema) match {
       case (DynamicValue.Primitive(value, p), Schema.Primitive(p2, _)) if p == p2 =>
         Right(value.asInstanceOf[A])
 
-      case (DynamicValue.Record(_, values), Schema.GenericRecord(_, structure, _)) =>
-        DynamicValue.decodeStructure(values, structure.toChunk).asInstanceOf[Either[DecodeError, A]]
+      case (record @ DynamicValue.Record(id, values), Schema.GenericRecord(_, structure, _)) =>
+        registry.get(id) match {
+          case Some(typedRecord: Schema.Record[_])
+              if typedRecord.id == id && !typedRecord.isInstanceOf[Schema.GenericRecord] =>
+            record.toValue(typedRecord.asInstanceOf[Schema[Any]], registry).asInstanceOf[Either[DecodeError, A]]
+          case _ =>
+            DynamicValue.decodeStructure(values, structure.toChunk, registry).asInstanceOf[Either[DecodeError, A]]
+        }
 
       case (DynamicValue.Record(_, values), s: Schema.Record[A]) =>
         DynamicValue
-          .decodeStructure(values, s.fields)
+          .decodeStructure(values, s.fields, registry)
           .map(m => Chunk.fromIterable(m.values))
           .flatMap(values => s.construct(values)(Unsafe.unsafe).left.map(err => DecodeError.MalformedField(s, err)))
 
       case (DynamicValue.Enumeration(_, (key, value)), s: Schema.Enum[A]) =>
         s.caseOf(key) match {
           case Some(caseValue) =>
-            value.toTypedValueLazyError(caseValue.schema).asInstanceOf[Either[DecodeError, A]]
+            value.toTypedValueLazyError(caseValue.schema, registry).asInstanceOf[Either[DecodeError, A]]
           case None => Left(DecodeError.MissingCase(key, s))
         }
 
       case (DynamicValue.LeftValue(value), Schema.Either(schema1, _, _)) =>
-        value.toTypedValueLazyError(schema1).map(Left(_))
+        value.toTypedValueLazyError(schema1, registry).map(Left(_))
 
       case (DynamicValue.RightValue(value), Schema.Either(_, schema1, _)) =>
-        value.toTypedValueLazyError(schema1).map(Right(_))
+        value.toTypedValueLazyError(schema1, registry).map(Right(_))
 
       case (DynamicValue.Tuple(leftValue, rightValue), Schema.Tuple2(leftSchema, rightSchema, _)) =>
-        val typedLeft  = leftValue.toTypedValueLazyError(leftSchema)
-        val typedRight = rightValue.toTypedValueLazyError(rightSchema)
+        val typedLeft  = leftValue.toTypedValueLazyError(leftSchema, registry)
+        val typedRight = rightValue.toTypedValueLazyError(rightSchema, registry)
         (typedLeft, typedRight) match {
           case (Left(e1), Left(e2)) =>
             Left(DecodeError.And(e1, e2))
@@ -70,7 +91,7 @@ sealed trait DynamicValue {
           .foldLeft[Either[DecodeError, Chunk[t]]](Right[DecodeError, Chunk[t]](Chunk.empty)) {
             case (err @ Left(_), _) => err
             case (Right(values), value) =>
-              value.toTypedValueLazyError(schema.elementSchema).map(values :+ _)
+              value.toTypedValueLazyError(schema.elementSchema, registry).map(values :+ _)
           }
           .map(schema.fromChunk)
 
@@ -78,18 +99,18 @@ sealed trait DynamicValue {
         values.foldLeft[Either[DecodeError, Set[t]]](Right[DecodeError, Set[t]](Set.empty)) {
           case (err @ Left(_), _) => err
           case (Right(values), value) =>
-            value.toTypedValueLazyError(schema.elementSchema).map(values + _)
+            value.toTypedValueLazyError(schema.elementSchema, registry).map(values + _)
         }
 
       case (DynamicValue.SomeValue(value), Schema.Optional(schema: Schema[_], _)) =>
-        value.toTypedValueLazyError(schema).map(Some(_))
+        value.toTypedValueLazyError(schema, registry).map(Some(_))
 
       case (DynamicValue.NoneValue, Schema.Optional(_, _)) =>
         Right(None)
 
       case (value, Schema.Transform(schema, f, _, _, _)) =>
         value
-          .toTypedValueLazyError(schema)
+          .toTypedValueLazyError(schema, registry)
           .flatMap(value => f(value).left.map(err => DecodeError.MalformedField(schema, err)))
 
       case (DynamicValue.Dictionary(entries), schema: Schema.Map[k, v]) =>
@@ -97,21 +118,21 @@ sealed trait DynamicValue {
           case (err @ Left(_), _) => err
           case (Right(map), entry) => {
             for {
-              key   <- entry._1.toTypedValueLazyError(schema.keySchema)
-              value <- entry._2.toTypedValueLazyError(schema.valueSchema)
+              key   <- entry._1.toTypedValueLazyError(schema.keySchema, registry)
+              value <- entry._2.toTypedValueLazyError(schema.valueSchema, registry)
             } yield map ++ Map(key -> value)
           }
         }
 
       case (_, l @ Schema.Lazy(_)) =>
-        toTypedValueLazyError(l.schema)
+        toTypedValueLazyError(l.schema, registry)
 
       case (DynamicValue.Error(message), _) =>
         Left(DecodeError.ReadError(Cause.empty, message))
 
       case (DynamicValue.Tuple(dyn, DynamicValue.DynamicAst(ast)), _) =>
         val valueSchema = ast.toSchema.asInstanceOf[Schema[Any]]
-        dyn.toTypedValueLazyError(valueSchema).map(a => (a -> valueSchema).asInstanceOf[A])
+        dyn.toTypedValueLazyError(valueSchema, registry).map(a => (a -> valueSchema).asInstanceOf[A])
 
       case (dyn, Schema.Dynamic(_)) => Right(dyn)
 
@@ -193,13 +214,20 @@ object DynamicValue {
   def decodeStructure(
     values: ListMap[String, DynamicValue],
     structure: Chunk[Schema.Field[_, _]]
+  ): Either[DecodeError, ListMap[String, _]] =
+    decodeStructure(values, structure, Map.empty)
+
+  def decodeStructure(
+    values: ListMap[String, DynamicValue],
+    structure: Chunk[Schema.Field[_, _]],
+    registry: Map[TypeId, Schema[_]]
   ): Either[DecodeError, ListMap[String, _]] = {
     val keys = values.keySet
     keys.foldLeft[Either[DecodeError, ListMap[String, Any]]](Right(ListMap.empty)) {
       case (Right(record), key) =>
         (structure.find(_.name == key), values.get(key)) match {
           case (Some(field), Some(value)) =>
-            value.toTypedValueLazyError(field.schema).map(value => (record + (key -> value)))
+            value.toTypedValueLazyError(field.schema, registry).map(value => (record + (key -> value)))
           case _ =>
             Left(DecodeError.IncompatibleShape(values, structure))
         }


### PR DESCRIPTION
/claim #511

## Summary

This patch adds an explicit schema-registry overload for `DynamicValue` decoding so typed records can round-trip through `schema.ast.toSchema` without introducing reflection.

## What changed

- added overloads:
  - `toTypedValue(schema, registry)`
  - `toValue(schema, registry)`
  - `toTypedValueOption(schema, registry)`
- threaded the registry through recursive dynamic decoding
- when decoding a `DynamicValue.Record` against a `Schema.GenericRecord`, the decoder now checks whether the record `TypeId` exists in the registry
- if a matching nominal `Schema.Record` is present, decoding upgrades from the generic `ListMap` shape back into the original typed record

## Why this shape

This follows the direction already discussed in the issue:
- no Java reflection
- no silent behavior change for callers that do not supply a registry
- keeps the old generic-record behavior intact when no registry entry exists

## Validation

Focused validation:

```text
java -Xmx2G -jar C:\Users\Matteo\.sbt\launchers\1.12.11\sbt-launch.jar ";project testsJVM; testOnly zio.schema.DynamicValueSpec"
```

Result:

```text
46 tests passed. 0 tests failed. 1 tests ignored.
```

Added regression coverage for:
- decoding a typed record through `schema.ast.toSchema` without a registry still yields the generic `ListMap`
- supplying a registry keyed by `TypeId` reconstructs the original typed case class

No documentation update needed.
