### PR TITLE
Add Windows Scala 3 docs CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
   windows_scala3_docs:
     runs-on: windows-latest
     timeout-minutes: 20
+    env:
+      JDK_JAVA_OPTIONS: -Xmx6G -Xss4M -XX:+UseG1GC
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,22 @@ jobs:
     - name: Run tests
       run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
 
+  windows_scala3_docs:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: coursier/setup-action@v3
+        with:
+          jvm: temurin:17
+          apps: sbt
+      - name: Cache scala dependencies
+        uses: coursier/cache-action@v8
+      - name: Generate Scala 3 API docs on Windows
+        run: sbt "++3.3.7!" "zioSchemaJVM/Compile/doc"
+
   mima_check:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -76,7 +92,7 @@ jobs:
 
   ci:
     runs-on: ubuntu-latest
-    needs: [build,lint,mima_check]
+    needs: [build,lint,mima_check,windows_scala3_docs]
     steps:
       - run: echo "All checks passed"
 


### PR DESCRIPTION
/claim #674

## Summary
- Add a focused `windows-latest` CI job that generates Scala 3 JVM API docs.
- Wire the job into the aggregate `ci` gate so Windows scaladoc filename regressions are caught before merge.

## Validation
- `git diff --check`
- `C:\Users\karim\bounty-work\tools\coursier\cs-x86_64-pc-win32.exe launch --jvm temurin:17 sbt -- '++3.3.7!' 'zioSchemaJVM/Compile/doc'`