### PR TITLE
Fix JsonCodec decoder accepting malformed JSON with trailing characters

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 import zio.json.ast.Json
-import zio.json.internal.{ FastStringReader, Lexer, RecordingReader, RetractReader, StringMatrix, Write }
+import zio.json.internal.{ FastStringReader, Lexer, RecordingReader, RetractReader, StringMatrix, UnexpectedEnd, Write }
 import zio.json.{
   JsonCodec => ZJsonCodec,
   JsonDecoder => ZJsonDecoder,
@@ -31,6 +31,67 @@ import zio.{ Cause, Chunk, ChunkBuilder, ZIO, ZNothing }
 object JsonCodec {
 
   private val streamEncoderSeparator: Chunk[Byte] = Chunk.single('\n'.toByte)
+
+  /**
+   * Wraps a decoder so that decoding a complete input fails when anything but whitespace remains after the JSON
+   * value.
+   *
+   * zio-json's `decodeJson` is `final` and delegates to `unsafeDecode` with a `FastStringReader`, while the streaming
+   * entry points (`decodeJsonPipeline`, `decodeJsonStream`, ...) use other `RetractReader` implementations.
+   * Restricting the trailing check to `FastStringReader` therefore makes single-value decoding strict without
+   * changing streaming behavior, where a value may legitimately be followed by more input.
+   */
+  final private[codec] class StrictJsonDecoder[A](private[codec] val underlying: ZJsonDecoder[A])
+      extends ZJsonDecoder[A] {
+
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
+      val result = underlying.unsafeDecode(trace, in)
+      in match {
+        case reader: FastStringReader =>
+          val offset = reader.offset()
+          try {
+            val c = reader.nextNonWhitespace()
+            // zio-json's number parsers always retract one character after a number. When the number ends
+            // exactly at the end of the input that retract steps back into the number itself, leaving its
+            // last digit unread. That single digit must be accepted, anything else rejected.
+            val isLastDigitOfNumber =
+              c >= '0' && c <= '9' &&
+                reader.history(offset) == c && // no whitespace was skipped to reach c
+                startsWithNumber(reader) &&
+                atEnd(reader)
+            if (!isLastDigitOfNumber)
+              Lexer.error("Unexpected character after end of JSON value", trace)
+            result
+          } catch {
+            case _: UnexpectedEnd => result
+          }
+        case _ => result
+      }
+    }
+
+    override def unsafeDecodeMissing(trace: List[JsonError]): A = underlying.unsafeDecodeMissing(trace)
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): A = underlying.unsafeFromJsonAST(trace, json)
+
+    // a successful decode implies that a value started at the first non-whitespace character
+    private def startsWithNumber(reader: FastStringReader): Boolean = {
+      var i = 0
+      var c = reader.history(i)
+      while (c == ' ' || c == '\n' || c == '\r' || c == '\t') {
+        i += 1
+        c = reader.history(i)
+      }
+      c == '-' || (c >= '0' && c <= '9')
+    }
+
+    private def atEnd(reader: FastStringReader): Boolean =
+      try {
+        reader.nextNonWhitespace()
+        false
+      } catch {
+        case _: UnexpectedEnd => true
+      }
+  }
 
   @deprecated(
     """Use JsonCodec.Configuration instead.
@@ -169,7 +230,7 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
   implicit def zioJsonBinaryCodec[A](implicit jsonCodec: ZJsonCodec[A]): BinaryCodec[A] =
     new BinaryCodec[A] {
       override def decode(whole: Chunk[Byte]): Either[DecodeError, A] =
-        jsonCodec
+        new StrictJsonDecoder(jsonCodec.decoder)
           .decodeJson(new String(whole.toArray, JsonEncoder.CHARSET))
           .left
           .map(failure => DecodeError.ReadError(Cause.empty, failure))
@@ -179,7 +240,13 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
           ZPipeline.utfDecode.channel.mapError(cce => DecodeError.ReadError(Cause.fail(cce), cce.getMessage))
         ) >>> splitOnJsonBoundary >>>
           ZPipeline.mapEitherChunked { (s: String) =>
-            jsonCodec.decodeJson(s).left.map(failure => DecodeError.ReadError(Cause.empty, failure))
+            // streaming has to stay lenient: a value may be followed by more input, e.g. separator
+            // characters after numbers, and is decoded through a FastStringReader here
+            val decoder = jsonCodec.decoder match {
+              case strict: StrictJsonDecoder[_] => strict.underlying.asInstanceOf[ZJsonDecoder[A]]
+              case other                        => other
+            }
+            decoder.decodeJson(s).left.map(failure => DecodeError.ReadError(Cause.empty, failure))
           }
 
       override def encode(value: A): Chunk[Byte] =
@@ -324,7 +391,9 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
         ZPipeline.utfDecode.mapError(cce => DecodeError.ReadError(Cause.fail(cce), cce.getMessage)) >>>
           (if (cfg.treatStreamsAsArrays) splitJsonArrayElements else splitOnJsonBoundary) >>>
           ZPipeline.mapZIO { (s: String) =>
-            ZIO.fromEither(JsonDecoder.decode(schema, s, cfg))
+            // streaming has to stay lenient: a value may be followed by more input, e.g. separator
+            // characters after numbers, and is decoded through a FastStringReader here
+            ZIO.fromEither(JsonDecoder.decodeLenient(schema, s, cfg))
           }
 
       override def encode(value: A): Chunk[Byte] =
@@ -355,10 +424,10 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
     JsonEncoder.schemaEncoder(schema, cfg)
 
   def jsonDecoder[A](schema: Schema[A]): ZJsonDecoder[A] =
-    JsonDecoder.schemaDecoder(schema, JsonCodec.Configuration.default)
+    new StrictJsonDecoder(JsonDecoder.schemaDecoder(schema, JsonCodec.Configuration.default))
 
   def jsonDecoder[A](cfg: JsonCodec.Configuration)(schema: Schema[A]): ZJsonDecoder[A] =
-    JsonDecoder.schemaDecoder(schema, cfg)
+    new StrictJsonDecoder(JsonDecoder.schemaDecoder(schema, cfg))
 
   def jsonCodec[A](schema: Schema[A]): ZJsonCodec[A] =
     ZJsonCodec(jsonEncoder(schema), jsonDecoder(schema))
@@ -821,6 +890,16 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
     private[this] val decoders = new ConcurrentHashMap[DecoderKey[_], ZJsonDecoder[_]]
 
     final def decode[A](schema: Schema[A], json: String, config: Configuration): Either[DecodeError, A] =
+      new StrictJsonDecoder(schemaDecoder(schema, config)).decodeJson(json) match {
+        case Left(value)  => Left(DecodeError.ReadError(Cause.empty, value))
+        case Right(value) => Right(value)
+      }
+
+    final private[codec] def decodeLenient[A](
+      schema: Schema[A],
+      json: String,
+      config: Configuration
+    ): Either[DecodeError, A] =
       schemaDecoder(schema, config).decodeJson(json) match {
         case Left(value)  => Left(DecodeError.ReadError(Cause.empty, value))
         case Right(value) => Right(value)

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -30,10 +30,21 @@ object JsonCodecSpec extends ZIOSpecDefault {
 
   val personSchema: Schema[Person] = DeriveSchema.gen[Person]
 
+  case object Foo {
+    implicit val schema: Schema[Foo.type] = DeriveSchema.gen[Foo.type]
+  }
+
+  final case class Bar(a: Int)
+
+  object Bar {
+    implicit val schema: Schema[Bar] = DeriveSchema.gen[Bar]
+  }
+
   def spec: Spec[TestEnvironment, Any] =
     suite("JsonCodec Spec")(
       encoderSuite,
       decoderSuite,
+      trailingCharactersSuite,
       encoderDecoderSuite
     ) @@ timeout(180.seconds)
 
@@ -1604,6 +1615,103 @@ object JsonCodecSpec extends ZIOSpecDefault {
         val decoder = JsonCodec.schemaBasedBinaryCodec(schema).streamDecoder
         val result  = ZStream.fromChunk(charSequenceToByteChunk("[]")).via(decoder).runCollect.either
         assertZIO(result)(isLeft)
+      }
+    )
+  )
+
+  private val trailingCharactersSuite = suite("trailing characters after a valid JSON value")(
+    suite("are rejected by jsonDecoder")(
+      test("extra } after empty object") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[Foo.type]).decodeJson("""{}}""").isLeft
+        )
+      },
+      test("extra } after object") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[Bar]).decodeJson("""{"a":1}}""").isLeft
+        )
+      },
+      test("extra \" after string") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[String]).decodeJson("\"foo\"\"").isLeft
+        )
+      },
+      test("extra ] after array") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[List[Int]]).decodeJson("[1,2]]").isLeft
+        )
+      },
+      test("garbage after number") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[Int]).decodeJson("42 x").isLeft,
+          JsonCodec.jsonDecoder(Schema[Int]).decodeJson("42x").isLeft,
+          JsonCodec.jsonDecoder(Schema[Int]).decodeJson("4 5").isLeft,
+          JsonCodec.jsonDecoder(Schema[Int]).decodeJson("42}").isLeft
+        )
+      },
+      test("top level numbers are accepted") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[Int]).decodeJson("42") == Right(42),
+          JsonCodec.jsonDecoder(Schema[Int]).decodeJson("-1") == Right(-1),
+          JsonCodec.jsonDecoder(Schema[Long]).decodeJson("4612798522382848789") == Right(4612798522382848789L),
+          JsonCodec.jsonDecoder(Schema[Double]).decodeJson("-2620.5") == Right(-2620.5),
+          JsonCodec.jsonDecoder(Schema[BigDecimal]).decodeJson("1.5") == Right(BigDecimal("1.5"))
+        )
+      },
+      test("extra characters after boolean") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[Boolean]).decodeJson("true}}").isLeft
+        )
+      },
+      test("trailing whitespace is accepted") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[Bar]).decodeJson("""{"a":1} """) == Right(Bar(1)),
+          JsonCodec.jsonDecoder(Schema[String]).decodeJson("\"foo\"  ") == Right("foo"),
+          JsonCodec.jsonDecoder(Schema[Int]).decodeJson("42\n\t ") == Right(42)
+        )
+      },
+      test("leading and trailing whitespace is accepted") {
+        assertTrue(
+          JsonCodec.jsonDecoder(Schema[Bar]).decodeJson("""  {"a":1}  """) == Right(Bar(1))
+        )
+      }
+    ),
+    suite("are rejected by schemaBasedBinaryCodec")(
+      test("decode rejects extra } after object") {
+        val codec = JsonCodec.schemaBasedBinaryCodec(Schema[Bar])
+        assertTrue(
+          codec.decode(charSequenceToByteChunk("""{"a":1}}""")).isLeft
+        )
+      },
+      test("decode rejects extra \" after string") {
+        val codec = JsonCodec.schemaBasedBinaryCodec(Schema[String])
+        assertTrue(
+          codec.decode(charSequenceToByteChunk("\"foo\"\"")).isLeft
+        )
+      },
+      test("decode accepts trailing whitespace") {
+        val codec = JsonCodec.schemaBasedBinaryCodec(Schema[Bar])
+        assertTrue(
+          codec.decode(charSequenceToByteChunk("""{"a":1}  """)) == Right(Bar(1))
+        )
+      },
+      test("streamDecoder keeps decoding multiple newline separated values") {
+        assertDecodesMany(
+          Schema[Bar],
+          Chunk(Bar(1), Bar(2)),
+          charSequenceToByteChunk("""{"a":1}
+{"a":2}""")
+        )
+      }
+    ),
+    suite("are rejected by zioJsonBinaryCodec")(
+      test("decode rejects extra \" after string") {
+        implicit val jsonCodec: zio.json.JsonCodec[String] = JsonCodec.jsonCodec(Schema[String])
+        val codec                                          = JsonCodec.zioJsonBinaryCodec[String]
+        assertTrue(
+          codec.decode(charSequenceToByteChunk("\"foo\"\"")).isLeft,
+          codec.decode(charSequenceToByteChunk("\"foo\"")) == Right("foo")
+        )
       }
     )
   )


### PR DESCRIPTION
/claim 712
Closes #712

## Problem

`JsonCodec`'s decoders stop after the first valid JSON value and silently ignore any remaining input, so malformed documents like `{}}`, `{"a":1}}` or `"foo""` decode successfully (see the Scastie reproducer in the issue).

## Fix

The strictness cannot be added by overriding `decodeJson`, because zio-json declares it `final`; it funnels through `unsafeDecode` with a `FastStringReader`, while the streaming entry points (`decodeJsonPipeline`, `decodeJsonStream`, ...) use other `RetractReader` implementations. This PR therefore:

- adds a private `StrictJsonDecoder` wrapper whose `unsafeDecode` rejects any non-whitespace remainder, but only when the reader is a `FastStringReader`, so single-value decoding becomes strict while streaming stays lenient;
- handles a zio-json quirk where the number parsers retract one character after a number, stepping back into the number's last digit when the number ends exactly at the end of the input (top-level numbers like `42` would otherwise be wrongly rejected);
- returns the strict decoder from `jsonDecoder(schema)` and uses it in `JsonDecoder.decode`, `schemaBasedBinaryCodec.decode` and `zioJsonBinaryCodec.decode`;
- keeps `schemaBasedBinaryCodec.streamDecoder` and `zioJsonBinaryCodec.streamDecoder` lenient (via `JsonDecoder.decodeLenient` and unwrapping of `StrictJsonDecoder`), preserving existing behavior such as `1 2, 3;;; 4x5` decoding as a stream of five ints and partial `Fallback` decodes (`[30,"hello"]` as `Fallback.Left(30)`).

## Tests

New `trailing characters after a valid JSON value` suite in `JsonCodecSpec`, covering the issue reproducers (`{}}`, `{"a":1}}`, `"foo""`), extra characters after arrays/booleans/numbers, top-level numbers (the retract quirk), acceptance of leading/trailing whitespace, strictness of `schemaBasedBinaryCodec.decode` and `zioJsonBinaryCodec.decode`, and unchanged newline-delimited stream decoding.

Verified locally: `zioSchemaJsonJVM/test` on Scala 2.12.21, 2.13.18 and 3.3.8 (312 tests), `zioSchemaJsonJS/test` (307 tests), `zioSchemaJsonNative/Test/compile`, `fmtCheck`, `fixCheck` and `mimaReportBinaryIssues`.

## Comparison with #724

#724 applies the trailing check inside `schemaDecoder` itself, so it also runs after every nested value (e.g. right after a field value, where the object's closing `}` follows), which breaks decoding of nested structures; it also reformats the whole `schemaDecoder` match and currently has merge conflicts with `main`. This PR applies the check only at the top-level decode entry points, leaves nested decoding untouched, and additionally covers the `BinaryCodec` entry points and the number-retract edge case described above.

---
This PR was prepared with the assistance of an AI coding agent; every change was verified by running the test suites and lint checks listed above.
