### PR TITLE
Support constructor registry in DynamicValue.toTypedValue for AST-rebuilt schemas (#511)

### DIFF
--- a/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
+++ b/tests/shared/src/test/scala/zio/schema/DynamicValueSpec.scala
@@ -1,5 +1,7 @@
 package zio.schema
 
+import scala.collection.immutable.ListMap
+
 import zio._
 import zio.schema.Schema.Primitive
 import zio.schema.SchemaGen._
@@ -100,6 +102,62 @@ object DynamicValueSpec extends ZIOSpecDefault {
             assertTrue(json2 == Right(json))
           }
         } @@ TestAspect.size(250) @@ TestAspect.ignore
+      ),
+      suite("toTypedValue with constructor registry")(
+        test("converts a record rebuilt from its AST back to a typed value") {
+          val user        = RegistryUser("John", 30)
+          val userDynamic = RegistryUser.schema.toDynamic(user)
+          val registry    = DynamicValue.Constructor.registry(RegistryUser.schema)
+
+          val typed = userDynamic.toTypedValue(registry)(RegistryUser.schema.ast.toSchema)
+
+          assertTrue(typed == Right(user))
+        },
+        test("decodes to a generic record when the registry has no matching constructor") {
+          val userDynamic = RegistryUser.schema.toDynamic(RegistryUser("John", 30))
+
+          val typed = userDynamic.toTypedValue(PartialFunction.empty[TypeId, DynamicValue.Constructor[_]])(
+            RegistryUser.schema.ast.toSchema
+          )
+
+          assertTrue(typed == Right(ListMap("name" -> "John", "age" -> 30)))
+        },
+        test("converts nested records, options and sequences rebuilt from their AST") {
+          val person = RegistryPerson(
+            "John",
+            RegistryAddress("Main St", "12345"),
+            Some(RegistryAddress("2nd St", "67890")),
+            Chunk(RegistryAddress("3rd St", "54321"))
+          )
+          val personDynamic = RegistryPerson.schema.toDynamic(person)
+          val registry      = DynamicValue.Constructor.registry(RegistryPerson.schema, RegistryAddress.schema)
+
+          val typed = personDynamic.toTypedValue(registry)(RegistryPerson.schema.ast.toSchema)
+
+          assertTrue(typed == Right(person))
+        },
+        test("converts enum cases rebuilt from their AST") {
+          val shapes        = Chunk[RegistryShape](RegistryShape.Circle(2.0), RegistryShape.Rectangle(3.0, 4.0))
+          val shapesDynamic = Schema[Chunk[RegistryShape]].toDynamic(shapes)
+          val registry =
+            DynamicValue.Constructor.registry(RegistryShape.Circle.schema, RegistryShape.Rectangle.schema)
+
+          val typed = shapesDynamic.toTypedValue(registry)(Schema[Chunk[RegistryShape]].ast.toSchema)
+
+          assertTrue(typed == Right(shapes))
+        },
+        test("fails when the dynamic record does not match the registered constructor") {
+          val userDynamic = RegistryUser.schema.toDynamic(RegistryUser("John", 30))
+          val incomplete = userDynamic match {
+            case DynamicValue.Record(id, values) => DynamicValue.Record(id, values - "age")
+            case other                           => other
+          }
+          val registry = DynamicValue.Constructor.registry(RegistryUser.schema)
+
+          val typed = incomplete.toTypedValue(registry)(RegistryUser.schema.ast.toSchema)
+
+          assertTrue(typed.isLeft)
+        }
       )
     )
 
@@ -114,5 +172,47 @@ object DynamicValueSpec extends ZIOSpecDefault {
     check(gen) { a =>
       assert(schema.fromDynamic(schema.toDynamic(a)))(isRight(equalTo(a)))
     }
+
+  final case class RegistryUser(name: String, age: Int)
+
+  object RegistryUser {
+    implicit val schema: Schema[RegistryUser] = DeriveSchema.gen[RegistryUser]
+  }
+
+  final case class RegistryAddress(street: String, zip: String)
+
+  object RegistryAddress {
+    implicit val schema: Schema[RegistryAddress] = DeriveSchema.gen[RegistryAddress]
+  }
+
+  final case class RegistryPerson(
+    name: String,
+    address: RegistryAddress,
+    previousAddress: Option[RegistryAddress],
+    otherAddresses: Chunk[RegistryAddress]
+  )
+
+  object RegistryPerson {
+    implicit val schema: Schema[RegistryPerson] = DeriveSchema.gen[RegistryPerson]
+  }
+
+  sealed trait RegistryShape
+
+  object RegistryShape {
+
+    final case class Circle(radius: Double) extends RegistryShape
+
+    object Circle {
+      implicit val schema: Schema[Circle] = DeriveSchema.gen[Circle]
+    }
+
+    final case class Rectangle(width: Double, height: Double) extends RegistryShape
+
+    object Rectangle {
+      implicit val schema: Schema[Rectangle] = DeriveSchema.gen[Rectangle]
+    }
+
+    implicit val schema: Schema[RegistryShape] = DeriveSchema.gen[RegistryShape]
+  }
 
 }

--- a/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
+++ b/zio-schema/shared/src/main/scala/zio/schema/DynamicValue.scala
@@ -22,41 +22,77 @@ sealed trait DynamicValue {
   def toTypedValue[A](implicit schema: Schema[A]): Either[String, A] =
     toTypedValueLazyError.left.map(_.message)
 
+  /**
+   * Converts this dynamic value to a typed value using the given schema, using the
+   * supplied registry to reconstruct record types whose schemas were rebuilt from a
+   * `MetaSchema` (e.g. via `schema.ast.toSchema`) and therefore no longer know how to
+   * construct their typed representation.
+   *
+   * The registry maps the `TypeId` of a record to the [[DynamicValue.Constructor]] used
+   * to build an instance of that record from its decoded field values, at any nesting
+   * level. Records missing from the registry are decoded to their generic representation
+   * (`ListMap[String, _]`), exactly as they would be without a registry.
+   */
+  def toTypedValue[A](
+    registry: PartialFunction[TypeId, DynamicValue.Constructor[_]]
+  )(implicit schema: Schema[A]): Either[DecodeError, A] =
+    toTypedValueLazyError(registry)
+
   def toValue[A](implicit schema: Schema[A]): Either[DecodeError, A] = toTypedValueLazyError
 
   def toTypedValueOption[A](implicit schema: Schema[A]): Option[A] =
     toTypedValueLazyError.toOption
 
   private def toTypedValueLazyError[A](implicit schema: Schema[A]): Either[DecodeError, A] =
+    toTypedValueLazyError(PartialFunction.empty[TypeId, DynamicValue.Constructor[_]])
+
+  private def toTypedValueLazyError[A](
+    registry: PartialFunction[TypeId, DynamicValue.Constructor[_]]
+  )(implicit schema: Schema[A]): Either[DecodeError, A] =
     (self, schema) match {
       case (DynamicValue.Primitive(value, p), Schema.Primitive(p2, _)) if p == p2 =>
         Right(value.asInstanceOf[A])
 
-      case (DynamicValue.Record(_, values), Schema.GenericRecord(_, structure, _)) =>
-        DynamicValue.decodeStructure(values, structure.toChunk).asInstanceOf[Either[DecodeError, A]]
+      case (DynamicValue.Record(_, values), s @ Schema.GenericRecord(id, structure, _)) =>
+        registry.lift(id) match {
+          case Some(constructor) =>
+            DynamicValue
+              .decodeStructure(values, structure.toChunk, registry)
+              .map(m => Chunk.fromIterable(m.values))
+              .flatMap(
+                values =>
+                  constructor
+                    .construct(values)(Unsafe.unsafe)
+                    .left
+                    .map(err => DecodeError.MalformedField(s, err))
+                    .map(_.asInstanceOf[A])
+              )
+          case None =>
+            DynamicValue.decodeStructure(values, structure.toChunk, registry).asInstanceOf[Either[DecodeError, A]]
+        }
 
       case (DynamicValue.Record(_, values), s: Schema.Record[A]) =>
         DynamicValue
-          .decodeStructure(values, s.fields)
+          .decodeStructure(values, s.fields, registry)
           .map(m => Chunk.fromIterable(m.values))
           .flatMap(values => s.construct(values)(Unsafe.unsafe).left.map(err => DecodeError.MalformedField(s, err)))
 
       case (DynamicValue.Enumeration(_, (key, value)), s: Schema.Enum[A]) =>
         s.caseOf(key) match {
           case Some(caseValue) =>
-            value.toTypedValueLazyError(caseValue.schema).asInstanceOf[Either[DecodeError, A]]
+            value.toTypedValueLazyError(registry)(caseValue.schema).asInstanceOf[Either[DecodeError, A]]
           case None => Left(DecodeError.MissingCase(key, s))
         }
 
       case (DynamicValue.LeftValue(value), Schema.Either(schema1, _, _)) =>
-        value.toTypedValueLazyError(schema1).map(Left(_))
+        value.toTypedValueLazyError(registry)(schema1).map(Left(_))
 
       case (DynamicValue.RightValue(value), Schema.Either(_, schema1, _)) =>
-        value.toTypedValueLazyError(schema1).map(Right(_))
+        value.toTypedValueLazyError(registry)(schema1).map(Right(_))
 
       case (DynamicValue.Tuple(leftValue, rightValue), Schema.Tuple2(leftSchema, rightSchema, _)) =>
-        val typedLeft  = leftValue.toTypedValueLazyError(leftSchema)
-        val typedRight = rightValue.toTypedValueLazyError(rightSchema)
+        val typedLeft  = leftValue.toTypedValueLazyError(registry)(leftSchema)
+        val typedRight = rightValue.toTypedValueLazyError(registry)(rightSchema)
         (typedLeft, typedRight) match {
           case (Left(e1), Left(e2)) =>
             Left(DecodeError.And(e1, e2))
@@ -70,7 +106,7 @@ sealed trait DynamicValue {
           .foldLeft[Either[DecodeError, Chunk[t]]](Right[DecodeError, Chunk[t]](Chunk.empty)) {
             case (err @ Left(_), _) => err
             case (Right(values), value) =>
-              value.toTypedValueLazyError(schema.elementSchema).map(values :+ _)
+              value.toTypedValueLazyError(registry)(schema.elementSchema).map(values :+ _)
           }
           .map(schema.fromChunk)
 
@@ -78,18 +114,18 @@ sealed trait DynamicValue {
         values.foldLeft[Either[DecodeError, Set[t]]](Right[DecodeError, Set[t]](Set.empty)) {
           case (err @ Left(_), _) => err
           case (Right(values), value) =>
-            value.toTypedValueLazyError(schema.elementSchema).map(values + _)
+            value.toTypedValueLazyError(registry)(schema.elementSchema).map(values + _)
         }
 
       case (DynamicValue.SomeValue(value), Schema.Optional(schema: Schema[_], _)) =>
-        value.toTypedValueLazyError(schema).map(Some(_))
+        value.toTypedValueLazyError(registry)(schema).map(Some(_))
 
       case (DynamicValue.NoneValue, Schema.Optional(_, _)) =>
         Right(None)
 
       case (value, Schema.Transform(schema, f, _, _, _)) =>
         value
-          .toTypedValueLazyError(schema)
+          .toTypedValueLazyError(registry)(schema)
           .flatMap(value => f(value).left.map(err => DecodeError.MalformedField(schema, err)))
 
       case (DynamicValue.Dictionary(entries), schema: Schema.Map[k, v]) =>
@@ -97,21 +133,21 @@ sealed trait DynamicValue {
           case (err @ Left(_), _) => err
           case (Right(map), entry) => {
             for {
-              key   <- entry._1.toTypedValueLazyError(schema.keySchema)
-              value <- entry._2.toTypedValueLazyError(schema.valueSchema)
+              key   <- entry._1.toTypedValueLazyError(registry)(schema.keySchema)
+              value <- entry._2.toTypedValueLazyError(registry)(schema.valueSchema)
             } yield map ++ Map(key -> value)
           }
         }
 
       case (_, l @ Schema.Lazy(_)) =>
-        toTypedValueLazyError(l.schema)
+        toTypedValueLazyError(registry)(l.schema)
 
       case (DynamicValue.Error(message), _) =>
         Left(DecodeError.ReadError(Cause.empty, message))
 
       case (DynamicValue.Tuple(dyn, DynamicValue.DynamicAst(ast)), _) =>
         val valueSchema = ast.toSchema.asInstanceOf[Schema[Any]]
-        dyn.toTypedValueLazyError(valueSchema).map(a => (a -> valueSchema).asInstanceOf[A])
+        dyn.toTypedValueLazyError(registry)(valueSchema).map(a => (a -> valueSchema).asInstanceOf[A])
 
       case (dyn, Schema.Dynamic(_)) => Right(dyn)
 
@@ -122,6 +158,48 @@ sealed trait DynamicValue {
 }
 
 object DynamicValue {
+
+  /**
+   * Knows how to construct a value of type `A` from the decoded values of the fields of
+   * a record, in the order in which the fields are declared in the record's schema.
+   *
+   * Used together with `DynamicValue.toTypedValue(registry)(schema)` to rebuild typed
+   * values from schemas materialized from a `MetaSchema` (e.g. `schema.ast.toSchema`),
+   * which represent records as `Schema.GenericRecord` and have therefore lost the
+   * information required to construct the original type.
+   */
+  sealed trait Constructor[A] {
+    def construct(fieldValues: Chunk[Any])(implicit unsafe: Unsafe): scala.util.Either[String, A]
+  }
+
+  object Constructor {
+
+    def apply[A](f: (Chunk[Any], Unsafe) => Either[String, A]): Constructor[A] =
+      new Constructor[A] {
+        override def construct(fieldValues: Chunk[Any])(implicit unsafe: Unsafe): scala.util.Either[String, A] =
+          f(fieldValues, unsafe)
+      }
+
+    /**
+     * Creates a constructor from the given record schema, pairing it with the schema's
+     * `TypeId` so that it can be registered in a constructor registry. Returns `None`
+     * for schemas that are not records.
+     */
+    def fromSchema[A](schema: Schema[A]): Option[(TypeId, Constructor[A])] =
+      schema match {
+        case record: Schema.Record[A] =>
+          Some(record.id -> Constructor[A]((fieldValues, unsafe) => record.construct(fieldValues)(unsafe)))
+        case _ => None
+      }
+
+    /**
+     * Builds a constructor registry from the given schemas, mapping the `TypeId` of each
+     * record schema to a [[Constructor]] capable of rebuilding instances of that record.
+     * Non-record schemas are ignored.
+     */
+    def registry(schemas: Schema[_]*): PartialFunction[TypeId, Constructor[_]] =
+      schemas.flatMap(schema => fromSchema(schema.asInstanceOf[Schema[Any]])).toMap
+  }
 
   private object FromSchemaAndValue extends SimpleMutableSchemaBasedValueProcessor[DynamicValue] {
     override protected def processPrimitive(value: Any, typ: StandardType[Any]): DynamicValue =
@@ -193,13 +271,20 @@ object DynamicValue {
   def decodeStructure(
     values: ListMap[String, DynamicValue],
     structure: Chunk[Schema.Field[_, _]]
+  ): Either[DecodeError, ListMap[String, _]] =
+    decodeStructure(values, structure, PartialFunction.empty[TypeId, Constructor[_]])
+
+  private def decodeStructure(
+    values: ListMap[String, DynamicValue],
+    structure: Chunk[Schema.Field[_, _]],
+    registry: PartialFunction[TypeId, Constructor[_]]
   ): Either[DecodeError, ListMap[String, _]] = {
     val keys = values.keySet
     keys.foldLeft[Either[DecodeError, ListMap[String, Any]]](Right(ListMap.empty)) {
       case (Right(record), key) =>
         (structure.find(_.name == key), values.get(key)) match {
           case (Some(field), Some(value)) =>
-            value.toTypedValueLazyError(field.schema).map(value => (record + (key -> value)))
+            value.toTypedValueLazyError(registry)(field.schema).map(value => (record + (key -> value)))
           case _ =>
             Left(DecodeError.IncompatibleShape(values, structure))
         }


### PR DESCRIPTION
/claim 511

Closes #511

## Problem

When a schema is rebuilt from its AST (`schema.ast.toSchema`), records are materialized as `Schema.GenericRecord`, which only knows how to build a `ListMap[String, _]`. Converting a dynamic record with such a schema therefore yields a raw `ListMap` instead of the original case class — the typed constructor was lost when the schema was turned into a `MetaSchema`.

## Solution

Implements the registry approach suggested by @jdegoes in the issue discussion (https://github.com/zio/zio-schema/issues/511#issuecomment-1880819029):

- New overload `DynamicValue.toTypedValue[A](registry: PartialFunction[TypeId, DynamicValue.Constructor[_]])(implicit schema: Schema[A]): Either[DecodeError, A]`.
- New `DynamicValue.Constructor[A]`, which builds an `A` from the decoded field values of a record, with `Constructor.fromSchema` and `Constructor.registry` helpers to build a registry directly from record schemas (including the implicit derived ones, so no reflection is involved).
- The registry is threaded through the whole conversion, so records are reconstructed **at any nesting level**: nested records, `Option`, sequences, sets, maps, `Either`, tuples and enum cases — not just at the top level (this is where the naive attempt in #725 stops).
- Records missing from the registry keep the existing behaviour and decode to their generic representation (`ListMap[String, _]`), so the change is fully backwards compatible; `decodeStructure` retains its original signature.

Usage with the reproduction from the issue:

```scala
final case class User(name: String, age: Int)
implicit val schema: Schema[User] = DeriveSchema.gen[User]

val user        = User("John", 30)
val userDynamic = schema.toDynamic(user)
val registry    = DynamicValue.Constructor.registry(schema)

userDynamic.toTypedValue(registry)(schema.ast.toSchema)
// Right(User("John", 30))
```

## Tests

- 5 new tests in `DynamicValueSpec` covering: top-level records rebuilt from their AST, fallback to generic records when no constructor is registered, nested records / `Option` / `Chunk`, enum cases, and failure when the dynamic record does not match the registered constructor.
- Verified locally: `zioSchemaJVM/test`, `zioSchemaDerivationJVM/test`, `testsJVM/test` on Scala 2.12.21, 2.13.18 and 3.3.8; `zioSchemaJS/test`, `testsJS/testOnly zio.schema.DynamicValueSpec` on 2.13.18; `zioSchemaNative/compile`, `testsNative/compile`; `scalafmtCheckAll`, `scalafix --check` on the touched modules; `zioSchemaJVM/mimaReportBinaryIssues` (no problems).

_Note: this PR was prepared with the assistance of an AI coding agent; the changes were reviewed and verified by running the checks listed above._
