### PR TITLE
fix(codec): return Left instead of throwing when a NonEmptyChunk/Set/Map field is missing in JSON

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1253,11 +1253,9 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
                       schema match {
                         case _: Schema.Optional[_] if !explicitNulls => None
                         case collection: Schema.Collection[_, _] if !explicitEmptyCollections =>
-                          try collection.empty
-                          catch {
-                            case _: IllegalArgumentException =>
-                              lexer.error("missing", spansWithDecoders.get(fieldName)._1 :: trace)
-                          }
+                          collection.defaultValue.getOrElse(
+                            lexer.error("missing", spansWithDecoders.get(fieldName)._1 :: trace)
+                          )
                         case _ => lexer.error("missing", spansWithDecoders.get(fieldName)._1 :: trace)
                       }
                     }
@@ -1851,8 +1849,7 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
             buffer(idx) = schema match {
               case _: Schema.Optional[_] if !explicitNulls => None
               case collection: Schema.Collection[_, _] if !explicitEmptyCollections =>
-                try collection.empty
-                catch { case _: IllegalArgumentException => lexer.error("missing", spans(idx) :: trace) }
+                collection.defaultValue.getOrElse(lexer.error("missing", spans(idx) :: trace))
               case _ => lexer.error("missing", spans(idx) :: trace)
             }
           }

--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -1251,9 +1251,14 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
                         case _                 =>
                       }
                       schema match {
-                        case _: Schema.Optional[_] if !explicitNulls                          => None
-                        case collection: Schema.Collection[_, _] if !explicitEmptyCollections => collection.empty
-                        case _                                                                => lexer.error("missing", spansWithDecoders.get(fieldName)._1 :: trace)
+                        case _: Schema.Optional[_] if !explicitNulls => None
+                        case collection: Schema.Collection[_, _] if !explicitEmptyCollections =>
+                          try collection.empty
+                          catch {
+                            case _: IllegalArgumentException =>
+                              lexer.error("missing", spansWithDecoders.get(fieldName)._1 :: trace)
+                          }
+                        case _ => lexer.error("missing", spansWithDecoders.get(fieldName)._1 :: trace)
                       }
                     }
                   }
@@ -1844,9 +1849,11 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
               case _                 =>
             }
             buffer(idx) = schema match {
-              case _: Schema.Optional[_] if !explicitNulls                          => None
-              case collection: Schema.Collection[_, _] if !explicitEmptyCollections => collection.empty
-              case _                                                                => lexer.error("missing", spans(idx) :: trace)
+              case _: Schema.Optional[_] if !explicitNulls => None
+              case collection: Schema.Collection[_, _] if !explicitEmptyCollections =>
+                try collection.empty
+                catch { case _: IllegalArgumentException => lexer.error("missing", spans(idx) :: trace) }
+              case _ => lexer.error("missing", spans(idx) :: trace)
             }
           }
         }

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecSpec.scala
@@ -30,6 +30,10 @@ object JsonCodecSpec extends ZIOSpecDefault {
 
   val personSchema: Schema[Person] = DeriveSchema.gen[Person]
 
+  case class WithNonEmptyChunk(items: NonEmptyChunk[String])
+
+  val withNonEmptyChunkSchema: Schema[WithNonEmptyChunk] = DeriveSchema.gen[WithNonEmptyChunk]
+
   def spec: Spec[TestEnvironment, Any] =
     suite("JsonCodec Spec")(
       encoderSuite,
@@ -1603,6 +1607,11 @@ object JsonCodecSpec extends ZIOSpecDefault {
         val schema  = Schema[NonEmptyChunk[String]]
         val decoder = JsonCodec.schemaBasedBinaryCodec(schema).streamDecoder
         val result  = ZStream.fromChunk(charSequenceToByteChunk("[]")).via(decoder).runCollect.either
+        assertZIO(result)(isLeft)
+      },
+      test("NonEmptyChunk field decoder returns Left, not a thrown exception, when the field is missing") {
+        val decoder = JsonCodec.schemaBasedBinaryCodec(withNonEmptyChunkSchema).streamDecoder
+        val result  = ZStream.fromChunk(charSequenceToByteChunk("{}")).via(decoder).runCollect.either
         assertZIO(result)(isLeft)
       }
     )


### PR DESCRIPTION
## Summary
- `JsonCodec`'s record decoder defaults a missing collection field to `collection.empty` when `explicitEmptyCollections` is disabled (the default). For `Schema.NonEmptySequence` (backing `NonEmptyChunk`/`NonEmptySet`) and `Schema.NonEmptyMap`, `.empty` unconditionally throws `IllegalArgumentException`, so a JSON body that simply omits one of these fields crashes the decoder with an uncaught exception instead of a `DecodeError` — `BinaryCodec.decode`/`streamDecoder` is typed to return `Either[DecodeError, A]`/fail with `DecodeError`, so this is a contract violation, and in practice it surfaces as an unhandled defect (e.g. a 500) instead of a typed decode failure (e.g. a 400).
- This is distinct from #892 / #1016: that fix addressed a JSON body that explicitly contains an *empty array* (`[]`) for a `NonEmptyChunk`/`NonEmptySet` field. A field that is *absent entirely* goes through a different branch in `JsonCodec` (the "missing field defaults" logic) that was never patched, and still throws on current `main`.
- Fix: at both call sites (the generic `ListMap`-based record decoder and `CaseClassJsonDecoder`), use `collection.defaultValue` instead of calling `collection.empty` directly. `defaultValue` is already `Left(...)` for `NonEmptySequence`/`NonEmptyMap` and `Right(empty)` for every other `Collection` subtype, so this falls back to the existing "missing field" decode error without needing to catch an exception.

## Test plan
- [x] Added a regression test reproducing the crash: a case class with a `NonEmptyChunk` field decoding `{}` now returns `Left`, not a thrown exception.
- [x] `zioSchemaJsonJVM/testOnly zio.schema.codec.JsonCodecSpec` — 286 passed, 0 failed (Scala 2.13.18).
- [x] Same suite passes under Scala 3.3.7.
- [x] `zioSchemaJsonJS/Test/compile` and `zioSchemaJsonNative/Test/compile` succeed.