### PR TITLE
Reject trailing JSON in whole-value binary decoding

### DIFF
--- a/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
+++ b/zio-schema-json/shared/src/main/scala/zio/schema/codec/JsonCodec.scala
@@ -12,7 +12,16 @@ import scala.util.control.NonFatal
 
 import zio.json.JsonDecoder.{JsonError, UnsafeJson}
 import zio.json.ast.Json
-import zio.json.internal.{FastStringReader, Lexer, OneCharReader, RecordingReader, RetractReader, StringMatrix, Write}
+import zio.json.internal.{
+  FastStringReader,
+  Lexer,
+  OneCharReader,
+  RecordingReader,
+  RetractReader,
+  StringMatrix,
+  WithRetractReader,
+  Write
+}
 import zio.json.{
   JsonCodec => ZJsonCodec,
   JsonDecoder => ZJsonDecoder,
@@ -172,7 +181,7 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
   implicit def zioJsonBinaryCodec[A](implicit jsonCodec: ZJsonCodec[A]): BinaryCodec[A] =
     new BinaryCodec[A] {
       override def decode(whole: Chunk[Byte]): Either[DecodeError, A] =
-        jsonCodec
+        wholeValueDecoder(jsonCodec.decoder)
           .decodeJson(new String(whole.toArray, JsonEncoder.CHARSET))
           .left
           .map(failure => DecodeError.ReadError(Cause.empty, failure))
@@ -327,7 +336,7 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
         ZPipeline.utfDecode.mapError(cce => DecodeError.ReadError(Cause.fail(cce), cce.getMessage)) >>>
           (if (cfg.treatStreamsAsArrays) splitJsonArrayElements else splitOnJsonBoundary) >>>
           ZPipeline.mapZIO { (s: String) =>
-            ZIO.fromEither(JsonDecoder.decode(schema, s, cfg))
+            ZIO.fromEither(schemaDecoder(schema, cfg).decodeJson(s).left.map(DecodeError.ReadError(Cause.empty, _)))
           }
 
       override def encode(value: A): Chunk[Byte] =
@@ -349,6 +358,20 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
 
   def jsonEncoder[A](schema: Schema[A]): ZJsonEncoder[A] =
     JsonEncoder.schemaEncoder(schema, JsonCodec.Configuration.default)
+
+  // Enforce EOF only at a whole-value boundary, never inside a composable schema decoder.
+  private def wholeValueDecoder[A](decoder: ZJsonDecoder[A]): ZJsonDecoder[A] =
+    new ZJsonDecoder[A] {
+      override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
+        // Numeric decoders retract even after EOF; preserve EOF instead of replaying the last digit.
+        val reader = new WithRetractReader(in)
+        val value  = decoder.unsafeDecode(trace, reader)
+        var next   = reader.read()
+        while (next == ' ' || next == '\t' || next == '\r' || next == '\n') next = reader.read()
+        if (next != -1) Lexer.error("Unexpected trailing characters", trace)
+        value
+      }
+    }
 
   @deprecated("Use Configuration based method instead", "1.6.7")
   def jsonEncoder[A](cfg: JsonCodec.Config)(schema: Schema[A]): ZJsonEncoder[A] =
@@ -832,7 +855,7 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
     private[this] val decoders = new ConcurrentHashMap[DecoderKey[_], ZJsonDecoder[_]]
 
     final def decode[A](schema: Schema[A], json: String, config: Configuration): Either[DecodeError, A] =
-      schemaDecoder(schema, config).decodeJson(json) match {
+      wholeValueDecoder(schemaDecoder(schema, config)).decodeJson(json) match {
         case Left(value)  => Left(DecodeError.ReadError(Cause.empty, value))
         case Right(value) => Right(value)
       }
@@ -1323,16 +1346,18 @@ JsonCodec.Configuration makes it now possible to configure en-/decoding of empty
             }
 
             // get right element
-            if (((left eq None) || schema.fullDecode) && lexer.firstArrayElement(in)) {
+            if (lexer.firstArrayElement(in)) {
               val trace_ = JsonError.ArrayAccess(1) :: trace
-              try right = Some(rightDecoder.unsafeDecode(trace_, in))
-              catch {
-                case _: UnsafeJson => ()
-              }
-              try lexer.nextArrayElement(trace, in)
-              catch {
-                case _: UnsafeJson => ()
-              }
+              if ((left eq None) || schema.fullDecode) {
+                val rr = RecordingReader(in)
+                try right = Some(rightDecoder.unsafeDecode(trace_, rr))
+                catch {
+                  case _: UnsafeJson =>
+                    rr.rewind()
+                    lexer.skipValue(trace_, rr)
+                }
+              } else lexer.skipValue(trace_, in)
+              lexer.nextArrayElement(trace, in)
             }
 
           } catch {

--- a/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecWholeInputSpec.scala
+++ b/zio-schema-json/shared/src/test/scala/zio/schema/codec/JsonCodecWholeInputSpec.scala
@@ -1,0 +1,87 @@
+package zio.schema.codec
+
+import zio._
+import zio.schema._
+import zio.schema.codec.JsonCodec.JsonEncoder.charSequenceToByteChunk
+import zio.stream.ZStream
+import zio.test._
+
+object JsonCodecWholeInputSpec extends ZIOSpecDefault {
+  private def codecs[A](schema: Schema[A]): List[BinaryCodec[A]] =
+    List(
+      JsonCodec.schemaBasedBinaryCodec(schema),
+      JsonCodec.schemaBasedBinaryCodec(JsonCodec.Configuration(treatStreamsAsArrays = true))(schema),
+      JsonCodec.zioJsonBinaryCodec(JsonCodec.jsonCodec(schema))
+    )
+
+  private def rejects[A](schema: Schema[A], inputs: String*): TestResult =
+    assertTrue(
+      codecs(schema).forall(codec => inputs.forall(input => codec.decode(charSequenceToByteChunk(input)).isLeft))
+    )
+
+  def spec: Spec[TestEnvironment, Any] = suite("JsonCodec whole input")(
+    test("rejects trailing characters after strings and objects (issue 712)") {
+      rejects(Schema[String], "\"foo\"\"", "\"foo\"garbage", "\"foo\" \"bar\"") &&
+      rejects(Schema[Unit], "{}}", "{}{}", "{} trailing")
+    },
+    test("rejects trailing characters after numbers, booleans, arrays and null") {
+      rejects(Schema[Int], "123x", "1 2", "1]", "1\nfalse") &&
+      rejects(Schema[Boolean], "truefalse", "false}") &&
+      rejects(Schema[List[Int]], "[1,2]]", "[1,2] []") &&
+      rejects(Schema[Option[Int]], "nullx", "null null")
+    },
+    test("rejects non-JSON whitespace after a value") {
+      rejects(Schema[Int], "1\u0000", "1\u000b", "1\u000c", "1\u00a0")
+    },
+    test("accepts end of input and the four JSON whitespace characters") {
+      assertTrue(codecs(Schema[Int]).forall { codec =>
+        List("123", " 123 ", "123\t\r\n ").forall(input => codec.decode(charSequenceToByteChunk(input)) == Right(123))
+      }) && assertTrue(codecs(Schema[String]).forall { codec =>
+        codec.decode(charSequenceToByteChunk("\"foo\" \t\r\n")) == Right("foo")
+      })
+    },
+    test("preserves malformed and incomplete input errors") {
+      rejects(Schema[Int], "", " \t\r\n", "oops") &&
+      rejects(Schema[String], "\"unfinished") &&
+      rejects(Schema[List[Int]], "[1,2")
+    },
+    test("preserves nested decoder composition") {
+      val schema = Schema[List[Option[Int]]]
+      assertTrue(codecs(schema).forall { codec =>
+        codec.decode(charSequenceToByteChunk("[1,null,2]")) == Right(List(Some(1), None, Some(2)))
+      })
+    },
+    test("fallbacks consume the unselected value before checking for trailing input") {
+      val leftOnly   = Schema.Fallback(Schema[Int], Schema[String])
+      val fullDecode = Schema.Fallback(Schema[Int], Schema[String], true)
+      assertTrue(codecs(leftOnly).forall { codec =>
+        codec.decode(charSequenceToByteChunk("[30,\"hello\"]")) == Right(Fallback.Left(30))
+      }) && assertTrue(codecs(fullDecode).forall { codec =>
+        codec.decode(charSequenceToByteChunk("[30,30]")) == Right(Fallback.Left(30))
+      }) && rejects(leftOnly, "[30,\"hello\"]garbage") && rejects(fullDecode, "[30,30]]")
+    },
+    test("streams still decode multiple values across byte chunks") {
+      val schemaCodec = JsonCodec.schemaBasedBinaryCodec(Schema[Int])
+      val zioCodec    = JsonCodec.zioJsonBinaryCodec(zio.json.JsonCodec.int)
+      for {
+        results <- ZIO.foreach(List(schemaCodec, zioCodec)) { codec =>
+                     ZStream
+                       .fromChunk(charSequenceToByteChunk("1\n2\n3"))
+                       .rechunk(1)
+                       .via(codec.streamDecoder)
+                       .runCollect
+                   }
+      } yield assertTrue(results.forall(_ == Chunk(1, 2, 3)))
+    },
+    test("array streams still decode each element") {
+      val codec = JsonCodec.schemaBasedBinaryCodec(JsonCodec.Configuration(treatStreamsAsArrays = true))(Schema[Int])
+      for {
+        result <- ZStream
+                    .fromChunk(charSequenceToByteChunk("[1,2,3]"))
+                    .rechunk(1)
+                    .via(codec.streamDecoder)
+                    .runCollect
+      } yield assertTrue(result == Chunk(1, 2, 3))
+    }
+  )
+}


### PR DESCRIPTION
Related issue: https://github.com/zio/zio-schema/issues/712

`schemaBasedBinaryCodec.decode` and `zioJsonBinaryCodec.decode` currently accept inputs such as `{}}` and `"foo""` by stopping after the first value. Require end of input after optional JSON whitespace and report trailing content as a `DecodeError.ReadError`.

The check runs at the whole-value boundary. Schema decoders remain composable, and streams retain their existing fragment-decoding behavior. Use the existing `WithRetractReader` so numeric decoders that retract after EOF do not replay the last digit. Ensure a fallback decoder consumes its unselected or type-mismatched second value, so valid fallback arrays are not mistaken for trailing content. The public `jsonDecoder`/`jsonCodec` methods continue to expose upstream zio-json's composable, prefix-decoding behavior.

Regression coverage includes strings, objects, numbers, booleans, arrays, null, invalid trailing whitespace, incomplete input, nested values, fallback arrays, and chunked streams, across both binary-codec adapters and the array-stream configuration.

Validation (Scala 2.13.18, Java 17):

- Before the fix, the new trailing-input regression tests failed on the original code.
- `zioSchemaJsonJVM/test`: 308 passed, 0 failed.
- `zioSchemaJsonJVM/scalafix --check` and `zioSchemaJsonJVM/Test/scalafix --check`: passed.
- `fmtCheck`: passed across the repository.
- `git diff --check` and reverse patch applicability: passed.
- JS/Native tests, other Scala versions, and binary-compatibility checks have not been run locally.


This contribution was prepared with an AI coding assistant on behalf of Matthew Feroz. I am aware of existing submissions #724 and #1136; this patch keeps the public composable decoders unchanged and covers whole-value binary decoding and fallback consumption.

/claim #712
